### PR TITLE
build(deps): Bump envoy to v1.37.2 and ubi-minimal digest in authproxy

### DIFF
--- a/authbridge/authproxy/Dockerfile.authbridge
+++ b/authbridge/authproxy/Dockerfile.authbridge
@@ -26,7 +26,7 @@ RUN cd cmd/authbridge && CGO_ENABLED=0 GOOS=linux go build -o /authbridge .
 FROM ghcr.io/spiffe/spiffe-helper:0.11.0 AS spiffe
 
 # Stage 3: Combined runtime
-FROM docker.io/envoyproxy/envoy:v1.37.1
+FROM docker.io/envoyproxy/envoy:v1.37.2
 
 USER root
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- Bumps `envoyproxy/envoy` from v1.37.1 to v1.37.2 in `Dockerfile.authbridge` and `Dockerfile.envoy`
- Bumps `ubi9/ubi-minimal` digest from `83006d5` to `fe688da` in `Dockerfile.envoy`

Bundles Dependabot PRs #301 and #302 into a single update.

## Test plan
- [x] CI passes (build workflow)
- [x] Container images build successfully

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>