### PR TITLE
Refactor: Rename rossocortex → cortex (fix module paths)

### DIFF
--- a/.claude/skills/demo.md
+++ b/.claude/skills/demo.md
@@ -4,8 +4,8 @@ This skill captures knowledge from building, debugging, and running AuthBridge d
 
 ## Repository Context
 
-- **Repo:** `rossoctl/rossocortex` (monorepo)
-- **Container registry:** `ghcr.io/rossoctl/rossocortex/<image-name>`
+- **Repo:** `rossoctl/cortex` (monorepo)
+- **Container registry:** `ghcr.io/rossoctl/cortex/<image-name>`
 - **Agent examples repo:** `rossoctl/examples` (separate repo, images NOT published to GHCR)
 - **Demo guides:** `authbridge/demos/<demo-name>/demo-manual.md` (manual kubectl) and `demo-ui.md` (UI-driven)
 
@@ -35,9 +35,9 @@ docker build -t ghcr.io/rossoctl/examples/<agent>:latest ./a2a/<agent>/
 docker build -t ghcr.io/rossoctl/examples/<tool>:latest ./mcp/<tool>/
 
 # Build AuthBridge sidecar images
-cd rossocortex/authbridge/authproxy
-docker build -f Dockerfile.init -t ghcr.io/rossoctl/rossocortex/proxy-init:latest .
-docker build -f Dockerfile.envoy -t ghcr.io/rossoctl/rossocortex/envoy-with-processor:latest .
+cd cortex/authbridge/authproxy
+docker build -f Dockerfile.init -t ghcr.io/rossoctl/cortex/proxy-init:latest .
+docker build -f Dockerfile.envoy -t ghcr.io/rossoctl/cortex/envoy-with-processor:latest .
 
 # Load into Kind
 kind load docker-image <image> --name rossoctl

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,4 @@
-name: rossocortex CodeQL config
+name: cortex CodeQL config
 
 queries:
   - uses: security-extended

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - Rossoctl Extensions
 
-This file provides context for Claude (AI assistant) when working with the `rossocortex` monorepo.
+This file provides context for Claude (AI assistant) when working with the `cortex` monorepo.
 
 ## AI Assistant Instructions
 
@@ -8,18 +8,18 @@ This file provides context for Claude (AI assistant) when working with the `ross
 
 ## Repository Overview
 
-**rossocortex** contains Kubernetes security extensions for the [Rossoctl](https://github.com/rossoctl/rossoctl) ecosystem. It provides **zero-trust authentication** for Kubernetes workloads through transparent token exchange and dynamic Keycloak client registration using SPIFFE/SPIRE identities.
+**cortex** contains Kubernetes security extensions for the [Rossoctl](https://github.com/rossoctl/rossoctl) ecosystem. It provides **zero-trust authentication** for Kubernetes workloads through transparent token exchange and dynamic Keycloak client registration using SPIFFE/SPIRE identities.
 
 The sidecar injection webhook lives in a separate repo: [rossoctl/operator](https://github.com/rossoctl/operator).
 
-**GitHub:** `github.com/rossoctl/rossocortex`
-**Container registry:** `ghcr.io/rossoctl/rossocortex/<image-name>`
+**GitHub:** `github.com/rossoctl/cortex`
+**Container registry:** `ghcr.io/rossoctl/cortex/<image-name>`
 **License:** Apache 2.0
 
 ## Top-Level Directory Structure
 
 ```
-rossocortex/
+cortex/
 ├── authbridge/               # Authentication bridge components
 │   ├── authlib/              #   Shared auth building blocks (Go module)
 │   │   ├── validation/       #     JWKS-backed JWT verifier
@@ -163,7 +163,7 @@ lowercase prefixes. Use `Fix:` / `Feat:` / `Docs:` in PR titles.
 
 ## Container Images
 
-All images are pushed to `ghcr.io/rossoctl/rossocortex/` from
+All images are pushed to `ghcr.io/rossoctl/cortex/` from
 `.github/workflows/build.yaml`:
 
 | Image | Source | Description |
@@ -271,7 +271,7 @@ cd authbridge && podman build -f cmd/authbridge-proxy/Dockerfile \
 
 1. Add entry to `.github/workflows/build.yaml` matrix (`image_config` array)
 2. Provide `name`, `context`, and `dockerfile` fields
-3. Image will be pushed to `ghcr.io/rossoctl/rossocortex/<name>`
+3. Image will be pushed to `ghcr.io/rossoctl/cortex/<name>`
 
 ## Code Style and Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ Comment `/claim` on an issue to have it automatically assigned to you. Issues la
 
 ```bash
 # Clone the repository
-git clone https://github.com/rossoctl/rossocortex.git
-cd rossocortex
+git clone https://github.com/rossoctl/cortex.git
+cd cortex
 
 # Install pre-commit hooks
 pre-commit install

--- a/LOCAL_TESTING_GUIDE.md
+++ b/LOCAL_TESTING_GUIDE.md
@@ -1,6 +1,6 @@
 # Local Testing Guide for JWT-SVID Authentication
 
-> **⚠️ This guide is stale after rossocortex#411.** It was written
+> **⚠️ This guide is stale after cortex#411.** It was written
 > for the pre-#411 multi-sidecar shape (separate `client-registration`,
 > `envoy-with-processor`, and standalone `spiffe-helper` containers) and
 > several of its YAML examples reference images that no longer publish.
@@ -26,7 +26,7 @@ This guide walks you through testing JWT-SVID authentication using local images 
 **CRITICAL**: You MUST run the `./local-build-and-test.sh` script to build all required images. Do NOT build images individually with `docker build` or `podman build` commands, as this will miss critical images like `spiffe-idp-setup:local` (located in the rossoctl repo).
 
 The script:
-- Builds images from **both** rossoctl and rossocortex repositories
+- Builds images from **both** rossoctl and cortex repositories
 - Automatically detects Docker vs Podman
 - Loads all images into your Kind cluster
 - Ensures consistent image tags and pull policies
@@ -35,7 +35,7 @@ The script:
 
 - Docker or Podman running
 - Kind CLI installed
-- Both `rossoctl` and `rossocortex` repositories cloned
+- Both `rossoctl` and `cortex` repositories cloned
 
 ## Step 0: Create Kind Cluster
 
@@ -68,7 +68,7 @@ kubectl cluster-info --context kind-rossoctl-dev
 The `local-build-and-test.sh` script is the **only supported way** to build local images for testing. It builds images from both repositories and ensures everything is loaded correctly.
 
 ```bash
-cd rossocortex
+cd cortex
 
 # Make the script executable (first time only)
 chmod +x local-build-and-test.sh
@@ -87,10 +87,10 @@ export KIND_EXPERIMENTAL_PROVIDER=podman  # Only needed for Podman
 **From rossoctl repo** (critical - often missed!):
 - `ghcr.io/rossoctl/rossoctl/spiffe-idp-setup:local` - Configures SPIFFE Identity Provider in Keycloak
 
-**From rossocortex repo**:
-- `ghcr.io/rossoctl/rossocortex/client-registration:local` - Registers agents as Keycloak clients
-- `ghcr.io/rossoctl/rossocortex/envoy-with-processor:local` - Envoy proxy with token exchange
-- `ghcr.io/rossoctl/rossocortex/proxy-init:local` - iptables initialization
+**From cortex repo**:
+- `ghcr.io/rossoctl/cortex/client-registration:local` - Registers agents as Keycloak clients
+- `ghcr.io/rossoctl/cortex/envoy-with-processor:local` - Envoy proxy with token exchange
+- `ghcr.io/rossoctl/cortex/proxy-init:local` - iptables initialization
 
 ### Common Mistakes to Avoid:
 
@@ -105,7 +105,7 @@ export KIND_EXPERIMENTAL_PROVIDER=podman  # Only needed for Podman
 
 ## Step 2: Install Rossoctl with Ansible
 
-**IMPORTANT:** For federated-JWT testing with local images, use the unified `federated-jwt-values.yaml` overlay file from rossocortex.
+**IMPORTANT:** For federated-JWT testing with local images, use the unified `federated-jwt-values.yaml` overlay file from cortex.
 
 The ansible installer will detect the existing `rossoctl-dev` cluster and install into it:
 
@@ -116,7 +116,7 @@ cd rossoctl
 # Install with dev base values + TWO overlays (deps local images + extensions federated-jwt)
 # --env dev                                → Loads dev_values.yaml (base Kind development config)
 # --env-file deployments/envs/...         → Local images for rossoctl-deps (SPIRE, Keycloak, etc.)
-# --env-file ../rossocortex/...    → Federated-jwt + local images for rossocortex
+# --env-file ../cortex/...    → Federated-jwt + local images for cortex
 deployments/ansible/run-install.sh --env dev \
   --env-file deployments/envs/dev_values_local_images.yaml \
   --env-file deployments/envs/dev_values_federated-jwt.yaml
@@ -158,7 +158,7 @@ This installation will:
 ## Step 3: Verify SPIRE and Keycloak
 
 ```bash
-cd rossocortex
+cd cortex
 
 chmod +x verify-spire-keycloak.sh
 ./verify-spire-keycloak.sh
@@ -246,7 +246,7 @@ spec:
         - name: certs
           mountPath: /opt
       - name: client-registration
-        image: ghcr.io/rossoctl/rossocortex/client-registration:local
+        image: ghcr.io/rossoctl/cortex/client-registration:local
         imagePullPolicy: Never
         command:
           - /bin/sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Root Makefile for rossocortex monorepo
+# Root Makefile for cortex monorepo
 # Orchestrates linting and formatting across all sub-projects
 
 .PHONY: lint fmt pre-commit build-proxy-init help

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ See the [AuthBridge README](./authbridge/README.md) for architecture details and
 
 ## Container Images
 
-All images are published to `ghcr.io/rossoctl/rossocortex/`. After
-rossocortex#411 the unified binary was split into three
+All images are published to `ghcr.io/rossoctl/cortex/`. After
+cortex#411 the unified binary was split into three
 mode-specific combined images, and the per-component sidecars
 (`client-registration`, standalone `spiffe-helper`) were retired:
 

--- a/aiac/docs/specs/demo/github-agent.md
+++ b/aiac/docs/specs/demo/github-agent.md
@@ -42,7 +42,7 @@ RFC-8693 token exchange, and the `github-tool` MitM swaps the exchanged token fo
 - Existing (issue-only) agent card: [`../../analysis/github-agent-card.json`](../../analysis/github-agent-card.json)
 - `github-tool` MCP tool catalog (44 tools): [`../../analysis/github-mcp-tools-summary.json`](../../analysis/github-mcp-tools-summary.json)
 - Reference agent: `agent-examples/a2a/git_issue_agent/`
-- Reference deployment: `rossocortex/authbridge/demos/github-issue/k8s/`
+- Reference deployment: `cortex/authbridge/demos/github-issue/k8s/`
 - **Sibling tool spec (UC-1 onboarding fixture):** [`github-tool.md`](github-tool.md) — a simplified
   4-tool stub (`source-read`, `source-write`, `issues-read`, `issues-write`) deployed as Service
   `github-tool`. **This is not the tool this agent connects to.** The agent connects to the production

--- a/aiac/docs/specs/demo/github-tool.md
+++ b/aiac/docs/specs/demo/github-tool.md
@@ -68,7 +68,7 @@ Phase 1 only discovers and evaluates them.
 - Scenario fixture (`TOOL_SCOPES`): [`../../../test/integration/scenario.py`](../../../test/integration/scenario.py)
 - Scenario spec: [`../integration-test/policy-pipeline.md`](../integration-test/policy-pipeline.md)
 - Sibling agent spec: [`github-agent.md`](github-agent.md)
-- Reference deployment: `rossocortex/authbridge/demos/github-issue/k8s/`
+- Reference deployment: `cortex/authbridge/demos/github-issue/k8s/`
 
 ---
 

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -26,7 +26,7 @@ The shared auth library at [`authlib/`](./authlib/) contains the building blocks
 
 ## Architecture (Operator-Injected)
 
-The following describes the operator-injected sidecar deployment. After rossocortex#411 each mode is served by its own combined image (one container per pod, with `spiffe-helper` bundled inside and gated by `SPIRE_ENABLED`). The legacy `authbridge-unified`, `authbridge-light`, `envoy-with-processor`, and standalone `client-registration` / `spiffe-helper` sidecars are gone.
+The following describes the operator-injected sidecar deployment. After cortex#411 each mode is served by its own combined image (one container per pod, with `spiffe-helper` bundled inside and gated by `SPIRE_ENABLED`). The legacy `authbridge-unified`, `authbridge-light`, `envoy-with-processor`, and standalone `client-registration` / `spiffe-helper` sidecars are gone.
 
 ### What AuthBridge Does
 
@@ -149,7 +149,7 @@ flowchart TB
 
 ### Workload Pod
 
-After rossocortex#411 a workload pod has the application
+After cortex#411 a workload pod has the application
 container plus a single combined AuthBridge sidecar. In
 envoy-sidecar mode it also has a one-shot `proxy-init` init
 container; in proxy-sidecar mode (the cluster default) it does
@@ -432,7 +432,7 @@ To make a plugin excludable:
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/<name>"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/<name>"
 ```
 
 2. Remove the corresponding `_ "...plugins/<name>"` import from that binary's `main.go`.

--- a/authbridge/authlib/README.md
+++ b/authbridge/authlib/README.md
@@ -36,8 +36,8 @@ Plugins own their own configuration and construct any `auth.Auth` they need inte
 
 ```go
 import (
-    "github.com/rossoctl/rossocortex/authbridge/authlib/config"
-    "github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+    "github.com/rossoctl/cortex/authbridge/authlib/config"
+    "github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 cfg, _ := config.Load("config.yaml")
@@ -58,7 +58,7 @@ For direct use of the `auth/` composition layer (outside of plugins), see `auth/
 ## Go Module
 
 ```
-module github.com/rossoctl/rossocortex/authbridge/authlib
+module github.com/rossoctl/cortex/authbridge/authlib
 ```
 
 Direct dependencies: `lestrrat-go/jwx/v2`, `gobwas/glob`, `gopkg.in/yaml.v3`. No gRPC or Envoy deps.

--- a/authbridge/authlib/auth/auth.go
+++ b/authbridge/authlib/auth/auth.go
@@ -10,11 +10,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/cache"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/cache"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
 )
 
 // IdentityConfig holds the agent's identity for audience validation and token exchange.

--- a/authbridge/authlib/auth/auth_test.go
+++ b/authbridge/authlib/auth/auth_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/cache"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/cache"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
 )
 
 // mockVerifier captures the audiences arg and returns configured claims/error.

--- a/authbridge/authlib/auth/result.go
+++ b/authbridge/authlib/auth/result.go
@@ -3,7 +3,7 @@
 package auth
 
 import (
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
 )
 
 // Inbound actions.

--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"gopkg.in/yaml.v3"
 )
 

--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // --- Preset Tests ---

--- a/authbridge/authlib/go.mod
+++ b/authbridge/authlib/go.mod
@@ -1,4 +1,4 @@
-module github.com/rossoctl/rossocortex/authbridge/authlib
+module github.com/rossoctl/cortex/authbridge/authlib
 
 go 1.26.4
 

--- a/authbridge/authlib/go.mod
+++ b/authbridge/authlib/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gobwas/glob v0.2.3
-	github.com/rossoctl/context-guru v0.0.0-20260713113308-b624f2c3d8c2
 	github.com/lestrrat-go/jwx/v2 v2.1.7
 	github.com/maximhq/bifrost/core v1.7.0
 	github.com/open-policy-agent/opa v1.18.2
+	github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563
 	github.com/spiffe/go-spiffe/v2 v2.8.1
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0

--- a/authbridge/authlib/go.sum
+++ b/authbridge/authlib/go.sum
@@ -191,6 +191,8 @@ github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8A
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
+github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563 h1:YsOMYgqAxFzy9mxzmSC+1dWfC36riFQrV7vce2AtjUo=
+github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563/go.mod h1:Uycopjjz08nDc2UsrnUxUUjqK0myN9VDnZBTaLnbfLs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/authbridge/authlib/listener/e2e/placeholder_e2e_test.go
+++ b/authbridge/authlib/listener/e2e/placeholder_e2e_test.go
@@ -20,13 +20,13 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/forwardproxy"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/reverseproxy"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	jwtvalidation "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation"
-	tokenexchange "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/forwardproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/reverseproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	jwtvalidation "github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation"
+	tokenexchange "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 // startJWKS mints an RSA keypair, serves its public half as a JWKS, and

--- a/authbridge/authlib/listener/extauthz/server.go
+++ b/authbridge/authlib/listener/extauthz/server.go
@@ -15,8 +15,8 @@ import (
 
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // Server implements the Envoy ext_authz Authorization gRPC service.

--- a/authbridge/authlib/listener/extauthz/server_test.go
+++ b/authbridge/authlib/listener/extauthz/server_test.go
@@ -11,13 +11,13 @@ import (
 	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"google.golang.org/grpc/codes"
 
-	authpkg "github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/cache"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
+	authpkg "github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/cache"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
 )
 
 type mockVerifier struct {

--- a/authbridge/authlib/listener/extproc/mcpreject_test.go
+++ b/authbridge/authlib/listener/extproc/mcpreject_test.go
@@ -8,7 +8,7 @@ import (
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // pctxWithMCP builds the minimum pctx needed to trigger the JSON-RPC

--- a/authbridge/authlib/listener/extproc/placeholder_test.go
+++ b/authbridge/authlib/listener/extproc/placeholder_test.go
@@ -6,7 +6,7 @@ import (
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // mintPlugin rewrites the inbound Authorization header to a minted

--- a/authbridge/authlib/listener/extproc/server.go
+++ b/authbridge/authlib/listener/extproc/server.go
@@ -21,12 +21,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/httpx"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/internal/sseframe"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/skiphost"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/httpx"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/sseframe"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes

--- a/authbridge/authlib/listener/extproc/server_test.go
+++ b/authbridge/authlib/listener/extproc/server_test.go
@@ -14,15 +14,15 @@ import (
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"google.golang.org/grpc/metadata"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/cache"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/cache"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // mockStream implements ExternalProcessor_ProcessServer for testing.

--- a/authbridge/authlib/listener/extproc/skiphost_test.go
+++ b/authbridge/authlib/listener/extproc/skiphost_test.go
@@ -8,10 +8,10 @@ import (
 
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/skiphost"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // markerPlugin records one Invocation per OnRequest call so tests can

--- a/authbridge/authlib/listener/forwardproxy/mcp_sse_repro_test.go
+++ b/authbridge/authlib/listener/forwardproxy/mcp_sse_repro_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/inferenceparser"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/mcpparser"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/mcpparser"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // TestForwardProxy_MCP_SSEResponse_RecordsObserve reproduces the live

--- a/authbridge/authlib/listener/forwardproxy/mcp_sse_stream_test.go
+++ b/authbridge/authlib/listener/forwardproxy/mcp_sse_stream_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // TestForwardProxy_SSE_StreamsWithoutResponder is the regression test for

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -19,15 +19,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/httpx"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/internal/sseframe"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/skiphost"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
-	authtls "github.com/rossoctl/rossocortex/authbridge/authlib/tls"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/tlsbridge"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/httpx"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/sseframe"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
+	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes

--- a/authbridge/authlib/listener/forwardproxy/server_test.go
+++ b/authbridge/authlib/listener/forwardproxy/server_test.go
@@ -13,14 +13,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/cache"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/cache"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 type mockVerifier struct {

--- a/authbridge/authlib/listener/forwardproxy/session_pin_test.go
+++ b/authbridge/authlib/listener/forwardproxy/session_pin_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // TestRecordOutboundResponse_PinsRequestSession is the regression guard for

--- a/authbridge/authlib/listener/forwardproxy/skiphost_test.go
+++ b/authbridge/authlib/listener/forwardproxy/skiphost_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/skiphost"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // markerPlugin records one Invocation per OnRequest call. Tests use it to

--- a/authbridge/authlib/listener/forwardproxy/streaming_test.go
+++ b/authbridge/authlib/listener/forwardproxy/streaming_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // streamingProbe is a minimal Plugin + StreamingResponder used to

--- a/authbridge/authlib/listener/forwardproxy/tlsbridge_integration_test.go
+++ b/authbridge/authlib/listener/forwardproxy/tlsbridge_integration_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/tlsbridge"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
 // bridgeProbePlugin records the decrypted request method/path/headers it sees.

--- a/authbridge/authlib/listener/forwardproxy/transparent.go
+++ b/authbridge/authlib/listener/forwardproxy/transparent.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/tlsbridge"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
 // HandleTransparentConn processes one outbound connection captured by an

--- a/authbridge/authlib/listener/forwardproxy/transparent_test.go
+++ b/authbridge/authlib/listener/forwardproxy/transparent_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // TestRecordTunnelOpened_SetsTunnelMarker locks the explicit producer marker:

--- a/authbridge/authlib/listener/httpx/render.go
+++ b/authbridge/authlib/listener/httpx/render.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // WriteRejection renders a pipeline.Reject Action onto an HTTP

--- a/authbridge/authlib/listener/httpx/render_test.go
+++ b/authbridge/authlib/listener/httpx/render_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // mcpAction matches what mcp-parser populates plus what ibac (or any

--- a/authbridge/authlib/listener/internal/tlssniff/listener_test.go
+++ b/authbridge/authlib/listener/internal/tlssniff/listener_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/internal/tlssniff"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/tlssniff"
 )
 
 // TestPermissive_ServesTLS confirms that a TLS handshake byte (0x16)

--- a/authbridge/authlib/listener/reverseproxy/finisher_test.go
+++ b/authbridge/authlib/listener/reverseproxy/finisher_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
 )
 
 // waitSeen polls b until it's true, up to ~1s. OnFinish runs in the

--- a/authbridge/authlib/listener/reverseproxy/placeholder_test.go
+++ b/authbridge/authlib/listener/reverseproxy/placeholder_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // rewritePlugin sets a new Authorization on the inbound context, simulating

--- a/authbridge/authlib/listener/reverseproxy/recording_test.go
+++ b/authbridge/authlib/listener/reverseproxy/recording_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // allowOnlyPlugin records an ALLOW invocation but never sets

--- a/authbridge/authlib/listener/reverseproxy/server.go
+++ b/authbridge/authlib/listener/reverseproxy/server.go
@@ -17,13 +17,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/httpx"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/internal/sseframe"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/internal/tlssniff"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
-	authtls "github.com/rossoctl/rossocortex/authbridge/authlib/tls"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/httpx"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/sseframe"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/tlssniff"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
+	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
 )
 
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes

--- a/authbridge/authlib/listener/reverseproxy/server_test.go
+++ b/authbridge/authlib/listener/reverseproxy/server_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/plugintesting"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/plugintesting"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 type mockVerifier struct {

--- a/authbridge/authlib/listener/reverseproxy/streaming_test.go
+++ b/authbridge/authlib/listener/reverseproxy/streaming_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // streamingProbe is a Plugin + StreamingResponder for asserting on

--- a/authbridge/authlib/llmclient/README.md
+++ b/authbridge/authlib/llmclient/README.md
@@ -7,7 +7,7 @@ The package exists so plugin authors don't rewrite ~150 LOC of HTTP plumbing, JS
 ## Quick start
 
 ```go
-import "github.com/rossoctl/rossocortex/authbridge/authlib/llmclient"
+import "github.com/rossoctl/cortex/authbridge/authlib/llmclient"
 
 c := llmclient.New(llmclient.Options{
     Endpoint:           "http://host.docker.internal:11434",

--- a/authbridge/authlib/llmclient/client_test.go
+++ b/authbridge/authlib/llmclient/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/llmclient"
+	"github.com/rossoctl/cortex/authbridge/authlib/llmclient"
 )
 
 // Smallest possible response shape — the server always returns

--- a/authbridge/authlib/observe/statserver.go
+++ b/authbridge/authlib/observe/statserver.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/redact"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/redact"
 )
 
 type StatServer struct {

--- a/authbridge/authlib/observe/statserver_test.go
+++ b/authbridge/authlib/observe/statserver_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
 )
 
 func newTestConfig() *config.Config {

--- a/authbridge/authlib/pipeline/content.go
+++ b/authbridge/authlib/pipeline/content.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
 )
 
 // This file wires the named protocol extensions (A2AExtension,

--- a/authbridge/authlib/pipeline/content_test.go
+++ b/authbridge/authlib/pipeline/content_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
 )
 
 func TestA2AExtension_Fragments(t *testing.T) {

--- a/authbridge/authlib/pipeline/context.go
+++ b/authbridge/authlib/pipeline/context.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
 )
 
 // Identity carries the subject identity established by whichever auth

--- a/authbridge/authlib/pipeline/sharedstore_test.go
+++ b/authbridge/authlib/pipeline/sharedstore_test.go
@@ -3,8 +3,8 @@ package pipeline_test
 import (
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 // shared.Store must satisfy pipeline.SharedStore so listeners can inject it.

--- a/authbridge/authlib/plugins/a2aparser/plugin.go
+++ b/authbridge/authlib/plugins/a2aparser/plugin.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"log/slog"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/internal/parsercommon"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/internal/parsercommon"
 )
 
 // A2AParser parses A2A JSON-RPC 2.0 request bodies and populates

--- a/authbridge/authlib/plugins/a2aparser/plugin_test.go
+++ b/authbridge/authlib/plugins/a2aparser/plugin_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestA2AParser_Capabilities(t *testing.T) {

--- a/authbridge/authlib/plugins/a2aparser/streaming_test.go
+++ b/authbridge/authlib/plugins/a2aparser/streaming_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestA2AParser_OnResponseFrame_FoldsArtifactAndFinalStatus(t *testing.T) {

--- a/authbridge/authlib/plugins/contextguru/build_test.go
+++ b/authbridge/authlib/plugins/contextguru/build_test.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 
 	// Register inference-parser so context-guru's RequiresAny is satisfiable.
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/inferenceparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
 )
 
 // TestBuild_InChainAfterInferenceParser confirms the plugin assembles on the

--- a/authbridge/authlib/plugins/contextguru/plugin.go
+++ b/authbridge/authlib/plugins/contextguru/plugin.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/llmclient"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/llmclient"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 
 	"github.com/rossoctl/context-guru/apply"
 	cgcomponents "github.com/rossoctl/context-guru/components"

--- a/authbridge/authlib/plugins/contextguru/plugin_test.go
+++ b/authbridge/authlib/plugins/contextguru/plugin_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	bschemas "github.com/maximhq/bifrost/core/schemas"
 )
 

--- a/authbridge/authlib/plugins/cpex/README.md
+++ b/authbridge/authlib/plugins/cpex/README.md
@@ -29,7 +29,7 @@ That orchestration allows you to see the full scope of your authorization flow (
 
 ## How it works
 
-AuthBridge parses traffic into a typed pipeline context ([inspired by CPEX's specification](https://github.com/rossoctl/rossocortex/commit/4c53164d02809ddb19f3b79b3abf9c288a8bc4fb)).
+AuthBridge parses traffic into a typed pipeline context ([inspired by CPEX's specification](https://github.com/rossoctl/cortex/commit/4c53164d02809ddb19f3b79b3abf9c288a8bc4fb)).
 The cpex plugin projects that context into CMF (a normalized, typed policy context), invokes the
 CPEX hooks the operator configured, applies any modifications CPEX returns
 (redacted bodies, mutated headers, session labels), and maps the CPEX outcome

--- a/authbridge/authlib/plugins/cpex/cmf_a2a.go
+++ b/authbridge/authlib/plugins/cpex/cmf_a2a.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // A2A (JSON-RPC) body write-back. Like the inference re-serializers, the

--- a/authbridge/authlib/plugins/cpex/cmf_a2a_test.go
+++ b/authbridge/authlib/plugins/cpex/cmf_a2a_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // --- a2aToCMFParts (request) ---

--- a/authbridge/authlib/plugins/cpex/cmf_body.go
+++ b/authbridge/authlib/plugins/cpex/cmf_body.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // isStreamingResponseGap reports whether a response-phase invocation has a

--- a/authbridge/authlib/plugins/cpex/cmf_body_test.go
+++ b/authbridge/authlib/plugins/cpex/cmf_body_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // --- applyMCPRequestBodyMod ---

--- a/authbridge/authlib/plugins/cpex/cmf_inference.go
+++ b/authbridge/authlib/plugins/cpex/cmf_inference.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // Inference (OpenAI chat/completions) body write-back. The cgo adapter

--- a/authbridge/authlib/plugins/cpex/cmf_inference_test.go
+++ b/authbridge/authlib/plugins/cpex/cmf_inference_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // --- inferenceToCMFParts (request) ---

--- a/authbridge/authlib/plugins/cpex/manager.go
+++ b/authbridge/authlib/plugins/cpex/manager.go
@@ -3,7 +3,7 @@ package cpex
 import (
 	"context"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // Manager is the surface plugin.go uses to talk to CPEX. It is a

--- a/authbridge/authlib/plugins/cpex/manager_cpex.go
+++ b/authbridge/authlib/plugins/cpex/manager_cpex.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	rcpex "github.com/contextforge-org/cpex/go/cpex"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // cpexManager is the CPEX-backed Manager implementation. Wraps

--- a/authbridge/authlib/plugins/cpex/manager_test.go
+++ b/authbridge/authlib/plugins/cpex/manager_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // FakeManager is a programmable Manager for unit tests. Set Hooks,

--- a/authbridge/authlib/plugins/cpex/plugin.go
+++ b/authbridge/authlib/plugins/cpex/plugin.go
@@ -57,9 +57,9 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 // CPEX is the AuthBridge plugin chassis around a CPEX PluginManager.

--- a/authbridge/authlib/plugins/cpex/plugin_test.go
+++ b/authbridge/authlib/plugins/cpex/plugin_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // Canonical test-config strings. Most dispatch tests want a single

--- a/authbridge/authlib/plugins/ibac/judge.go
+++ b/authbridge/authlib/plugins/ibac/judge.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/llmclient"
+	"github.com/rossoctl/cortex/authbridge/authlib/llmclient"
 )
 
 // Judge evaluates whether a proposed agent action aligns with a recorded

--- a/authbridge/authlib/plugins/ibac/judge_test.go
+++ b/authbridge/authlib/plugins/ibac/judge_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/llmclient"
+	"github.com/rossoctl/cortex/authbridge/authlib/llmclient"
 )
 
 // These tests cover the IBAC-specific layer on top of llmclient:

--- a/authbridge/authlib/plugins/ibac/plugin.go
+++ b/authbridge/authlib/plugins/ibac/plugin.go
@@ -35,10 +35,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 // ibacConfig is the plugin's local config schema. See

--- a/authbridge/authlib/plugins/ibac/plugin_test.go
+++ b/authbridge/authlib/plugins/ibac/plugin_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // fakeJudge records what it was asked and returns the configured

--- a/authbridge/authlib/plugins/inferenceparser/anthropic.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // anthropicMessagesPath is the Anthropic Messages API endpoint. Clients

--- a/authbridge/authlib/plugins/inferenceparser/anthropic_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestInferenceParser_AnthropicMessages_Request(t *testing.T) {

--- a/authbridge/authlib/plugins/inferenceparser/plugin.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/internal/parsercommon"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/internal/parsercommon"
 )
 
 // InferenceParser parses outbound OpenAI-compatible LLM inference requests

--- a/authbridge/authlib/plugins/inferenceparser/plugin_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestInferenceParser_Capabilities(t *testing.T) {

--- a/authbridge/authlib/plugins/inferenceparser/streaming_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/streaming_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestInferenceParser_OnResponseFrame_StreamFoldsDeltas(t *testing.T) {

--- a/authbridge/authlib/plugins/jwtvalidation/e2e_audiences_test.go
+++ b/authbridge/authlib/plugins/jwtvalidation/e2e_audiences_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // E2E-style test: full jwt-validation Configure + OnRequest against a

--- a/authbridge/authlib/plugins/jwtvalidation/identity.go
+++ b/authbridge/authlib/plugins/jwtvalidation/identity.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
 )
 
 // claimsIdentity adapts a *validation.Claims to the pipeline.Identity

--- a/authbridge/authlib/plugins/jwtvalidation/identity_test.go
+++ b/authbridge/authlib/plugins/jwtvalidation/identity_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/contracts"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
 )
 
 func TestClaimsIdentity_BasicAccessors(t *testing.T) {

--- a/authbridge/authlib/plugins/jwtvalidation/placeholder_test.go
+++ b/authbridge/authlib/plugins/jwtvalidation/placeholder_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 func mintTestContext(store pipeline.SharedStore) *pipeline.Context {

--- a/authbridge/authlib/plugins/jwtvalidation/plugin.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin.go
@@ -11,14 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
 )
 
 // jwtValidationConfig is the plugin's local config schema. See

--- a/authbridge/authlib/plugins/jwtvalidation/plugin_test.go
+++ b/authbridge/authlib/plugins/jwtvalidation/plugin_test.go
@@ -8,10 +8,10 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation/validation"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation/validation"
 )
 
 // invokeOnRequest mirrors what Pipeline.Run does around each plugin

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 type budgetTrackConfig struct {
@@ -73,7 +73,7 @@ func (p *BudgetTrack) OnRequest(_ context.Context, pctx *pipeline.Context) pipel
 
 	if spend >= p.cfg.MaxBudget {
 		return pipeline.DenyStatus(429, "budget.exceeded",
-			fmt.Sprintf("Rossocortex ExceededTokenBudget: daily spend $%.4f exceeds budget $%.2f. Reset at midnight UTC.", spend, p.cfg.MaxBudget))
+			fmt.Sprintf("Cortex ExceededTokenBudget: daily spend $%.4f exceeds budget $%.2f. Reset at midnight UTC.", spend, p.cfg.MaxBudget))
 	}
 	return pipeline.Action{Type: pipeline.Continue}
 }

--- a/authbridge/authlib/plugins/mcpparser/plugin.go
+++ b/authbridge/authlib/plugins/mcpparser/plugin.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/internal/parsercommon"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/internal/parsercommon"
 )
 
 // Synthetic method names emitted on body-less MCP transport-layer

--- a/authbridge/authlib/plugins/mcpparser/plugin_test.go
+++ b/authbridge/authlib/plugins/mcpparser/plugin_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // configured returns an MCPParser with paths configured. Most existing

--- a/authbridge/authlib/plugins/mcpparser/streaming_test.go
+++ b/authbridge/authlib/plugins/mcpparser/streaming_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestMCPParser_OnResponseFrame_PerMessageRecording(t *testing.T) {

--- a/authbridge/authlib/plugins/opa/plugin.go
+++ b/authbridge/authlib/plugins/opa/plugin.go
@@ -17,9 +17,9 @@ import (
 	"github.com/open-policy-agent/opa/sdk"
 	opalog "github.com/open-policy-agent/opa/v1/logging"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 const (

--- a/authbridge/authlib/plugins/opa/plugin_test.go
+++ b/authbridge/authlib/plugins/opa/plugin_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/open-policy-agent/opa/sdk"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // mockDecider implements the decider interface for testing.

--- a/authbridge/authlib/plugins/plugins_test.go
+++ b/authbridge/authlib/plugins/plugins_test.go
@@ -6,20 +6,20 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 	// Side-effect imports register the bundled plugins. Same pattern
 	// main.go uses — each plugin lives in its own subpackage and
 	// advertises itself via init(); importing here makes the name
 	// resolvable to plugins.Build in these tests.
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/a2aparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/inferenceparser"
-	jwtvalidation "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/mcpparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/opa"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenbroker"
-	tokenexchange "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/a2aparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
+	jwtvalidation "github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/mcpparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/opa"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenbroker"
+	tokenexchange "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange"
 )
 
 // TestBuiltinsRegistered verifies every in-tree plugin is discoverable

--- a/authbridge/authlib/plugins/plugintesting/plugintesting.go
+++ b/authbridge/authlib/plugins/plugintesting/plugintesting.go
@@ -16,9 +16,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
 )
 
 // JWTValidationStub mimics the jwt-validation plugin's OnRequest

--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // PluginFactory returns a fresh plugin instance. Plugins take no

--- a/authbridge/authlib/plugins/registry_test.go
+++ b/authbridge/authlib/plugins/registry_test.go
@@ -6,9 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // TestRegisterPlugin_DoubleRegistration_Panics locks the strict-fail

--- a/authbridge/authlib/plugins/sparc/collect.go
+++ b/authbridge/authlib/plugins/sparc/collect.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // correlateInferenceContext pulls the conversation (incl. system prompt) and

--- a/authbridge/authlib/plugins/sparc/plugin.go
+++ b/authbridge/authlib/plugins/sparc/plugin.go
@@ -45,9 +45,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/bypass"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/bypass"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 // enforcement modes.

--- a/authbridge/authlib/plugins/sparc/plugin_test.go
+++ b/authbridge/authlib/plugins/sparc/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 type fakeReflector struct {

--- a/authbridge/authlib/plugins/sparc/respond.go
+++ b/authbridge/authlib/plugins/sparc/respond.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // buildClarificationText renders an agent-facing message from SPARC's issues.

--- a/authbridge/authlib/plugins/staticinject/plugin.go
+++ b/authbridge/authlib/plugins/staticinject/plugin.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 // Source values for staticInjectConfig.Source.

--- a/authbridge/authlib/plugins/staticinject/plugin_test.go
+++ b/authbridge/authlib/plugins/staticinject/plugin_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestSwapsPlaceholderForRealToken(t *testing.T) {

--- a/authbridge/authlib/plugins/staticinject/resolver.go
+++ b/authbridge/authlib/plugins/staticinject/resolver.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"path/filepath"
 
-	credconfig "github.com/rossoctl/rossocortex/authbridge/authlib/config"
+	credconfig "github.com/rossoctl/cortex/authbridge/authlib/config"
 )
 
 // Resolver looks up a credential value by key. ok=false means the key is

--- a/authbridge/authlib/plugins/stats.go
+++ b/authbridge/authlib/plugins/stats.go
@@ -1,8 +1,8 @@
 package plugins
 
 import (
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // StatsSource is an optional interface a plugin implements when it

--- a/authbridge/authlib/plugins/tokenbroker/plugin.go
+++ b/authbridge/authlib/plugins/tokenbroker/plugin.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 
 	"github.com/gobwas/glob"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenbroker/client"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenbroker/client"
 	"gopkg.in/yaml.v3"
 )
 

--- a/authbridge/authlib/plugins/tokenbroker/plugin_edge_test.go
+++ b/authbridge/authlib/plugins/tokenbroker/plugin_edge_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // =============================================================================

--- a/authbridge/authlib/plugins/tokenbroker/plugin_request_test.go
+++ b/authbridge/authlib/plugins/tokenbroker/plugin_request_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // =============================================================================

--- a/authbridge/authlib/plugins/tokenbroker/plugin_routing_test.go
+++ b/authbridge/authlib/plugins/tokenbroker/plugin_routing_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // =============================================================================

--- a/authbridge/authlib/plugins/tokenexchange/delegation_test.go
+++ b/authbridge/authlib/plugins/tokenexchange/delegation_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestSplitScopes(t *testing.T) {

--- a/authbridge/authlib/plugins/tokenexchange/placeholder_test.go
+++ b/authbridge/authlib/plugins/tokenexchange/placeholder_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 func resolveTestPlugin(t *testing.T, exchangeURL string) *TokenExchange {

--- a/authbridge/authlib/plugins/tokenexchange/plugin.go
+++ b/authbridge/authlib/plugins/tokenexchange/plugin.go
@@ -12,15 +12,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/cache"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/routing"
-	fwspiffe "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/cache"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/routing"
+	fwspiffe "github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // tokenExchangeConfig is the plugin's local config schema. See

--- a/authbridge/authlib/plugins/tokenexchange/plugin_test.go
+++ b/authbridge/authlib/plugins/tokenexchange/plugin_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	fwspiffe "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	fwspiffe "github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // fakeJWTSource is a minimal fwspiffe.JWTSource for unit-testing the

--- a/authbridge/authlib/plugins/tokenexchange/provider.go
+++ b/authbridge/authlib/plugins/tokenexchange/provider.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	fwspiffe "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	fwspiffe "github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // Identity type constants.

--- a/authbridge/authlib/plugins/tokenexchange/provider_keycloak.go
+++ b/authbridge/authlib/plugins/tokenexchange/provider_keycloak.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-	fwspiffe "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+	fwspiffe "github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // keycloakProvider derives endpoints and builds client auth from

--- a/authbridge/authlib/reloader/reloader.go
+++ b/authbridge/authlib/reloader/reloader.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // PipelineBuilder loads the config file, validates it, and returns the

--- a/authbridge/authlib/reloader/reloader_test.go
+++ b/authbridge/authlib/reloader/reloader_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // buildFn captures the caller-supplied pipeline results so tests can

--- a/authbridge/authlib/session/intent_pin_test.go
+++ b/authbridge/authlib/session/intent_pin_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // intent fabricates the same shape SessionView.LastIntent recognizes:

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // DefaultSessionID is used when no explicit A2A SessionID is present and no

--- a/authbridge/authlib/session/store_test.go
+++ b/authbridge/authlib/session/store_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func TestStore_AppendAndView(t *testing.T) {

--- a/authbridge/authlib/sessionapi/catalog_adapter.go
+++ b/authbridge/authlib/sessionapi/catalog_adapter.go
@@ -1,8 +1,8 @@
 package sessionapi
 
 import (
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 // PluginsCatalog adapts plugins.Catalog() into the wire-shaped

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/redact"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/redact"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // defaultHeartbeatInterval is how often the SSE stream sends a keep-alive

--- a/authbridge/authlib/sessionapi/server_test.go
+++ b/authbridge/authlib/sessionapi/server_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // newTestServer wires a Server backed by a fresh Store onto httptest so tests

--- a/authbridge/authlib/tls/client.go
+++ b/authbridge/authlib/tls/client.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // ClientConfig builds an mTLS *tls.Config for the forward-proxy

--- a/authbridge/authlib/tls/server.go
+++ b/authbridge/authlib/tls/server.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // ServerConfig builds an mTLS *tls.Config for the reverse-proxy

--- a/authbridge/authlib/tls/server_test.go
+++ b/authbridge/authlib/tls/server_test.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
-	authtls "github.com/rossoctl/rossocortex/authbridge/authlib/tls"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
+	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
 )
 
 // fakeSource lets tests drive Certificate / TrustBundle results

--- a/authbridge/cmd/README.md
+++ b/authbridge/cmd/README.md
@@ -11,9 +11,9 @@ image is a build variant of the proxy binary (proxy Dockerfile +
 
 | Directory | Mode | Listeners | Plugins | Image (CI) |
 |---|---|---|---|---|
-| [`authbridge-proxy/`](authbridge-proxy/) | `proxy-sidecar` (default) | HTTP forward + reverse proxies | full (jwt-validation, token-exchange, a2a-parser, mcp-parser, inference-parser) | `ghcr.io/rossoctl/rossocortex/authbridge` |
-| [`authbridge-envoy/`](authbridge-envoy/) | `envoy-sidecar` | gRPC ext_proc on `:9090` (hooked into Envoy) | full | `ghcr.io/rossoctl/rossocortex/authbridge-envoy` |
-| `authbridge-lite` _(build variant of `authbridge-proxy`)_ | `proxy-sidecar` | HTTP forward + reverse proxies | lite — `authbridge-proxy` built with `exclude_plugin_*` tags (jwt-validation + token-exchange only; OPA + parsers dropped) | `ghcr.io/rossoctl/rossocortex/authbridge-lite` |
+| [`authbridge-proxy/`](authbridge-proxy/) | `proxy-sidecar` (default) | HTTP forward + reverse proxies | full (jwt-validation, token-exchange, a2a-parser, mcp-parser, inference-parser) | `ghcr.io/rossoctl/cortex/authbridge` |
+| [`authbridge-envoy/`](authbridge-envoy/) | `envoy-sidecar` | gRPC ext_proc on `:9090` (hooked into Envoy) | full | `ghcr.io/rossoctl/cortex/authbridge-envoy` |
+| `authbridge-lite` _(build variant of `authbridge-proxy`)_ | `proxy-sidecar` | HTTP forward + reverse proxies | lite — `authbridge-proxy` built with `exclude_plugin_*` tags (jwt-validation + token-exchange only; OPA + parsers dropped) | `ghcr.io/rossoctl/cortex/authbridge-lite` |
 | [`abctl/`](abctl/) | n/a | n/a | n/a | not published — local TUI for the Session Events API |
 
 Each binary directory contains `main.go`, `go.mod`/`go.sum`,

--- a/authbridge/cmd/abctl/apiclient/client.go
+++ b/authbridge/cmd/abctl/apiclient/client.go
@@ -12,8 +12,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 // Client is a handle to a session API endpoint. Safe for concurrent use.

--- a/authbridge/cmd/abctl/apiclient/client_test.go
+++ b/authbridge/cmd/abctl/apiclient/client_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
 
 func TestListSessions(t *testing.T) {

--- a/authbridge/cmd/abctl/apiclient/sse.go
+++ b/authbridge/cmd/abctl/apiclient/sse.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // StreamEvent is what Stream publishes. One of Event or Status is set per

--- a/authbridge/cmd/abctl/edit/edit.go
+++ b/authbridge/cmd/abctl/edit/edit.go
@@ -8,7 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // tempFileMaxAge is how long a stale edit tempfile is allowed to sit

--- a/authbridge/cmd/abctl/edit/templates.go
+++ b/authbridge/cmd/abctl/edit/templates.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // FenceMarker delimits the active pipeline subtree (above) from the

--- a/authbridge/cmd/abctl/edit/templates_test.go
+++ b/authbridge/cmd/abctl/edit/templates_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 func TestRenderTemplates_EmptyCatalog(t *testing.T) {

--- a/authbridge/cmd/abctl/edit/validate.go
+++ b/authbridge/cmd/abctl/edit/validate.go
@@ -5,7 +5,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // ValidationError describes one problem with a proposed pipeline,

--- a/authbridge/cmd/abctl/edit/validate_test.go
+++ b/authbridge/cmd/abctl/edit/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 func validateFixtureCatalog() []apiclient.PluginCatalogEntry {

--- a/authbridge/cmd/abctl/go.mod
+++ b/authbridge/cmd/abctl/go.mod
@@ -1,4 +1,4 @@
-module github.com/rossoctl/rossocortex/authbridge/cmd/abctl
+module github.com/rossoctl/cortex/authbridge/cmd/abctl
 
 go 1.26.4
 
@@ -7,14 +7,14 @@ go 1.26.4
 // workspace will not resolve this path — if abctl is ever distributed as
 // a standalone binary, drop the replace and version authlib as a proper
 // dependency once it has a tagged release.
-replace github.com/rossoctl/rossocortex/authbridge/authlib => ../../authlib
+replace github.com/rossoctl/cortex/authbridge/authlib => ../../authlib
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.7
-	github.com/rossoctl/rossocortex/authbridge/authlib v0.0.0-00010101000000-000000000000
+	github.com/rossoctl/cortex/authbridge/authlib v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -15,9 +15,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/tui"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/tui"
 )
 
 func main() {

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -18,11 +18,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"gopkg.in/yaml.v3"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 // Pane identifiers.

--- a/authbridge/cmd/abctl/tui/catalog_pane.go
+++ b/authbridge/cmd/abctl/tui/catalog_pane.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/table"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // newCatalogTable builds the registered-plugin catalog table. Same

--- a/authbridge/cmd/abctl/tui/catalog_pane_test.go
+++ b/authbridge/cmd/abctl/tui/catalog_pane_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 func TestRebuildCatalogTable_RendersEntries(t *testing.T) {

--- a/authbridge/cmd/abctl/tui/deps.go
+++ b/authbridge/cmd/abctl/tui/deps.go
@@ -3,7 +3,7 @@ package tui
 import (
 	"fmt"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // depCheck describes whether one declared dependency is satisfied by

--- a/authbridge/cmd/abctl/tui/deps_test.go
+++ b/authbridge/cmd/abctl/tui/deps_test.go
@@ -3,7 +3,7 @@ package tui
 import (
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 func TestPluginDepsAllSatisfied_RequiresMet(t *testing.T) {

--- a/authbridge/cmd/abctl/tui/detail_pane.go
+++ b/authbridge/cmd/abctl/tui/detail_pane.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // showDetail loads the row's event into the detail viewport as colorized

--- a/authbridge/cmd/abctl/tui/detail_pane_test.go
+++ b/authbridge/cmd/abctl/tui/detail_pane_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // tlsHeader returns "" for plaintext events so callers can prepend

--- a/authbridge/cmd/abctl/tui/e2e_test.go
+++ b/authbridge/cmd/abctl/tui/e2e_test.go
@@ -8,10 +8,10 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/sessionapi"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/sessionapi"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // startStack spins up a real session store + sessionapi.Server on a random

--- a/authbridge/cmd/abctl/tui/edit_e2e_test.go
+++ b/authbridge/cmd/abctl/tui/edit_e2e_test.go
@@ -12,7 +12,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 const editFixtureCMYAML = `apiVersion: v1

--- a/authbridge/cmd/abctl/tui/edit_overlay.go
+++ b/authbridge/cmd/abctl/tui/edit_overlay.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 // editPhase tracks where the edit state machine currently sits.

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // newEventsTable builds an empty events table. Uses the shared tableStyles

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -7,7 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // TestPageActivePane_EventsTable verifies PgDn/PgUp page the events table by a

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -7,8 +7,8 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 // catalogPlugins extracts the plugin slice from a (possibly nil)

--- a/authbridge/cmd/abctl/tui/namespaces_pane.go
+++ b/authbridge/cmd/abctl/tui/namespaces_pane.go
@@ -10,9 +10,9 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 // newNamespacesTable builds an empty namespaces picker table.

--- a/authbridge/cmd/abctl/tui/picker_test.go
+++ b/authbridge/cmd/abctl/tui/picker_test.go
@@ -9,8 +9,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
 )
 
 // fakeLister returns a fixed []AgentNamespace and counts ListAgents calls.

--- a/authbridge/cmd/abctl/tui/pipeline_pane.go
+++ b/authbridge/cmd/abctl/tui/pipeline_pane.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/table"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // newPipelineTable builds the plugins table shown on the Pipeline top-level

--- a/authbridge/cmd/abctl/tui/pipeline_pane_test.go
+++ b/authbridge/cmd/abctl/tui/pipeline_pane_test.go
@@ -3,7 +3,7 @@ package tui
 import (
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // TestRebuildPipelineTable_AllRowsMatchColumnCount is a regression guard:

--- a/authbridge/cmd/abctl/tui/plugin_detail_pane.go
+++ b/authbridge/cmd/abctl/tui/plugin_detail_pane.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // showPluginDetail loads the focused plugin into the detail viewport.

--- a/authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
+++ b/authbridge/cmd/abctl/tui/plugin_detail_pane_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 func TestShowPluginDetailRendersConfig(t *testing.T) {

--- a/authbridge/cmd/abctl/tui/pods_pane.go
+++ b/authbridge/cmd/abctl/tui/pods_pane.go
@@ -6,7 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
 )
 
 // newPodsTable builds an empty pods picker table.

--- a/authbridge/cmd/abctl/tui/sessions_pane.go
+++ b/authbridge/cmd/abctl/tui/sessions_pane.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/table"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // newSessionsTable builds an empty sessions table.

--- a/authbridge/cmd/authbridge-cpex/go.mod
+++ b/authbridge/cmd/authbridge-cpex/go.mod
@@ -1,8 +1,8 @@
-module github.com/rossoctl/rossocortex/authbridge/cmd/authbridge-cpex
+module github.com/rossoctl/cortex/authbridge/cmd/authbridge-cpex
 
 go 1.26.4
 
-require github.com/rossoctl/rossocortex/authbridge/authlib v0.0.0-00010101000000-000000000000
+require github.com/rossoctl/cortex/authbridge/authlib v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -38,4 +38,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/rossoctl/rossocortex/authbridge/authlib => ../../authlib
+replace github.com/rossoctl/cortex/authbridge/authlib => ../../authlib

--- a/authbridge/cmd/authbridge-cpex/main.go
+++ b/authbridge/cmd/authbridge-cpex/main.go
@@ -31,34 +31,34 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/observe"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/reloader"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/sessionapi"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
-	authtls "github.com/rossoctl/rossocortex/authbridge/authlib/tls"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/observe"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/reloader"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/sessionapi"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
+	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/forwardproxy"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/reverseproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/forwardproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/reverseproxy"
 
 	// Plugins — same set as authbridge-proxy, plus the cpex plugin
 	// which lives behind //go:build cpex. The cpex import only fires
 	// in this binary's build; pure-Go binaries (authbridge-proxy,
 	// authbridge-envoy, authbridge-lite) don't import it.
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/a2aparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/cpex"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/ibac"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/inferenceparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/mcpparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/sparc"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenbroker"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/a2aparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/cpex"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/ibac"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/mcpparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/sparc"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenbroker"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange"
 )
 
 var logLevel = new(slog.LevelVar)

--- a/authbridge/cmd/authbridge-envoy/go.mod
+++ b/authbridge/cmd/authbridge-envoy/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/huandu/go-sqlbuilder v1.41.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/rossoctl/context-guru v0.0.0-20260713113308-b624f2c3d8c2 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
@@ -82,6 +81,7 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
+	github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/authbridge/cmd/authbridge-envoy/go.mod
+++ b/authbridge/cmd/authbridge-envoy/go.mod
@@ -1,12 +1,12 @@
-module github.com/rossoctl/rossocortex/authbridge/cmd/authbridge-envoy
+module github.com/rossoctl/cortex/authbridge/cmd/authbridge-envoy
 
 go 1.26.4
 
-replace github.com/rossoctl/rossocortex/authbridge/authlib => ../../authlib
+replace github.com/rossoctl/cortex/authbridge/authlib => ../../authlib
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
-	github.com/rossoctl/rossocortex/authbridge/authlib v0.0.0-00010101000000-000000000000
+	github.com/rossoctl/cortex/authbridge/authlib v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.82.0
 )
 

--- a/authbridge/cmd/authbridge-envoy/go.sum
+++ b/authbridge/cmd/authbridge-envoy/go.sum
@@ -189,6 +189,8 @@ github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8A
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
+github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563 h1:YsOMYgqAxFzy9mxzmSC+1dWfC36riFQrV7vce2AtjUo=
+github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563/go.mod h1:Uycopjjz08nDc2UsrnUxUUjqK0myN9VDnZBTaLnbfLs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -31,32 +31,32 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/observe"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/reloader"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/sessionapi"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/observe"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/reloader"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/sessionapi"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 
 	// Only the ext_proc listener is compiled in (no ext_authz, no
 	// HTTP proxies).
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/extproc"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/skiphost"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/extproc"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
 
 	// Plugins. Auth gates first, then the protocol parsers that
 	// supply session-event context for abctl.
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/a2aparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/inferenceparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/mcpparser"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/opa"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/sparc"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenbroker"
-	_ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/a2aparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/mcpparser"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/opa"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/sparc"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenbroker"
+	_ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange"
 )
 
 var logLevel = new(slog.LevelVar)

--- a/authbridge/cmd/authbridge-envoy/plugins_contextguru.go
+++ b/authbridge/cmd/authbridge-envoy/plugins_contextguru.go
@@ -7,4 +7,4 @@
 // linked only when built with -tags include_plugin_contextguru.
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/contextguru"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/contextguru"

--- a/authbridge/cmd/authbridge-envoy/plugins_ibac.go
+++ b/authbridge/cmd/authbridge-envoy/plugins_ibac.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/ibac"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/ibac"

--- a/authbridge/cmd/authbridge-proxy/go.mod
+++ b/authbridge/cmd/authbridge-proxy/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/huandu/go-sqlbuilder v1.41.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/rossoctl/context-guru v0.0.0-20260713113308-b624f2c3d8c2 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
@@ -73,6 +72,7 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
+	github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/authbridge/cmd/authbridge-proxy/go.mod
+++ b/authbridge/cmd/authbridge-proxy/go.mod
@@ -1,8 +1,8 @@
-module github.com/rossoctl/rossocortex/authbridge/cmd/authbridge-proxy
+module github.com/rossoctl/cortex/authbridge/cmd/authbridge-proxy
 
 go 1.26.4
 
-require github.com/rossoctl/rossocortex/authbridge/authlib v0.0.0-00010101000000-000000000000
+require github.com/rossoctl/cortex/authbridge/authlib v0.0.0-00010101000000-000000000000
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -118,4 +118,4 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/rossoctl/rossocortex/authbridge/authlib => ../../authlib
+replace github.com/rossoctl/cortex/authbridge/authlib => ../../authlib

--- a/authbridge/cmd/authbridge-proxy/go.sum
+++ b/authbridge/cmd/authbridge-proxy/go.sum
@@ -181,6 +181,8 @@ github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8A
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
+github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563 h1:YsOMYgqAxFzy9mxzmSC+1dWfC36riFQrV7vce2AtjUo=
+github.com/rossoctl/context-guru v0.0.0-20260720181432-8fc7c7b36563/go.mod h1:Uycopjjz08nDc2UsrnUxUUjqK0myN9VDnZBTaLnbfLs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -30,25 +30,25 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/auth"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/observe"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/reloader"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/session"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/sessionapi"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
-	authtls "github.com/rossoctl/rossocortex/authbridge/authlib/tls"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/tlsbridge"
+	"github.com/rossoctl/cortex/authbridge/authlib/auth"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/observe"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/reloader"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/sessionapi"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
+	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 
 	// Only HTTP listeners are compiled in: no extproc/extauthz
 	// (no gRPC, no envoy types).
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/forwardproxy"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/reverseproxy"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/skiphost"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/listener/transparentproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/forwardproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/reverseproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/transparentproxy"
 	// Plugins are wired via per-plugin plugins_<name>.go files, each gated
 	// by `//go:build !exclude_plugin_<name>`. main.go imports no plugin
 	// package directly, so every plugin can be dropped at build time. The

--- a/authbridge/cmd/authbridge-proxy/main_test.go
+++ b/authbridge/cmd/authbridge-proxy/main_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/config"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange"
 )
 
 func identityConfig(idType string) json.RawMessage {

--- a/authbridge/cmd/authbridge-proxy/plugins_a2aparser.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_a2aparser.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/a2aparser"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/a2aparser"

--- a/authbridge/cmd/authbridge-proxy/plugins_contextguru.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_contextguru.go
@@ -7,4 +7,4 @@
 // linked only when built with -tags include_plugin_contextguru.
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/contextguru"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/contextguru"

--- a/authbridge/cmd/authbridge-proxy/plugins_ibac.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_ibac.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/ibac"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/ibac"

--- a/authbridge/cmd/authbridge-proxy/plugins_inferenceparser.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_inferenceparser.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/inferenceparser"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"

--- a/authbridge/cmd/authbridge-proxy/plugins_jwtvalidation.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_jwtvalidation.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/jwtvalidation"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/jwtvalidation"

--- a/authbridge/cmd/authbridge-proxy/plugins_litellm_budgettrack.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_litellm_budgettrack.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/litellm_budgettrack"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/litellm_budgettrack"

--- a/authbridge/cmd/authbridge-proxy/plugins_mcpparser.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_mcpparser.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/mcpparser"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/mcpparser"

--- a/authbridge/cmd/authbridge-proxy/plugins_opa.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_opa.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/opa"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/opa"

--- a/authbridge/cmd/authbridge-proxy/plugins_sparc.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_sparc.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/sparc"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/sparc"

--- a/authbridge/cmd/authbridge-proxy/plugins_staticinject.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_staticinject.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/staticinject"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/staticinject"

--- a/authbridge/cmd/authbridge-proxy/plugins_tokenbroker.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_tokenbroker.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenbroker"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenbroker"

--- a/authbridge/cmd/authbridge-proxy/plugins_tokenexchange.go
+++ b/authbridge/cmd/authbridge-proxy/plugins_tokenexchange.go
@@ -2,4 +2,4 @@
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange"

--- a/authbridge/demos/README.md
+++ b/authbridge/demos/README.md
@@ -5,7 +5,7 @@ authentication for Kubernetes agent workloads. Each demo progressively introduce
 more AuthBridge capabilities.
 
 > **Note:** These demos use the operator-injected combined sidecar (after
-> rossocortex#411 — `authbridge` for proxy-sidecar, `authbridge-envoy`
+> cortex#411 — `authbridge` for proxy-sidecar, `authbridge-envoy`
 > for envoy-sidecar, and `authbridge-lite`, the proxy image built auth-only
 > via `exclude_plugin_*` tags). The previous `authbridge-unified` image and the per-component
 > sidecars (`client-registration`, standalone `spiffe-helper`) have been

--- a/authbridge/demos/echo/go.mod
+++ b/authbridge/demos/echo/go.mod
@@ -1,3 +1,3 @@
-module github.com/rossoctl/rossocortex/authbridge/demos/echo
+module github.com/rossoctl/cortex/authbridge/demos/echo
 
 go 1.24

--- a/authbridge/demos/echo/scripts/setup_keycloak.py
+++ b/authbridge/demos/echo/scripts/setup_keycloak.py
@@ -338,7 +338,7 @@ def main():
     # reject UI chat requests with "invalid audience".
     #
     # TODO: Remove this workaround once the client-registration sidecar
-    # handles this automatically (rossoctl/rossocortex#169).
+    # handles this automatically (rossoctl/cortex#169).
     print(f"\n--- Adding agent audience scope to UI client '{UI_CLIENT_ID}' ---")
     ui_client_internal_id = keycloak_admin.get_client_id(UI_CLIENT_ID)
     if ui_client_internal_id:

--- a/authbridge/demos/finance-sparc/Makefile
+++ b/authbridge/demos/finance-sparc/Makefile
@@ -31,7 +31,7 @@ AGENT             := finance-agent
 PLATFORM_NS       := rossoctl-system
 # Prefer whichever runtime's daemon is actually reachable (docker first).
 CONTAINER_RUNTIME ?= $(shell docker info >/dev/null 2>&1 && echo docker || (podman info >/dev/null 2>&1 && echo podman) || echo docker)
-AUTHBRIDGE_IMAGE  ?= ghcr.io/rossoctl/rossocortex/authbridge:v0.6.0-alpha.4
+AUTHBRIDGE_IMAGE  ?= ghcr.io/rossoctl/cortex/authbridge:v0.6.0-alpha.4
 
 AGENT_IMAGE := finance-agent:latest
 MCP_IMAGE   := finance-mcp:latest

--- a/authbridge/demos/finance-sparc/go.mod
+++ b/authbridge/demos/finance-sparc/go.mod
@@ -1,3 +1,3 @@
-module github.com/rossoctl/rossocortex/authbridge/demos/finance-sparc
+module github.com/rossoctl/cortex/authbridge/demos/finance-sparc
 
 go 1.24

--- a/authbridge/demos/github-issue/aiac/Makefile
+++ b/authbridge/demos/github-issue/aiac/Makefile
@@ -32,7 +32,7 @@ help:  ## Show this menu (default)
 	@printf "\nVariables:\n"
 	@printf "  \033[36m%-20s\033[0m %s\n" "POLICY" "policy file to apply (default: policies/regular_policy.txt)"
 	@printf "  \033[36m%-20s\033[0m %s\n" "RBAC_CONFIG" "RBAC config file (default: rbac/config.yaml)"
-	@printf "  \033[36m%-20s\033[0m %s\n" "PYTHON"  "Python interpreter (default: rossocortex/.venv/bin/python)"
+	@printf "  \033[36m%-20s\033[0m %s\n" "PYTHON"  "Python interpreter (default: cortex/.venv/bin/python)"
 	@printf "\nPrerequisites: uv, Keycloak running, aiac.env and llm_conf.yaml configured.\n\n"
 
 POLICY ?= policies/regular_policy.txt

--- a/authbridge/demos/github-issue/demo-aiac.md
+++ b/authbridge/demos/github-issue/demo-aiac.md
@@ -74,7 +74,7 @@ Before starting, ensure you have:
 
 - Python 3.9+ with `venv` support
 - Keycloak running and accessible
-- The rossocortex repository cloned
+- The cortex repository cloned
 - Basic understanding of Keycloak concepts (realms, clients, roles)
 
 **Creating GitHub Personal Access Tokens**
@@ -110,7 +110,7 @@ kind load docker-image --name rossoctl ghcr.io/rossoctl/examples/git-issue-agent
 Create and activate a Python virtual environment:
 
 ```bash
-cd rossocortex/
+cd cortex/
 
 # Create virtual environment
 uv sync
@@ -130,7 +130,7 @@ The Rossoctl installer creates default ConfigMaps.
 Apply the demo-specific ConfigMaps — the `authproxy-routes` ConfigMap configures per-route token exchange (target audience and scopes for the `github-tool` host), and `authbridge-config` sets the agent SPIFFE ID for inbound audience validation. Apply this **before** deploying the agent.
 
 ```bash
-cd rossocortex/authbridge
+cd cortex/authbridge
 
 # Create namespace if it doesn't exist
 kubectl create namespace team1 --dry-run=client -o yaml | kubectl apply -f -

--- a/authbridge/demos/github-issue/demo-manual.md
+++ b/authbridge/demos/github-issue/demo-manual.md
@@ -175,7 +175,7 @@ Ensure you have completed the Rossoctl platform setup as described in the
 [Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md).
 
 You should also have:
-- The [rossocortex](https://github.com/rossoctl/rossocortex) repo cloned
+- The [cortex](https://github.com/rossoctl/cortex) repo cloned
 - The [agent-examples](https://github.com/rossoctl/examples) repo cloned
 - Python 3.9+ with `venv` support
 - **Ollama running** with the `ibm/granite4:latest` model (or another model of your choice)
@@ -411,7 +411,7 @@ github-tool-7f8c9d6b44-yyyyy      1/1     Running   0          3m
 
 ### Check operator-managed client registration
 
-After rossocortex#411 / operator#361, registration runs in
+After cortex#411 / operator#361, registration runs in
 the operator (outside the workload pod). Verify the resulting
 Secret was mounted into the agent's sidecar:
 
@@ -513,7 +513,7 @@ kubectl wait --for=condition=ready pod/test-client -n team1 --timeout=30s
 ### 8a. Agent Card - Public Endpoint (No Token Required)
 
 The `/.well-known/agent.json` endpoint is publicly accessible — authbridge
-[bypasses JWT validation](https://github.com/rossoctl/rossocortex/pull/133)
+[bypasses JWT validation](https://github.com/rossoctl/cortex/pull/133)
 for `/.well-known/*`, `/healthz`, `/readyz`, and `/livez` by default:
 
 ```bash
@@ -846,14 +846,14 @@ kubectl delete pod test-client -n team1 --ignore-not-found
 
 ## Step 10: Access Control — Alice vs Bob
 
-<!-- WORKAROUND: Remove this note once rossocortex#139 is implemented.
+<!-- WORKAROUND: Remove this note once cortex#139 is implemented.
      The full scope-forwarding feature in authbridge is required for this step to work
      end-to-end. Until that lands, the exchanged token always includes github-full-access
      (from the static token_scopes in the authproxy-routes ConfigMap).
-     Track: https://github.com/rossoctl/rossocortex/issues/139 -->
+     Track: https://github.com/rossoctl/cortex/issues/139 -->
 
 > **Known limitation:** This step requires the authbridge scope forwarding feature
-> ([rossocortex#139](https://github.com/rossoctl/rossocortex/issues/139)).
+> ([cortex#139](https://github.com/rossoctl/cortex/issues/139)).
 > Currently, `token_scopes` in the `authproxy-routes` ConfigMap is static per-route, so
 > all exchanged tokens include `github-full-access` regardless of the original user's
 > scopes. Once scope forwarding is implemented, Alice's exchanged token will omit
@@ -873,7 +873,7 @@ The flow:
    (`github-full-access` is a realm OPTIONAL scope — Keycloak only includes it when the
    token request contains `scope=openid github-full-access`)
 3. AuthBridge exchanges the token — once scope forwarding is implemented
-   ([#139](https://github.com/rossoctl/rossocortex/issues/139)), the exchanged
+   ([#139](https://github.com/rossoctl/cortex/issues/139)), the exchanged
    token will preserve the scope difference
 4. The GitHub tool checks for `REQUIRED_SCOPE` (`github-full-access`) in the exchanged token
 5. Tokens with the scope get the privileged PAT; tokens without get the public-only PAT

--- a/authbridge/demos/github-issue/demo-rbac.md
+++ b/authbridge/demos/github-issue/demo-rbac.md
@@ -175,7 +175,7 @@ Ensure you have completed the Rossoctl platform setup as described in the
 [Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md).
 
 You should also have:
-- The [rossocortex](https://github.com/rossoctl/rossocortex) repo cloned
+- The [cortex](https://github.com/rossoctl/cortex) repo cloned
 - The [agent-examples](https://github.com/rossoctl/examples) repo cloned
 - Python 3.9+ with `venv` support
 - **Ollama running** with the `ibm/granite4:latest` model (or another model of your choice)
@@ -411,7 +411,7 @@ github-tool-7f8c9d6b44-yyyyy      1/1     Running   0          3m
 
 ### Check operator-managed client registration
 
-After rossocortex#411 / operator#361, registration runs in
+After cortex#411 / operator#361, registration runs in
 the operator (outside the workload pod). Verify the resulting
 Secret was mounted into the agent's sidecar:
 
@@ -513,7 +513,7 @@ kubectl wait --for=condition=ready pod/test-client -n team1 --timeout=30s
 ### 8a. Agent Card - Public Endpoint (No Token Required)
 
 The `/.well-known/agent.json` endpoint is publicly accessible — authbridge
-[bypasses JWT validation](https://github.com/rossoctl/rossocortex/pull/133)
+[bypasses JWT validation](https://github.com/rossoctl/cortex/pull/133)
 for `/.well-known/*`, `/healthz`, `/readyz`, and `/livez` by default:
 
 ```bash

--- a/authbridge/demos/github-issue/demo-ui.md
+++ b/authbridge/demos/github-issue/demo-ui.md
@@ -91,7 +91,7 @@ Ensure you have completed the Rossoctl platform setup as described in the
 including the Rossoctl UI.
 
 You should also have:
-- The [rossocortex](https://github.com/rossoctl/rossocortex) repo cloned
+- The [cortex](https://github.com/rossoctl/cortex) repo cloned
 - The Rossoctl UI running at `http://rossoctl-ui.localtest.me:8080`
 - Python 3.10+ with `venv` support
 - An LLM provider — either **Ollama** with `ibm/granite4:latest` (or another model)
@@ -389,7 +389,7 @@ Wait for the Shipwright build to complete and the deployment to become ready.
 kubectl get pods -n team1
 ```
 
-Expected output (after rossocortex#411 / operator#361:
+Expected output (after cortex#411 / operator#361:
 one combined AuthBridge sidecar, registration is operator-managed):
 
 ```
@@ -618,7 +618,7 @@ kubectl wait --for=condition=ready pod/test-client -n team1 --timeout=30s
 ### 9a. Agent Card - Public Endpoint (No Token Required)
 
 The `/.well-known/agent.json` endpoint is publicly accessible — authbridge
-[bypasses JWT validation](https://github.com/rossoctl/rossocortex/pull/133)
+[bypasses JWT validation](https://github.com/rossoctl/cortex/pull/133)
 for `/.well-known/*`, `/healthz`, `/readyz`, and `/livez` by default:
 
 ```bash
@@ -793,14 +793,14 @@ kubectl delete pod test-client -n team1 --ignore-not-found
 
 ## Step 10: Access Control — Alice vs Bob
 
-<!-- WORKAROUND: Remove this note once rossocortex#139 is implemented.
+<!-- WORKAROUND: Remove this note once cortex#139 is implemented.
      The full scope-forwarding feature in authbridge is required for this step to work
      end-to-end. Until that lands, the exchanged token always includes github-full-access
      (from the static token_scopes in the authproxy-routes ConfigMap).
-     Track: https://github.com/rossoctl/rossocortex/issues/139 -->
+     Track: https://github.com/rossoctl/cortex/issues/139 -->
 
 > **Known limitation:** This step requires the authbridge scope forwarding feature
-> ([rossocortex#139](https://github.com/rossoctl/rossocortex/issues/139)).
+> ([cortex#139](https://github.com/rossoctl/cortex/issues/139)).
 > Currently, `token_scopes` in the `authproxy-routes` ConfigMap is static per-route, so
 > all exchanged tokens include `github-full-access` regardless of the original user's
 > scopes. Once scope forwarding is implemented, Alice's exchanged token will omit
@@ -820,7 +820,7 @@ The flow:
    (`github-full-access` is a realm OPTIONAL scope — Keycloak only includes it when the
    token request contains `scope=openid github-full-access`)
 3. AuthBridge exchanges the token — once scope forwarding is implemented
-   ([#139](https://github.com/rossoctl/rossocortex/issues/139)), the exchanged
+   ([#139](https://github.com/rossoctl/cortex/issues/139)), the exchanged
    token will preserve the scope difference
 4. The GitHub tool checks for `REQUIRED_SCOPE` (`github-full-access`) in the exchanged token
 5. Tokens with the scope get the privileged PAT; tokens without get the public-only PAT

--- a/authbridge/demos/github-issue/demo.md
+++ b/authbridge/demos/github-issue/demo.md
@@ -25,7 +25,7 @@ produce identical AuthBridge security behavior.
 3. **Transparent token exchange** — When the agent calls the GitHub tool, AuthBridge exchanges the token automatically
 4. **Subject preservation** — The end user's identity (`sub` claim) is preserved through the exchange
 5. **Scope-based access** — The tool uses token scopes to determine public or privileged GitHub API access
-6. **Access control (Alice vs Bob)** — Two users with different scopes get different GitHub API access levels: Alice (public only) cannot access private repos, while Bob (privileged) can access both (requires scope forwarding: [rossocortex#139](https://github.com/rossoctl/rossocortex/issues/139))
+6. **Access control (Alice vs Bob)** — Two users with different scopes get different GitHub API access levels: Alice (public only) cannot access private repos, while Bob (privileged) can access both (requires scope forwarding: [cortex#139](https://github.com/rossoctl/cortex/issues/139))
 
 ## Architecture Overview
 
@@ -39,7 +39,7 @@ produce identical AuthBridge security behavior.
                   └──── Keycloak (token exchange) ─────────┘
 ```
 
-The agent pod has two containers (after rossocortex#411):
+The agent pod has two containers (after cortex#411):
 - **agent** — the A2A agent (port 8000)
 - **AuthBridge sidecar** — combined image; container name depends on
   the resolved AuthBridge mode:

--- a/authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
+++ b/authbridge/demos/github-issue/k8s/git-issue-agent-deployment.yaml
@@ -1,7 +1,7 @@
 # GitHub Issue Agent Deployment with AuthBridge
 #
 # This deployment uses the operator webhook to automatically inject
-# a single combined AuthBridge sidecar (post-rossocortex#411). The exact
+# a single combined AuthBridge sidecar (post-cortex#411). The exact
 # container shape depends on the resolved AuthBridge mode:
 # - proxy-sidecar (default): one container "authbridge-proxy" from the
 #   "authbridge" image. spiffe-helper is bundled inside; gated per-workload

--- a/authbridge/demos/github-issue/rbac/Makefile
+++ b/authbridge/demos/github-issue/rbac/Makefile
@@ -47,7 +47,7 @@ help:  ## Show this menu (default)
 	@printf "  \033[36m%-22s\033[0m %s\n" "PUBLIC_ACCESS_PAT"     "GitHub PAT with public-repo access (required for deploy)"
 	@printf "  \033[36m%-22s\033[0m %s\n" "RBAC_CONFIG"           "RBAC config file (default: rbac/config.yaml)"
 	@printf "  \033[36m%-22s\033[0m %s\n" "RBAC_POLICY"           "RBAC policy file (default: rbac/policy.yaml)"
-	@printf "  \033[36m%-22s\033[0m %s\n" "PYTHON"                "Python interpreter (default: rossocortex/.venv/bin/python)"
+	@printf "  \033[36m%-22s\033[0m %s\n" "PYTHON"                "Python interpreter (default: cortex/.venv/bin/python)"
 	@printf "\nPrerequisites: uv, kubectl, kind, docker, Keycloak running.\n\n"
 
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/authbridge/demos/github-issue/setup_keycloak.py
+++ b/authbridge/demos/github-issue/setup_keycloak.py
@@ -409,7 +409,7 @@ def main_manual(namespace: str = DEFAULT_NAMESPACE, service_account: str = DEFAU
     # reject UI chat requests with "invalid audience".
     #
     # TODO: Remove this workaround once the client-registration sidecar
-    # handles this automatically (rossoctl/rossocortex#169).
+    # handles this automatically (rossoctl/cortex#169).
     print(f"\n--- Adding agent audience scope to UI client '{UI_CLIENT_ID}' ---")
     ui_client_internal_id = keycloak_admin.get_client_id(UI_CLIENT_ID)
     if ui_client_internal_id:

--- a/authbridge/demos/ibac/go.mod
+++ b/authbridge/demos/ibac/go.mod
@@ -1,3 +1,3 @@
-module github.com/rossoctl/rossocortex/authbridge/demos/ibac
+module github.com/rossoctl/cortex/authbridge/demos/ibac
 
 go 1.24

--- a/authbridge/demos/mtls/k8s/callee-envoy.yaml
+++ b/authbridge/demos/mtls/k8s/callee-envoy.yaml
@@ -53,7 +53,7 @@ spec:
             requests: { cpu:  10m, memory: 32Mi }
 
         - name: envoy-proxy
-          image: ghcr.io/rossoctl/rossocortex/authbridge-envoy:latest
+          image: ghcr.io/rossoctl/cortex/authbridge-envoy:latest
           imagePullPolicy: IfNotPresent
           args: ["--config", "/etc/authbridge/config.yaml"]
           ports:

--- a/authbridge/demos/mtls/k8s/caller-envoy.yaml
+++ b/authbridge/demos/mtls/k8s/caller-envoy.yaml
@@ -66,7 +66,7 @@ spec:
             requests: { cpu:  10m, memory: 32Mi }
 
         - name: envoy-proxy
-          image: ghcr.io/rossoctl/rossocortex/authbridge-envoy:latest
+          image: ghcr.io/rossoctl/cortex/authbridge-envoy:latest
           imagePullPolicy: IfNotPresent
           # The combined image's entrypoint runs authbridge-envoy
           # with these args (which it forwards to the binary), then

--- a/authbridge/demos/weather-agent/demo-ui.md
+++ b/authbridge/demos/weather-agent/demo-ui.md
@@ -236,7 +236,7 @@ weather-tool-7f8c9d6b44-yyyyy     1/1     Running   0          5m
 ```
 
 > **Note:** AuthBridge ships as a single combined sidecar image (since
-> rossocortex#411). `weather-service` runs `agent` + the combined
+> cortex#411). `weather-service` runs `agent` + the combined
 > AuthBridge sidecar — `2/2` — regardless of whether SPIRE identity is
 > enabled. The `spiffe-helper` is bundled inside the combined image and
 > activated per workload via `SPIRE_ENABLED` (driven by the
@@ -269,7 +269,7 @@ the combined sidecar, not as a separate container.
 
 ### Check operator-managed client registration
 
-After rossocortex#411 / operator#361, client registration runs
+After cortex#411 / operator#361, client registration runs
 in the operator (outside the workload pod). Verify the resulting
 Secret is mounted into the agent's sidecar:
 

--- a/authbridge/demos/weather-agent/demo-with-abctl.md
+++ b/authbridge/demos/weather-agent/demo-with-abctl.md
@@ -39,11 +39,11 @@ Verify by sending one chat message and getting a weather response. Once that wor
 
 ## 1. Build `abctl`
 
-`abctl` lives in the `rossocortex` repo. Build it once:
+`abctl` lives in the `cortex` repo. Build it once:
 
 ```sh
-git clone https://github.com/rossoctl/rossocortex.git
-cd rossocortex/authbridge/cmd/abctl
+git clone https://github.com/rossoctl/cortex.git
+cd cortex/authbridge/cmd/abctl
 go build .
 ```
 

--- a/authbridge/docs/idp-plugin-contract.md
+++ b/authbridge/docs/idp-plugin-contract.md
@@ -1,6 +1,6 @@
 # IdP-Agnostic Token Exchange Plugin Contract
 
-> **Status:** Implemented — RHAIENG-5681 / rossocortex#481
+> **Status:** Implemented — RHAIENG-5681 / cortex#481
 >
 > This document defines the contract that an Identity Provider (IdP)
 > plugin must satisfy for the AuthBridge token exchange pipeline.
@@ -50,8 +50,8 @@ Create a single file — no changes to core plugin code required:
 package tokenexchange
 
 import (
-    "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/tokenexchange/exchange"
-    fwspiffe "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+    "github.com/rossoctl/cortex/authbridge/authlib/plugins/tokenexchange/exchange"
+    fwspiffe "github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 type oktaProvider struct{}

--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -13,7 +13,7 @@ with HTTP 429 when the configured daily budget is exceeded.
 
 ## Use Case
 
-When running AI agents through RossoCortex (local budget proxy), each agent needs
+When running AI agents through Cortex (local budget proxy), each agent needs
 a spending cap. LiteLLM returns the cost of each completion in the
 `x-litellm-response-cost` response header. This plugin reads that header in the
 AuthBridge inbound pipeline, tracks cumulative daily spend in a JSON ledger file,
@@ -22,7 +22,7 @@ and blocks further requests once the budget is exhausted.
 ## Architecture
 
 ```
-Agent → rossocortex.py → AuthBridge (litellm-budget-track) → LiteLLM upstream
+Agent → cortex.py → AuthBridge (litellm-budget-track) → LiteLLM upstream
                                     │
                                     ├── OnRequest: check if budget exceeded → 429
                                     └── OnResponse: read x-litellm-response-cost, accumulate
@@ -51,7 +51,7 @@ pipeline:
     plugins:
       - name: litellm-budget-track
         config:
-          spend_file: /etc/rossocortex/spend-authbridge.json
+          spend_file: /etc/cortex/spend-authbridge.json
           max_budget: 5.00
 ```
 
@@ -84,7 +84,7 @@ The spend file (`spend-authbridge.json`) is a simple JSON object:
 2. If `date` != today UTC → reset ledger to zero
 3. If `total_spend >= max_budget` → return HTTP 429 with body:
    ```
-   Rossocortex ExceededTokenBudget: daily spend $X.XXXX exceeds budget $Y.YY. Reset at midnight UTC.
+   Cortex ExceededTokenBudget: daily spend $X.XXXX exceeds budget $Y.YY. Reset at midnight UTC.
    ```
 4. Otherwise → continue pipeline
 
@@ -112,23 +112,23 @@ The registration file uses the standard build-tag pattern:
 
 package main
 
-import _ "github.com/rossoctl/rossocortex/authbridge/authlib/plugins/litellm_budgettrack"
+import _ "github.com/rossoctl/cortex/authbridge/authlib/plugins/litellm_budgettrack"
 ```
 
-## Integration with RossoCortex
+## Integration with Cortex
 
-RossoCortex generates the AuthBridge config on startup, embedding the plugin
+Cortex generates the AuthBridge config on startup, embedding the plugin
 in the inbound pipeline with the correct `spend_file` path and `max_budget`
 from the CLI flags:
 
 ```bash
 # rossoctlx.py start --budget 5.00
 # → generates config.yaml with litellm-budget-track plugin
-#   spend_file = ~/.config/rossocortex/spend-authbridge.json
+#   spend_file = ~/.config/cortex/spend-authbridge.json
 #   max_budget = 5.00
 ```
 
-The plugin complements rossocortex.py's own budget tracking (which reads
+The plugin complements cortex.py's own budget tracking (which reads
 the same `x-litellm-response-cost` header on direct HTTP requests). For
 CONNECT-tunneled traffic that flows through AuthBridge's TLS bridge,
 the plugin is the only cost-tracking mechanism.
@@ -153,4 +153,4 @@ go build ./cmd/authbridge-proxy/
 - Per-agent budget tracking (separate ledger files per agent identity)
 - Budget alerts at configurable thresholds (e.g., 80% warning)
 - Weekly/monthly budget periods (not just daily)
-- Integration with rossocortex control API for real-time budget queries
+- Integration with cortex control API for real-time budget queries

--- a/authbridge/docs/plugin-reference.md
+++ b/authbridge/docs/plugin-reference.md
@@ -433,7 +433,7 @@ import (
     "errors"
     "fmt"
 
-    "github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+    "github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // myPluginConfig is the plugin's private config schema. Fields are JSON-
@@ -889,7 +889,7 @@ the types in [`authlib/pipeline/content.go`](../authlib/pipeline/content.go).
 ### Consuming content in a guardrail
 
 ```go
-import "github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
+import "github.com/rossoctl/cortex/authbridge/authlib/contracts"
 
 func (p *JailbreakDetector) OnRequest(_ context.Context, pctx *pipeline.Context) pipeline.Action {
     for _, src := range pctx.ContentSources() {

--- a/authbridge/docs/plugin-tutorial.md
+++ b/authbridge/docs/plugin-tutorial.md
@@ -33,7 +33,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 type HelloLog struct{}
@@ -255,8 +255,8 @@ imports the registry instead of sharing its package:
 package myplugin
 
 import (
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
 
 type MyPlugin struct{}
@@ -279,7 +279,7 @@ package main
 import _ "github.com/acme/my-plugin"
 ```
 
-No fork of rossocortex required.
+No fork of cortex required.
 
 ## Step 7 — Test your plugin
 
@@ -330,7 +330,7 @@ Minimal example for an Inference-like parser whose extension stores
 `Messages []struct{ Role, Content string }`:
 
 ```go
-import "github.com/rossoctl/rossocortex/authbridge/authlib/contracts"
+import "github.com/rossoctl/cortex/authbridge/authlib/contracts"
 
 // Compile-time assertion — catches interface drift at build time.
 var _ contracts.ContentSource = (*MyExtension)(nil)

--- a/authbridge/docs/superpowers/plans/2026-05-22-authbridge-go-spiffe-sdk.md
+++ b/authbridge/docs/superpowers/plans/2026-05-22-authbridge-go-spiffe-sdk.md
@@ -1382,7 +1382,7 @@ func BuildWithSPIFFE(entries []config.PluginEntry, p *spiffe.Provider, opts ...p
 
 The existing `Build` function is unchanged; new wiring uses `BuildWithSPIFFE`.
 
-> Import for `spiffe` package: `import "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"`. Verify there's no cycle (spiffe should not import plugins; plugins importing spiffe is fine).
+> Import for `spiffe` package: `import "github.com/rossoctl/cortex/authbridge/authlib/spiffe"`. Verify there's no cycle (spiffe should not import plugins; plugins importing spiffe is fine).
 
 - [ ] **Step 4: Run tests**
 
@@ -1446,7 +1446,7 @@ In `authlib/plugins/tokenexchange/plugin.go`:
 
 ```go
 import (
-    fwspiffe "github.com/rossoctl/rossocortex/authbridge/authlib/spiffe"
+    fwspiffe "github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 )
 
 // Add field to TokenExchange struct:

--- a/authbridge/docs/superpowers/plans/2026-05-28-abctl-pipeline-edit.md
+++ b/authbridge/docs/superpowers/plans/2026-05-28-abctl-pipeline-edit.md
@@ -205,7 +205,7 @@ Expected: all tests pass, vet clean. The new `TestKubectlPortForward_StatusEndpo
 ### Step 6: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/cluster/portforward.go \
         authbridge/cmd/abctl/cluster/portforward_test.go \
         authbridge/cmd/abctl/tui/picker_test.go
@@ -458,7 +458,7 @@ Expected: all 4 tests PASS, vet clean.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/edit/configmap.go \
         authbridge/cmd/abctl/edit/configmap_test.go \
         authbridge/cmd/abctl/go.mod \
@@ -678,7 +678,7 @@ Expected: all 6 tests PASS, vet clean.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/edit/configmap.go \
         authbridge/cmd/abctl/edit/configmap_test.go
 git commit -s -m "feat(abctl): Add Splice and BuildManifest helpers
@@ -940,7 +940,7 @@ Expected: all 9 tests pass, vet clean.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/edit/configmap.go \
         authbridge/cmd/abctl/edit/configmap_test.go
 git commit -s -m "feat(abctl): Add Fetch and Apply for the edit flow
@@ -1192,7 +1192,7 @@ Expected: all 13 tests pass.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/edit/diff.go \
         authbridge/cmd/abctl/edit/diff_test.go
 git commit -s -m "feat(abctl): Add line-diff renderer for edit confirmation
@@ -1444,7 +1444,7 @@ Expected: all 17 tests pass, vet clean.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/edit/status.go \
         authbridge/cmd/abctl/edit/status_test.go
 git commit -s -m "feat(abctl): Poll /reload/status to detect framework reload
@@ -1550,7 +1550,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 // editPhase tracks where the edit state machine currently sits.
@@ -1648,7 +1648,7 @@ Expected: 5 new tests pass, all existing TUI tests still pass.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/tui/edit_overlay.go \
         authbridge/cmd/abctl/tui/edit_overlay_test.go
 git commit -s -m "feat(abctl): Add edit overlay state + render
@@ -1862,7 +1862,7 @@ Expected: all tests pass, vet clean.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/edit/edit.go \
         authbridge/cmd/abctl/edit/edit_test.go
 git commit -s -m "feat(abctl): Add tea.Cmd factories for the edit phases
@@ -1910,7 +1910,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 )
 
 const fixtureCMYAML = `apiVersion: v1
@@ -2124,7 +2124,7 @@ editRunner edit.Runner
 
 Add to the imports:
 ```go
-"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/edit"
+"github.com/rossoctl/cortex/authbridge/cmd/abctl/edit"
 ```
 
 Add new `tea.Msg` types near the others:
@@ -2331,7 +2331,7 @@ Expected: all tests pass, vet clean, binary builds.
 ### Step 5: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/tui/app.go \
         authbridge/cmd/abctl/tui/keys.go \
         authbridge/cmd/abctl/tui/edit_e2e_test.go \
@@ -2431,7 +2431,7 @@ Confirm the new section reads cleanly.
 ### Step 3: Commit
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git add authbridge/cmd/abctl/README.md
 git commit -s -m "docs(abctl): Document the e keybind for pipeline editing
 

--- a/authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md
+++ b/authbridge/docs/superpowers/plans/2026-05-28-abctl-plugin-config.md
@@ -974,7 +974,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/apiclient"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 func TestShowPluginDetailRendersConfig(t *testing.T) {

--- a/authbridge/docs/superpowers/plans/2026-05-28-abctl-pod-picker.md
+++ b/authbridge/docs/superpowers/plans/2026-05-28-abctl-pod-picker.md
@@ -800,7 +800,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
 )
 
 // fakeLister returns a fixed []AgentNamespace.
@@ -933,7 +933,7 @@ Find the `model` struct definition. Add these fields at the end (preserve existi
 Add the import for `cluster` to the import block:
 
 ```go
-"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
+"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
 ```
 
 Add tea messages near the other tea-message types:
@@ -957,7 +957,7 @@ import (
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
 )
 
 // newNamespacesTable builds an empty namespaces picker table.
@@ -1179,7 +1179,7 @@ package tui
 import (
 	"github.com/charmbracelet/bubbles/table"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
 )
 
 // newPodsTable builds an empty pods picker table.
@@ -1684,8 +1684,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/cluster"
-	"github.com/rossoctl/rossocortex/authbridge/cmd/abctl/tui"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/cluster"
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/tui"
 )
 
 func main() {

--- a/authbridge/docs/superpowers/plans/2026-06-02-credential-placeholder-swap.md
+++ b/authbridge/docs/superpowers/plans/2026-06-02-credential-placeholder-swap.md
@@ -345,8 +345,8 @@ package pipeline_test
 import (
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 // shared.Store must satisfy pipeline.SharedStore so listeners can inject it.
@@ -426,9 +426,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 // fakeAuth lets us drive OnRequest's allow path without real JWKS.
@@ -543,7 +543,7 @@ At the end of `Configure`, immediately before `return nil` (line 293), add:
 	}
 ```
 
-Ensure `time` is imported in plugin.go (it is used elsewhere; if not, add to the import block). Add `"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"` and confirm `"github.com/rossoctl/rossocortex/authbridge/authlib/auth"` are imported (auth is already used for `p.inner`).
+Ensure `time` is imported in plugin.go (it is used elsewhere; if not, add to the import block). Add `"github.com/rossoctl/cortex/authbridge/authlib/placeholder"` and confirm `"github.com/rossoctl/cortex/authbridge/authlib/auth"` are imported (auth is already used for `p.inner`).
 
 - [ ] **Step 5: Add the `mint` helper**
 
@@ -629,9 +629,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/shared"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/placeholder"
+	"github.com/rossoctl/cortex/authbridge/authlib/shared"
 )
 
 func resolveTestPlugin(t *testing.T, exchangeURL string) *TokenExchange {
@@ -745,7 +745,7 @@ In `authlib/plugins/tokenexchange/plugin.go`, add to `tokenExchangeConfig` (afte
 
 - [ ] **Step 4: Add the resolve step to `OnRequest`**
 
-Add the placeholder import: `"github.com/rossoctl/rossocortex/authbridge/authlib/placeholder"`.
+Add the placeholder import: `"github.com/rossoctl/cortex/authbridge/authlib/placeholder"`.
 
 In `OnRequest`, replace the opening lines:
 
@@ -791,7 +791,7 @@ func resolvePlaceholder(pctx *pipeline.Context, handle string) (string, bool) {
 }
 ```
 
-(`auth` is already imported — `auth.ExtractBearer` is used in the listeners and `p.inner` is `*auth.Auth`. Confirm the import is present in plugin.go; if not, add `"github.com/rossoctl/rossocortex/authbridge/authlib/auth"`.)
+(`auth` is already imported — `auth.ExtractBearer` is used in the listeners and `p.inner` is `*auth.Auth`. Confirm the import is present in plugin.go; if not, add `"github.com/rossoctl/cortex/authbridge/authlib/auth"`.)
 
 - [ ] **Step 5: Run tests to verify they pass**
 
@@ -826,7 +826,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 // rewritePlugin sets a new Authorization on the inbound context, simulating
@@ -970,7 +970,7 @@ import (
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 type mintPlugin struct{}
@@ -1088,7 +1088,7 @@ In `cmd/authbridge-proxy/main.go`, immediately after the `rpSrv, err := reversep
 	fpSrv.Shared = sharedStore
 ```
 
-Add the import `"github.com/rossoctl/rossocortex/authbridge/authlib/shared"`.
+Add the import `"github.com/rossoctl/cortex/authbridge/authlib/shared"`.
 
 - [ ] **Step 2: authbridge-lite — same injection**
 
@@ -1121,7 +1121,7 @@ Update the call site (line ~216):
 	grpcServers = append(grpcServers, startGRPCExtProc(inboundH, outboundH, sessions, shared.New(), cfg.Listener.ExtProcAddr))
 ```
 
-Add the imports `"github.com/rossoctl/rossocortex/authbridge/authlib/shared"` and (if not present) `"github.com/rossoctl/rossocortex/authbridge/authlib/pipeline"`.
+Add the imports `"github.com/rossoctl/cortex/authbridge/authlib/shared"` and (if not present) `"github.com/rossoctl/cortex/authbridge/authlib/pipeline"`.
 
 - [ ] **Step 4: Build everything**
 

--- a/authbridge/docs/superpowers/plans/2026-06-17-authbridge-tlsbridge-phase1.md
+++ b/authbridge/docs/superpowers/plans/2026-06-17-authbridge-tlsbridge-phase1.md
@@ -10,7 +10,7 @@
 
 **Scope (Phase 1 is test-only):** This PR is AuthBridge-only and proves the decrypt→pipeline→re-originate loop via **in-process integration tests** (a client configured to trust the ephemeral CA). It does **not** make a real operator-deployed agent trust the CA — that is Phase 2 (operator) work. On a real cluster, a live agent's egress will safely **tunnel** (the no-broken-calls guarantee), because it does not yet trust the minted leaf. See "Phase 2 compatibility" below — Phase 1 is built so the cert-manager path (2c) drops in with a one-line `main.go` swap and no changes to the bridge core.
 
-**Tech Stack:** Go 1.25, stdlib `crypto/tls` + `crypto/x509` (hand-rolled cert minting), `golang.org/x/net/http2` for h2. Module: `github.com/rossoctl/rossocortex/authbridge/authlib` (`go.mod` already has `golang.org/x/net v0.51.0` as an indirect dep — Task 5 promotes it to direct). Tests are package-internal `_test.go`, table-driven, loopback listeners; run with `go test ./...` from `authbridge/authlib`.
+**Tech Stack:** Go 1.25, stdlib `crypto/tls` + `crypto/x509` (hand-rolled cert minting), `golang.org/x/net/http2` for h2. Module: `github.com/rossoctl/cortex/authbridge/authlib` (`go.mod` already has `golang.org/x/net v0.51.0` as an indirect dep — Task 5 promotes it to direct). Tests are package-internal `_test.go`, table-driven, loopback listeners; run with `go test ./...` from `authbridge/authlib`.
 
 **Spec:** `authbridge/docs/superpowers/specs/2026-06-12-authbridge-tlsbridge-design.md`
 
@@ -62,7 +62,7 @@
 - [ ] **Step 1: Create the implementation branch from current upstream main**
 
 ```bash
-cd /Users/haihuang/works/go/src/github.com/rossoctl/rossocortex
+cd /Users/haihuang/works/go/src/github.com/rossoctl/cortex
 git fetch upstream main
 git checkout -b feat/tlsbridge-phase1 upstream/main
 ```
@@ -1042,7 +1042,7 @@ Add the field to the `Server` struct (after `SkipHosts`):
 	TLSBridge *tlsbridge.Engine // nil = disabled
 ```
 
-Add the import `"github.com/rossoctl/rossocortex/authbridge/authlib/tlsbridge"` and `"strconv"`.
+Add the import `"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"` and `"strconv"`.
 
 Add helpers (bottom of `server.go`):
 

--- a/authbridge/docs/superpowers/specs/2026-05-22-authbridge-go-spiffe-sdk-design.md
+++ b/authbridge/docs/superpowers/specs/2026-05-22-authbridge-go-spiffe-sdk-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Design — pending user review
 **Date:** 2026-05-22
-**Issue:** [rossocortex#332](https://github.com/rossoctl/rossocortex/issues/332)
+**Issue:** [cortex#332](https://github.com/rossoctl/cortex/issues/332)
 **Reference:** [klaviger's SDK usage](https://github.com/grs/klaviger/blob/main/internal/spiffe/jwt_source.go)
 
 ## Goal
@@ -399,4 +399,4 @@ the old image's loader rejects.
 | `rossoctl/charts/rossoctl/templates/` | Add `spiffe.jwt_audience` rendering. **Must precede this PR.** Later: remove `spiffe-helper-config` ConfigMap, stop emitting old fields. |
 | `rossoctl/operator` | Webhook injector: stop creating `spiffe-helper-config` Volume; surface `JWT_AUDIENCE` into authbridge YAML's `spiffe.jwt_audience`. Update e2e fixtures. |
 | `rossoctl/rossoctl/backend` | Delete `DEFAULT_SPIFFE_HELPER_CONF`; stop creating spiffe-helper-config ConfigMap on agent runtime creation. |
-| `rossocortex/authbridge` (envoy-sidecar mTLS) | When envoy-sidecar mode adds mTLS, Envoy's filesystem SDS can read the same `/opt/svid*.pem` paths the mirror writes. No additional auth bridge change needed — payoff of this design's option-B choice. |
+| `cortex/authbridge` (envoy-sidecar mTLS) | When envoy-sidecar mode adds mTLS, Envoy's filesystem SDS can read the same `/opt/svid*.pem` paths the mirror writes. No additional auth bridge change needed — payoff of this design's option-B choice. |

--- a/authbridge/docs/superpowers/specs/2026-06-12-authbridge-tlsbridge-design.md
+++ b/authbridge/docs/superpowers/specs/2026-06-12-authbridge-tlsbridge-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-12 (revised after adversarial review; renamed 2026-06-17)
 **Status:** Converged design — ready for implementation plan.
-**Repos touched:** `rossocortex/AuthBridge` (proxy), `operator` (CA coordination)
+**Repos touched:** `cortex/AuthBridge` (proxy), `operator` (CA coordination)
 
 > **Terminology:** this feature was originally called "MITM". It is now the
 > **TLS bridge** — terminate one TLS connection, run the pipeline on plaintext,

--- a/authbridge/proxy-init/README.md
+++ b/authbridge/proxy-init/README.md
@@ -132,7 +132,7 @@ make load-image          # load into a kind cluster
 ```
 
 The image is published from CI as
-`ghcr.io/rossoctl/rossocortex/proxy-init:<tag>` (build defined
+`ghcr.io/rossoctl/cortex/proxy-init:<tag>` (build defined
 in [`.github/workflows/build.yaml`](../../.github/workflows/build.yaml)).
 
 ## Testing

--- a/authbridge/sparc-service/deploy/Makefile
+++ b/authbridge/sparc-service/deploy/Makefile
@@ -17,7 +17,7 @@
 
 PROVIDER          ?= watsonx
 NAMESPACE         ?= rossoctl-system
-IMAGE             ?= ghcr.io/rossoctl/rossocortex/sparc-service:latest
+IMAGE             ?= ghcr.io/rossoctl/cortex/sparc-service:latest
 TRACK             ?= fast_track
 LLM_TIMEOUT       ?= 120
 PORT              ?= 8090

--- a/authbridge/sparc-service/deploy/README.md
+++ b/authbridge/sparc-service/deploy/README.md
@@ -30,7 +30,7 @@ When it's up, enable the plugin on an agent — see
 
 ## Image
 
-The default image is `ghcr.io/rossoctl/rossocortex/sparc-service:latest` (published by CI).
+The default image is `ghcr.io/rossoctl/cortex/sparc-service:latest` (published by CI).
 On a **kind** dev cluster, build and load a local image first:
 
 ```bash

--- a/authbridge/sparc-service/deploy/sparc-service.yaml
+++ b/authbridge/sparc-service/deploy/sparc-service.yaml
@@ -37,7 +37,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sparc-service
-          image: ghcr.io/rossoctl/rossocortex/sparc-service:latest
+          image: ghcr.io/rossoctl/cortex/sparc-service:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8090

--- a/local-build-and-test.sh
+++ b/local-build-and-test.sh
@@ -68,14 +68,14 @@ echo ""
 
 # Build authbridge (proxy-sidecar combined: authbridge-proxy + spiffe-helper)
 # Default deployment shape — used when the workload's mode is proxy-sidecar.
-# After rossocortex#411 the unified binary was split into three
+# After cortex#411 the unified binary was split into three
 # mode-specific binaries; each has its own Dockerfile under cmd/authbridge-*/.
 echo "=========================================="
 echo "Building authbridge (proxy-sidecar combined)"
 echo "=========================================="
 cd "${SCRIPT_DIR}/authbridge"
-${CONTAINER_RUNTIME} build -f cmd/authbridge-proxy/Dockerfile -t ghcr.io/rossoctl/rossocortex/authbridge:local .
-load_image_to_kind ghcr.io/rossoctl/rossocortex/authbridge:local
+${CONTAINER_RUNTIME} build -f cmd/authbridge-proxy/Dockerfile -t ghcr.io/rossoctl/cortex/authbridge:local .
+load_image_to_kind ghcr.io/rossoctl/cortex/authbridge:local
 echo "✅ Built and loaded: authbridge:local"
 echo ""
 
@@ -84,8 +84,8 @@ echo "=========================================="
 echo "Building authbridge-envoy (envoy-sidecar combined)"
 echo "=========================================="
 cd "${SCRIPT_DIR}/authbridge"
-${CONTAINER_RUNTIME} build -f cmd/authbridge-envoy/Dockerfile -t ghcr.io/rossoctl/rossocortex/authbridge-envoy:local .
-load_image_to_kind ghcr.io/rossoctl/rossocortex/authbridge-envoy:local
+${CONTAINER_RUNTIME} build -f cmd/authbridge-envoy/Dockerfile -t ghcr.io/rossoctl/cortex/authbridge-envoy:local .
+load_image_to_kind ghcr.io/rossoctl/cortex/authbridge-envoy:local
 echo "✅ Built and loaded: authbridge-envoy:local"
 echo ""
 
@@ -98,8 +98,8 @@ echo "=========================================="
 cd "${SCRIPT_DIR}/authbridge"
 ${CONTAINER_RUNTIME} build -f cmd/authbridge-proxy/Dockerfile \
   --build-arg GO_BUILD_TAGS="exclude_plugin_a2aparser,exclude_plugin_ibac,exclude_plugin_inferenceparser,exclude_plugin_mcpparser,exclude_plugin_opa,exclude_plugin_sparc,exclude_plugin_tokenbroker" \
-  -t ghcr.io/rossoctl/rossocortex/authbridge-lite:local .
-load_image_to_kind ghcr.io/rossoctl/rossocortex/authbridge-lite:local
+  -t ghcr.io/rossoctl/cortex/authbridge-lite:local .
+load_image_to_kind ghcr.io/rossoctl/cortex/authbridge-lite:local
 echo "✅ Built and loaded: authbridge-lite:local"
 echo ""
 
@@ -108,8 +108,8 @@ echo "=========================================="
 echo "Building proxy-init"
 echo "=========================================="
 cd "${SCRIPT_DIR}/authbridge/proxy-init"
-${CONTAINER_RUNTIME} build -f Dockerfile.init -t ghcr.io/rossoctl/rossocortex/proxy-init:local .
-load_image_to_kind ghcr.io/rossoctl/rossocortex/proxy-init:local
+${CONTAINER_RUNTIME} build -f Dockerfile.init -t ghcr.io/rossoctl/cortex/proxy-init:local .
+load_image_to_kind ghcr.io/rossoctl/cortex/proxy-init:local
 echo "✅ Built and loaded: proxy-init:local"
 echo ""
 
@@ -119,10 +119,10 @@ echo "=========================================="
 echo ""
 echo "Images loaded into cluster '${CLUSTER_NAME}':"
 echo "  - ghcr.io/rossoctl/rossoctl/spiffe-idp-setup:local"
-echo "  - ghcr.io/rossoctl/rossocortex/authbridge:local"
-echo "  - ghcr.io/rossoctl/rossocortex/authbridge-envoy:local"
-echo "  - ghcr.io/rossoctl/rossocortex/authbridge-lite:local"
-echo "  - ghcr.io/rossoctl/rossocortex/proxy-init:local"
+echo "  - ghcr.io/rossoctl/cortex/authbridge:local"
+echo "  - ghcr.io/rossoctl/cortex/authbridge-envoy:local"
+echo "  - ghcr.io/rossoctl/cortex/authbridge-lite:local"
+echo "  - ghcr.io/rossoctl/cortex/proxy-init:local"
 echo ""
 echo "Next steps:"
 echo "  1. Update values files to use :local tag"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for rossocortex tests."""
+"""Shared fixtures for cortex tests."""
 
 from unittest.mock import MagicMock
 


### PR DESCRIPTION
## Summary
Follow-up to the Rossoctl rename: #678 merged the kagenti→rossoctl content but **not** the later rossocortex→cortex change. The repo is now `rossoctl/cortex`, yet its 8 Go modules still declare `github.com/rossoctl/rossocortex/...` — a **module-path mismatch** that breaks `go get`/imports of `github.com/rossoctl/cortex/...`. This sweeps all `rossocortex → cortex`:

- Go modules (8): `github.com/rossoctl/rossocortex/...` → `github.com/rossoctl/cortex/...` (+ internal `replace` directives)
- Images: `ghcr.io/rossoctl/rossocortex/*` → `ghcr.io/rossoctl/cortex/*`
- Brand / prose

## Verification
- grep clean of `rossocortex` and `kagenti`
- `authbridge-cpex` + demos build ✅

## Known cross-repo dependency (not this PR)
`authlib`/`authbridge-envoy`/`authbridge-proxy` depend on `github.com/rossoctl/context-guru`, which is org-moved but **not yet module-path-renamed** (its go.mod still declares `github.com/kagenti/context-guru`). `go mod tidy` there is blocked until context-guru itself is renamed + republished; real go.sum checksums regenerate then.

## Related issue(s)
Related to #1972