### PR TITLE
Fix: duplicate build-args key in Build-Publish workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,9 +146,15 @@ jobs:
         with:
           context: ${{ matrix.image_config.context }}
           file: ${{ matrix.image_config.context }}/${{ matrix.image_config.dockerfile }}
-          build-args: ${{ matrix.image_config.build_args }}
+          # Merge both build-arg sources into a single key: static per-image
+          # args from the matrix (e.g. authbridge-lite GO_BUILD_TAGS) plus the
+          # dynamically resolved args (authbridge-cpex CPEX_FFI_*). A duplicate
+          # `build-args:` key is invalid YAML and fails the whole workflow; only
+          # one image sets each source, so concatenating them is safe.
+          build-args: |
+            ${{ matrix.image_config.build_args }}
+            ${{ steps.buildargs.outputs.args }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ steps.buildargs.outputs.args }}


### PR DESCRIPTION
## Summary

The `Build and push` step in `build.yaml` declared `build-args:` twice, which is invalid YAML (duplicate mapping key). GitHub rejects the whole workflow with "This run likely failed because of a workflow file issue", so **no cortex images are being published** under `rossoctl/cortex`.

This merges the two build-arg sources into a single multiline `build-args:`:
- static per-image `matrix.image_config.build_args` (used by `authbridge-lite` for `GO_BUILD_TAGS`)
- dynamically resolved `steps.buildargs.outputs.args` (used by `authbridge-cpex` for `CPEX_FFI_VERSION` / `CPEX_FFI_ABI`)

Only one image sets each source, so concatenating them is safe.

## Why it matters

Downstream, `rossoctl/operator` E2E fails in `BeforeSuite` pulling `ghcr.io/rossoctl/cortex/authbridge-*:latest` with `denied` — because those images never publish while this workflow is invalid. Fixing this unblocks image publishing.

(Note: after images publish, their GHCR package visibility should be confirmed public so anonymous CI pulls succeed — separate from this change.)

Part of the Kagenti to rossoctl rename CI cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the container build workflow to correctly combine build arguments.
  * Prevented potential workflow failures caused by duplicate build-argument configuration.
  * Image publishing settings, platforms, tags, and labels remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->