### PR TITLE
Feat: Log messages to help with invalid startup options

### DIFF
--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -288,7 +289,11 @@ func Build(entries []config.PluginEntry, opts ...pipeline.Option) (*pipeline.Pip
 		}
 		factory, ok := factoryFor(e.Name)
 		if !ok {
-			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, RegisteredPlugins())
+			pluginNames := RegisteredPlugins()
+			if len(pluginNames) == 0 {
+				slog.Warn("No registered plugins -- Built with --tags or use `go run .` to enable")
+			}
+			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, pluginNames)
 		}
 		p := factory()
 		if c, ok := p.(pipeline.Configurable); ok {
@@ -331,7 +336,11 @@ func BuildWithSPIFFE(entries []config.PluginEntry, p *spiffe.Provider, opts ...p
 		}
 		factory, ok := factoryFor(e.Name)
 		if !ok {
-			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, RegisteredPlugins())
+			pluginNames := RegisteredPlugins()
+			if len(pluginNames) == 0 {
+				slog.Warn("No registered plugins -- Built with --tags or use `go run .` to enable")
+			}
+			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, pluginNames)
 		}
 		plugin := factory()
 		// Inject the framework SPIFFE Provider BEFORE Configure runs so

--- a/authbridge/authlib/plugins/registry.go
+++ b/authbridge/authlib/plugins/registry.go
@@ -291,7 +291,7 @@ func Build(entries []config.PluginEntry, opts ...pipeline.Option) (*pipeline.Pip
 		if !ok {
 			pluginNames := RegisteredPlugins()
 			if len(pluginNames) == 0 {
-				slog.Warn("No registered plugins -- Built with --tags or use `go run .` to enable")
+				slog.Warn("No registered plugins -- Build with --tags or use `go run .` to enable")
 			}
 			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, pluginNames)
 		}
@@ -338,7 +338,7 @@ func BuildWithSPIFFE(entries []config.PluginEntry, p *spiffe.Provider, opts ...p
 		if !ok {
 			pluginNames := RegisteredPlugins()
 			if len(pluginNames) == 0 {
-				slog.Warn("No registered plugins -- Built with --tags or use `go run .` to enable")
+				slog.Warn("No registered plugins -- Build with --tags or use `go run .` to enable")
 			}
 			return nil, fmt.Errorf("unknown plugin %q (registered: %v)", e.Name, pluginNames)
 		}

--- a/authbridge/cmd/authbridge-cpex/main.go
+++ b/authbridge/cmd/authbridge-cpex/main.go
@@ -101,12 +101,12 @@ func main() {
 	startSignalToggle()
 
 	if *configPath == "" {
-		log.Fatal("--config is required and must be to a YAML file")
+		log.Fatal("--config is required and must point to a YAML file")
 	}
 
 	bootCfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("initial config load failed to load %q: %v", *configPath, err)
+		log.Fatalf("failed to load config %q: %v", *configPath, err)
 	}
 	var provider *spiffe.Provider
 	if bootCfg.SPIFFE != nil {

--- a/authbridge/cmd/authbridge-cpex/main.go
+++ b/authbridge/cmd/authbridge-cpex/main.go
@@ -101,12 +101,12 @@ func main() {
 	startSignalToggle()
 
 	if *configPath == "" {
-		log.Fatal("--config is required")
+		log.Fatal("--config is required and must be to a YAML file")
 	}
 
 	bootCfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("initial config load: %v", err)
+		log.Fatalf("initial config load failed to load %q: %v", *configPath, err)
 	}
 	var provider *spiffe.Provider
 	if bootCfg.SPIFFE != nil {

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -99,7 +99,7 @@ func main() {
 	startSignalToggle()
 
 	if *configPath == "" {
-		log.Fatal("--config is required")
+		log.Fatal("--config is required and must be to a YAML file")
 	}
 
 	// Build the SPIFFE Provider when the spiffe block is configured.
@@ -121,7 +121,7 @@ func main() {
 	// instances.
 	bootCfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("initial config load: %v", err)
+		log.Fatalf("initial config load failed to load %q: %v", *configPath, err)
 	}
 	var provider *spiffe.Provider
 	if bootCfg.SPIFFE != nil {

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -99,7 +99,7 @@ func main() {
 	startSignalToggle()
 
 	if *configPath == "" {
-		log.Fatal("--config is required and must be to a YAML file")
+		log.Fatal("--config is required and must point to a YAML file")
 	}
 
 	// Build the SPIFFE Provider when the spiffe block is configured.
@@ -121,7 +121,7 @@ func main() {
 	// instances.
 	bootCfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("initial config load failed to load %q: %v", *configPath, err)
+		log.Fatalf("failed to load config %q: %v", *configPath, err)
 	}
 	var provider *spiffe.Provider
 	if bootCfg.SPIFFE != nil {

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -147,7 +147,7 @@ func main() {
 	startSignalToggle()
 
 	if *configPath == "" {
-		log.Fatal("--config is required and must be to a YAML file")
+		log.Fatal("--config is required and must point to a YAML file")
 	}
 
 	// Build the SPIFFE Provider when the spiffe block is configured. The
@@ -162,7 +162,7 @@ func main() {
 	// freshly constructed plugin instances.
 	bootCfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("initial config load failed to load %q: %v", *configPath, err)
+		log.Fatalf("failed to load config %q: %v", *configPath, err)
 	}
 	// Build the SPIFFE Provider only when something actually consumes it —
 	// top-level mTLS (X509Source for the listeners) or a plugin whose identity

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -147,7 +147,7 @@ func main() {
 	startSignalToggle()
 
 	if *configPath == "" {
-		log.Fatal("--config is required")
+		log.Fatal("--config is required and must be to a YAML file")
 	}
 
 	// Build the SPIFFE Provider when the spiffe block is configured. The
@@ -162,7 +162,7 @@ func main() {
 	// freshly constructed plugin instances.
 	bootCfg, err := config.Load(*configPath)
 	if err != nil {
-		log.Fatalf("initial config load: %v", err)
+		log.Fatalf("initial config load failed to load %q: %v", *configPath, err)
 	}
 	// Build the SPIFFE Provider only when something actually consumes it —
 	// top-level mTLS (X509Source for the listeners) or a plugin whose identity


### PR DESCRIPTION
## Summary

No Issue.  A small PR that adds logging around invalid start options.

## (Optional) Testing Instructions

To start locally,

```
cd ./authbridge/cmd/authbridge-proxy
go run -tags include_plugin_contextguru . --config ../../../authbridge/demos/context-guru/k8s/authbridge-config.yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup validation for missing/empty `--config`, including clearer guidance that it must be a YAML file.
  * Enhanced fatal startup errors to include the provided config path and the underlying load failure.

* **Diagnostics**
  * Added a warning when a pipeline references an unknown plugin while no plugins are registered (helps detect build/config issues).
  * Updated unknown-plugin error details to include the available registered plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->