### PR TITLE
docs: Fix broken install.md links in authbridge demos (5 files)

### DIFF
--- a/authbridge/demos/echo/README.md
+++ b/authbridge/demos/echo/README.md
@@ -30,7 +30,7 @@ leaves it un-injected — what it logs is exactly what left the agent's sidecar.
 ## Prerequisites
 
 - A running rossoctl **kind** cluster (`rossoctl-system` + `team1` namespaces).
-  See the [install guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md).
+  See the [install guide](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md).
 - `kubectl`, `kind`, `podman` or `docker`.
 - `python3` + PyYAML (config merge) and `python-keycloak` (Keycloak setup):
   `pip install pyyaml python-keycloak`.

--- a/authbridge/demos/github-issue/demo-manual.md
+++ b/authbridge/demos/github-issue/demo-manual.md
@@ -172,7 +172,7 @@ Envoy — the agent application never sees them. This is tested in
 ## Prerequisites
 
 Ensure you have completed the Rossoctl platform setup as described in the
-[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md).
+[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md).
 
 You should also have:
 - The [cortex](https://github.com/rossoctl/cortex) repo cloned

--- a/authbridge/demos/github-issue/demo-rbac.md
+++ b/authbridge/demos/github-issue/demo-rbac.md
@@ -172,7 +172,7 @@ Envoy — the agent application never sees them. This is tested in
 ## Prerequisites
 
 Ensure you have completed the Rossoctl platform setup as described in the
-[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md).
+[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md).
 
 You should also have:
 - The [cortex](https://github.com/rossoctl/cortex) repo cloned

--- a/authbridge/demos/github-issue/demo-ui.md
+++ b/authbridge/demos/github-issue/demo-ui.md
@@ -87,7 +87,7 @@ providing end-to-end security:
 ## Prerequisites
 
 Ensure you have completed the Rossoctl platform setup as described in the
-[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md),
+[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md),
 including the Rossoctl UI.
 
 You should also have:

--- a/authbridge/demos/ibac/README.md
+++ b/authbridge/demos/ibac/README.md
@@ -6,7 +6,7 @@ An email-summarization agent receives a prompt-injection inside one of its email
 
 ## Prerequisites
 
-- A [rossoctl install](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md) on a kind cluster (operator + Keycloak + UI).
+- A [rossoctl install](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md) on a kind cluster (operator + Keycloak + UI).
 - ollama on the host with `llama3.2:3b` pulled, reachable from cluster pods at `host.docker.internal:11434`.
 - `kubectl`, `kind`, `podman` (or `docker`), `python3` with `PyYAML` (`pip3 install --user pyyaml`).
 


### PR DESCRIPTION
Automated fix by OpenClaw Link Health Fixer.
Broken internal links updated: the rossoctl docs directory was reorganized and `docs/install.md` moved to `docs/getting-started/install.md`.

| File | Old Path | New Path |
|------|----------|----------|
| `authbridge/demos/ibac/README.md` | `docs/install.md` | `docs/getting-started/install.md` |
| `authbridge/demos/github-issue/demo-ui.md` | `docs/install.md` | `docs/getting-started/install.md` |
| `authbridge/demos/github-issue/demo-rbac.md` | `docs/install.md` | `docs/getting-started/install.md` |
| `authbridge/demos/github-issue/demo-manual.md` | `docs/install.md` | `docs/getting-started/install.md` |
| `authbridge/demos/echo/README.md` | `docs/install.md` | `docs/getting-started/install.md` |

Fixes #698, #697, #696, #695, #694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide links in demo prerequisites to point to the current getting-started documentation.
  * Applied the link updates across the Echo, GitHub Issue, and IBAC demo guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->