### PR TITLE
Fix: mcp-parser observes notification acks instead of skipping

### DIFF
--- a/authbridge/authlib/plugins/mcpparser/plugin.go
+++ b/authbridge/authlib/plugins/mcpparser/plugin.go
@@ -242,6 +242,30 @@ func (p *MCPParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipelin
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
+// recordEmptyResponse records the terminal invocation for a response that
+// carried no body, distinguishing an expected ack from an anomaly:
+//
+//   - A JSON-RPC notification has no request id, so the transport acks it
+//     with an empty HTTP 202 and there is no response object to parse. That
+//     is the expected, complete end of the exchange — record an Observe so
+//     abctl credits mcp-parser (otherwise the paired response row renders as
+//     "—", which reads as if nothing handled it). Synthetic transport events
+//     ($transport/*) likewise carry no id and are handled MCP protocol events.
+//   - A request that DID carry an id but came back empty is anomalous (a
+//     truncated or failed upstream response). Keep it a Skip so it is not
+//     mistaken for a clean handling — a skip never credits the plugin in
+//     abctl, which is the right signal for a broken response.
+//
+// Either branch records an invocation, so abctl still pairs the response row
+// with the request row (pairing keys on plugin+method+direction).
+func recordEmptyResponse(pctx *pipeline.Context) {
+	if pctx.Extensions.MCP.RPCID == nil {
+		pctx.Observe("matched_" + pctx.Extensions.MCP.Method + "_ack")
+		return
+	}
+	pctx.Skip("no_response_body")
+}
+
 // OnResponse is the legacy buffered-path response hook. Because this
 // plugin implements StreamingResponder, pipeline.RunResponse skips it
 // and OnResponseFrame is the dispatch path under all listeners — this
@@ -266,12 +290,13 @@ func (p *MCPParser) OnResponse(_ context.Context, pctx *pipeline.Context) pipeli
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 	// We DID process the request but the response has no body — typical
-	// for JSON-RPC notifications that ack with HTTP 202. Record a Skip
-	// so abctl can pair the response row with the request row in the
-	// timeline (pairing keys on plugin+method+direction; an empty
-	// invocation slot orphans both ends).
+	// for JSON-RPC notifications that ack with HTTP 202. recordEmptyResponse
+	// credits mcp-parser with an Observe for an expected notification ack
+	// (no request id) and keeps a Skip for an anomalous empty response to a
+	// request that carried an id. Either way an invocation is recorded so
+	// abctl pairs the response row with the request row.
 	if len(pctx.ResponseBody) == 0 {
-		pctx.Skip("no_response_body")
+		recordEmptyResponse(pctx)
 		return pipeline.Action{Type: pipeline.Continue}
 	}
 
@@ -317,16 +342,17 @@ func (p *MCPParser) OnResponseFrame(_ context.Context, pctx *pipeline.Context, f
 
 	state := getOrCreateMCPStreamState(pctx)
 
-	// End-of-stream call with no payload. If we never saw a frame with
-	// a result/error and the response body was empty, record a Skip
-	// (matches the buffered path's "no_response_body" semantics so
-	// abctl pairs request and response rows uniformly across shapes).
-	// If we observed too many frames, emit a single truncation row so
-	// operators see that records were dropped.
+	// End-of-stream call with no payload. If we never saw a frame with a
+	// result/error and the response body was empty, record the terminal
+	// invocation via recordEmptyResponse (matches the buffered path: an
+	// Observe for an expected notification ack, a Skip for an anomalous empty
+	// response to a request with an id) so abctl pairs request and response
+	// rows uniformly across shapes. If we observed too many frames, emit a
+	// single truncation row so operators see that records were dropped.
 	if len(frame) == 0 {
 		if last {
 			if pctx.Extensions.MCP.Result == nil && pctx.Extensions.MCP.Err == nil && state.observed == 0 {
-				pctx.Skip("no_response_body")
+				recordEmptyResponse(pctx)
 			}
 			if state.truncated {
 				pctx.Observe("matched_" + pctx.Extensions.MCP.Method + "_response_truncated")

--- a/authbridge/authlib/plugins/mcpparser/plugin_test.go
+++ b/authbridge/authlib/plugins/mcpparser/plugin_test.go
@@ -286,15 +286,17 @@ func TestMCPParser_OnResponse_NoRequestContext(t *testing.T) {
 	}
 }
 
-// TestMCPParser_OnResponse_EmptyBody is the regression test for the
-// notifications/initialized pairing bug: when the request side parsed
-// the message (Extensions.MCP populated) but the response body is empty
-// (HTTP 202 ack), the parser must record a Skip so abctl can pair the
-// response row with the request row in the events timeline.
-func TestMCPParser_OnResponse_EmptyBody(t *testing.T) {
+// A JSON-RPC notification (no request id) is acked by the transport with an
+// empty HTTP 202 and gets no response object to parse — that's the expected,
+// complete end of the exchange. mcp-parser records an Observe so abctl credits
+// it (and pairs the response row with the request row) instead of rendering
+// the paired row as "—". Regression for the notification-ack observability
+// fix; supersedes the older skip-based pairing test.
+func TestMCPParser_OnResponse_NotificationAck_Observe(t *testing.T) {
 	p := NewMCPParser()
 	pctx := &pipeline.Context{
-		Direction:  pipeline.Outbound,
+		Direction: pipeline.Outbound,
+		// notifications/* carry no id → RPCID nil.
 		Extensions: pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "notifications/initialized"}},
 	}
 	action := p.OnResponse(context.Background(), pctx)
@@ -303,6 +305,36 @@ func TestMCPParser_OnResponse_EmptyBody(t *testing.T) {
 	}
 	if pctx.Extensions.MCP.Result != nil {
 		t.Error("Result should remain nil when response body is empty")
+	}
+	if pctx.Extensions.Invocations == nil {
+		t.Fatal("expected an Observe Invocation, got none")
+	}
+	invs := pctx.Extensions.Invocations.Outbound
+	if len(invs) != 1 {
+		t.Fatalf("expected 1 Invocation, got %d", len(invs))
+	}
+	if invs[0].Action != pipeline.ActionObserve {
+		t.Errorf("Action = %q, want observe", invs[0].Action)
+	}
+	if invs[0].Reason != "matched_notifications/initialized_ack" {
+		t.Errorf("Reason = %q, want matched_notifications/initialized_ack", invs[0].Reason)
+	}
+}
+
+// A request that carried an id but came back with an empty body is anomalous
+// (truncated / failed upstream response). mcp-parser keeps a Skip there — a
+// skip never credits the plugin in abctl, which is the correct signal for a
+// broken response, and it still pairs the response row with the request row.
+func TestMCPParser_OnResponse_RequestEmptyBody_Skip(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		// tools/call is a request and carries an id → RPCID non-nil.
+		Extensions: pipeline.Extensions{MCP: &pipeline.MCPExtension{Method: "tools/call", RPCID: float64(7)}},
+	}
+	action := p.OnResponse(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
 	}
 	if pctx.Extensions.Invocations == nil {
 		t.Fatal("expected a Skip Invocation, got none")

--- a/authbridge/authlib/plugins/mcpparser/streaming_test.go
+++ b/authbridge/authlib/plugins/mcpparser/streaming_test.go
@@ -81,11 +81,15 @@ func TestMCPParser_OnResponseFrame_NoExtensionMeansNoOp(t *testing.T) {
 	}
 }
 
-func TestMCPParser_OnResponseFrame_EmptyStreamRecordsSkip(t *testing.T) {
+// A request (has an id) whose stream ends with zero data frames is an
+// anomalous empty response: mcp-parser records a Skip. Mirrors the buffered
+// path's no_response_body semantics via recordEmptyResponse.
+func TestMCPParser_OnResponseFrame_RequestEmptyStream_Skip(t *testing.T) {
 	p := NewMCPParser()
 	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
 		Extensions: pipeline.Extensions{
-			MCP: &pipeline.MCPExtension{Method: "tools/call"},
+			MCP: &pipeline.MCPExtension{Method: "tools/call", RPCID: float64(3)},
 		},
 	}
 	// Streaming response with zero data frames: only the last=true call.
@@ -94,6 +98,33 @@ func TestMCPParser_OnResponseFrame_EmptyStreamRecordsSkip(t *testing.T) {
 	pctx.ClearCurrentPlugin()
 	if pctx.Extensions.Invocations == nil {
 		t.Fatal("no invocation recorded")
+	}
+	invs := pctx.Extensions.Invocations.Outbound
+	if len(invs) != 1 || invs[0].Action != pipeline.ActionSkip || invs[0].Reason != "no_response_body" {
+		t.Fatalf("expected single skip/no_response_body, got %+v", invs)
+	}
+}
+
+// A notification (no id) whose stream ends with zero data frames is the
+// expected empty ack: mcp-parser records an Observe so abctl credits it
+// rather than rendering the paired response row as "—".
+func TestMCPParser_OnResponseFrame_NotificationAck_Observe(t *testing.T) {
+	p := NewMCPParser()
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Extensions: pipeline.Extensions{
+			MCP: &pipeline.MCPExtension{Method: "notifications/initialized"}, // no RPCID → notification
+		},
+	}
+	pctx.SetCurrentPlugin("mcp-parser", pipeline.InvocationPhaseResponse)
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+	pctx.ClearCurrentPlugin()
+	if pctx.Extensions.Invocations == nil {
+		t.Fatal("no invocation recorded")
+	}
+	invs := pctx.Extensions.Invocations.Outbound
+	if len(invs) != 1 || invs[0].Action != pipeline.ActionObserve || invs[0].Reason != "matched_notifications/initialized_ack" {
+		t.Fatalf("expected single observe/matched_notifications/initialized_ack, got %+v", invs)
 	}
 }
 


### PR DESCRIPTION
## Summary

A JSON-RPC notification (e.g. `notifications/initialized`) has no request `id`, so per the MCP Streamable HTTP spec the transport acks it with an empty **HTTP 202** and there is **no response object** to parse. `mcp-parser` recorded a `Skip("no_response_body")` for that empty response, which `abctl` renders as **`— —`** — reading as if nothing handled the response, even though the paired request row clearly shows `mcp-parser`.

`abctl` deliberately never credits a `skip` to a plugin (so an unrelated skipping plugin isn't named on the wrong host), so the fix belongs in the parser, not the display.

## Change

Add `recordEmptyResponse`, used by both the buffered (`OnResponse`) and streaming (`OnResponseFrame`) empty-body paths:

- **Request had no id** (a notification, or a synthetic `$transport/*` event) → an empty response is the *expected, complete* ack → record `Observe("matched_<method>_ack")` so `abctl` credits `mcp-parser`.
- **Request carried an id** → an empty response is *anomalous* (truncated / failed upstream) → keep `Skip("no_response_body")` so it isn't mistaken for clean handling.

Both branches still record an invocation, so `abctl` pairs the response row with the request row exactly as before.

Result: the `notifications/initialized` response row now reads `observe / mcp-parser` instead of `— / —`.

## No functional impact

Response-phase invocations are observability-only. `Context.Classification()` / IBAC read the **request-side** `IsAction`, which is untouched.

## Testing Instructions

```
go test ./...        # full authlib module — pass
golangci-lint run ./plugins/mcpparser/...   # 0 issues
```

Notification ack → `observe`; request-with-id empty body → `skip`; covered for both the buffered and streaming paths.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
