### PR TITLE
Feat: Auto-generate the tls_bridge CA when generate_ca is set

### DIFF
--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -55,6 +55,15 @@ type TLSBridgeConfig struct {
 	// ca.crt is the trust cert handed to the agent. cert-manager Secret key
 	// conventions, so only the directory is configured.
 	CADir string `yaml:"ca_dir" json:"ca_dir"`
+	// GenerateCA, when true, makes the bridge mint and persist a self-signed CA
+	// into CADir (tls.crt/tls.key/ca.crt) if those files are absent, instead of
+	// failing at startup. For standalone / demo use only — in-cluster the CA is
+	// a mounted cert-manager Secret and this stays false so a missing Secret
+	// fails loudly rather than silently forging leaves under an untrusted CA.
+	// CADir should persist across restarts: on ephemeral storage (e.g. an
+	// emptyDir) a fresh CA is minted each boot, so clients must re-trust the
+	// new ca.crt.
+	GenerateCA bool `yaml:"generate_ca" json:"generate_ca"`
 	// UpstreamCABundle is an extra-roots PEM file for re-origination (private-CA
 	// origins the agent trusts); empty == system roots only.
 	UpstreamCABundle string `yaml:"upstream_ca_bundle" json:"upstream_ca_bundle"`

--- a/authbridge/authlib/tlsbridge/ca.go
+++ b/authbridge/authlib/tlsbridge/ca.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -31,12 +32,14 @@ type staticSource struct {
 func (s *staticSource) Issuer() (*x509.Certificate, crypto.Signer) { return s.cert, s.key }
 func (s *staticSource) CACertPEM() []byte                          { return s.certPEM }
 
-// NewEphemeralSource generates an in-memory self-signed CA. Used as the
-// standalone / no-cert-manager fallback and in tests.
-func NewEphemeralSource() (CASource, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+// genSelfSignedCA mints a fresh in-memory self-signed ECDSA-P256 CA and returns
+// the parsed cert, its signer, and both PEM encodings (cert + PKCS#8 key).
+// Shared by NewEphemeralSource (in-memory only) and NewGeneratedFileSource
+// (which persists the PEM to disk).
+func genSelfSignedCA() (cert *x509.Certificate, key crypto.Signer, certPEM, keyPEM []byte, err error) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("tlsbridge: generate CA key: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("tlsbridge: generate CA key: %w", err)
 	}
 	tmpl := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
@@ -47,19 +50,32 @@ func NewEphemeralSource() (CASource, error) {
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
 		BasicConstraintsValid: true,
 	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, ecKey.Public(), ecKey)
 	if err != nil {
-		return nil, fmt.Errorf("tlsbridge: self-sign CA: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("tlsbridge: self-sign CA: %w", err)
 	}
-	cert, err := x509.ParseCertificate(der)
+	cert, err = x509.ParseCertificate(der)
 	if err != nil {
-		return nil, fmt.Errorf("tlsbridge: parse self-signed CA: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("tlsbridge: parse self-signed CA: %w", err)
 	}
-	return &staticSource{
-		cert:    cert,
-		key:     key,
-		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
-	}, nil
+	keyDER, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("tlsbridge: marshal CA key: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return cert, ecKey, certPEM, keyPEM, nil
+}
+
+// NewEphemeralSource generates an in-memory self-signed CA. Used as the
+// standalone / no-cert-manager fallback and in tests. NewGeneratedFileSource is
+// the persisted variant used by the demo/standalone binary path (generate_ca).
+func NewEphemeralSource() (CASource, error) {
+	cert, key, certPEM, _, err := genSelfSignedCA()
+	if err != nil {
+		return nil, err
+	}
+	return &staticSource{cert: cert, key: key, certPEM: certPEM}, nil
 }
 
 // NewFileSource loads a CA (tls.crt/tls.key) from disk — the cert-manager /
@@ -106,6 +122,98 @@ func NewFileSource(certPath, keyPath string) (CASource, error) {
 		return nil, fmt.Errorf("tlsbridge: CA cert %s and key %s do not match", certPath, keyPath)
 	}
 	return &staticSource{cert: cert, key: key, certPEM: certPEM}, nil
+}
+
+// NewGeneratedFileSource mints a fresh self-signed CA and persists it into the
+// directory of certPath: the signing key at keyPath (0600), the CA cert at
+// certPath (0644), and — when trustPath is non-empty — a copy of the CA cert at
+// trustPath (0644, the "ca.crt" clients load into their trust store, e.g. via
+// NODE_EXTRA_CA_CERTS). Returns a CASource backed by the freshly minted
+// material. Used only on the generate_ca standalone/demo path.
+func NewGeneratedFileSource(certPath, keyPath, trustPath string) (CASource, error) {
+	cert, key, certPEM, keyPEM, err := genSelfSignedCA()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(certPath), 0o755); err != nil {
+		return nil, fmt.Errorf("tlsbridge: create ca_dir: %w", err)
+	}
+	// Each file is written atomically (temp + rename) so a reader or a
+	// subsequent boot never observes a half-written cert or key. The three
+	// writes are still sequential, so a crash or error between them leaves an
+	// INCOMPLETE set — EnsureFileSource treats that as "regenerate" rather than
+	// letting an orphaned tls.key wedge the next boot. Key first at 0600 (a
+	// signing key must never be world-readable); cert and ca.crt at 0644.
+	if err := atomicWriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return nil, fmt.Errorf("tlsbridge: write CA key %s: %w", keyPath, err)
+	}
+	if err := atomicWriteFile(certPath, certPEM, 0o644); err != nil {
+		return nil, fmt.Errorf("tlsbridge: write CA cert %s: %w", certPath, err)
+	}
+	if trustPath != "" {
+		if err := atomicWriteFile(trustPath, certPEM, 0o644); err != nil {
+			return nil, fmt.Errorf("tlsbridge: write trust cert %s: %w", trustPath, err)
+		}
+	}
+	return &staticSource{cert: cert, key: key, certPEM: certPEM}, nil
+}
+
+// EnsureFileSource loads the signing CA (tls.crt/tls.key) from caDir. With
+// generate=false it is exactly NewFileSource — a missing or invalid CA fails
+// loud, so an operator-mounted cert-manager Secret is never silently replaced.
+//
+// With generate=true it self-heals an INCOMPLETE on-disk set: when any of
+// tls.crt, tls.key, or ca.crt is missing it mints a fresh CA and persists all
+// three (generated=true). This closes two failure modes of a partial write (a
+// run killed or erroring between the three writes): an orphaned tls.key that
+// would otherwise wedge every subsequent boot (NewFileSource fails on the
+// missing cert → fatal), and a missing ca.crt trust anchor that loads fine yet
+// leaves clients unable to verify the forged leaves. A COMPLETE set is never
+// regenerated — it is loaded, and a complete-but-invalid cert/key still fails
+// loud via NewFileSource so a real Secret is not overwritten.
+func EnsureFileSource(caDir string, generate bool) (src CASource, generated bool, err error) {
+	certPath := filepath.Join(caDir, "tls.crt")
+	keyPath := filepath.Join(caDir, "tls.key")
+	trustPath := filepath.Join(caDir, "ca.crt")
+	complete := fileExists(certPath) && fileExists(keyPath) && fileExists(trustPath)
+	if generate && !complete {
+		src, err = NewGeneratedFileSource(certPath, keyPath, trustPath)
+		return src, err == nil, err
+	}
+	src, err = NewFileSource(certPath, keyPath)
+	return src, false, err
+}
+
+// fileExists reports whether path exists and is statable.
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// atomicWriteFile writes data to a temp file in the same directory and renames
+// it into place — atomic on POSIX, so a reader or the next boot never sees a
+// half-written cert or key. Mirrors authlib/spiffe.atomicWrite (unexported
+// there; kept local to avoid coupling the bridge to the spiffe package).
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // best-effort; a no-op after a successful rename
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // parsePrivateKey accepts PKCS#8, PKCS#1 (RSA) and SEC1 (EC) DER.

--- a/authbridge/authlib/tlsbridge/ca_test.go
+++ b/authbridge/authlib/tlsbridge/ca_test.go
@@ -1,6 +1,7 @@
 package tlsbridge
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -160,4 +161,212 @@ func TestFileSource_RejectsNonCAOrMismatch(t *testing.T) {
 			t.Fatal("expected error for cert/key mismatch, got nil")
 		}
 	})
+}
+
+func TestNewGeneratedFileSource_WritesAndReloads(t *testing.T) {
+	dir := t.TempDir()
+	certP := filepath.Join(dir, "tls.crt")
+	keyP := filepath.Join(dir, "tls.key")
+	trustP := filepath.Join(dir, "ca.crt")
+
+	src, err := NewGeneratedFileSource(certP, keyP, trustP)
+	if err != nil {
+		t.Fatalf("NewGeneratedFileSource: %v", err)
+	}
+
+	// All three artifacts written.
+	certPEM, err := os.ReadFile(certP)
+	if err != nil {
+		t.Fatalf("read tls.crt: %v", err)
+	}
+	if _, err := os.Stat(keyP); err != nil {
+		t.Fatalf("stat tls.key: %v", err)
+	}
+	trustPEM, err := os.ReadFile(trustP)
+	if err != nil {
+		t.Fatalf("read ca.crt: %v", err)
+	}
+	// ca.crt is a copy of the signing cert (same trust anchor clients load).
+	if !bytes.Equal(certPEM, trustPEM) {
+		t.Error("ca.crt should be identical to tls.crt")
+	}
+	// The private key must not be group/other-readable.
+	info, err := os.Stat(keyP)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("tls.key mode = %v, must not be group/other-accessible", info.Mode().Perm())
+	}
+
+	// The persisted pair reloads cleanly through the normal file path — proving
+	// it's a valid, self-consistent signing CA.
+	if _, err := NewFileSource(certP, keyP); err != nil {
+		t.Fatalf("generated CA should reload via NewFileSource: %v", err)
+	}
+	// And the source's own CA cert is a usable CA.
+	block, _ := pem.Decode(src.CACertPEM())
+	if block == nil {
+		t.Fatal("CACertPEM not a PEM block")
+	}
+	caCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	if !caCert.IsCA || caCert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Error("generated cert is not a signing CA")
+	}
+}
+
+func TestEnsureFileSource_GenerateWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	src, generated, err := EnsureFileSource(dir, true)
+	if err != nil {
+		t.Fatalf("EnsureFileSource: %v", err)
+	}
+	if !generated {
+		t.Error("expected generated=true for an empty ca_dir with generate=true")
+	}
+	if src == nil {
+		t.Fatal("nil source")
+	}
+	for _, name := range []string{"tls.crt", "tls.key", "ca.crt"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s to be written: %v", name, err)
+		}
+	}
+}
+
+func TestEnsureFileSource_NoGenerateFailsLoud(t *testing.T) {
+	dir := t.TempDir() // empty, no CA files
+	_, generated, err := EnsureFileSource(dir, false)
+	if err == nil {
+		t.Fatal("expected a load error when ca_dir is empty and generate=false")
+	}
+	if generated {
+		t.Error("generated must be false on the no-generate path")
+	}
+}
+
+func TestEnsureFileSource_LoadsExistingWithoutOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	// First call generates.
+	if _, generated, err := EnsureFileSource(dir, true); err != nil || !generated {
+		t.Fatalf("first EnsureFileSource: generated=%v err=%v", generated, err)
+	}
+	before, err := os.ReadFile(filepath.Join(dir, "tls.crt"))
+	if err != nil {
+		t.Fatalf("read tls.crt: %v", err)
+	}
+	// Second call with the files now present: load, do NOT regenerate/overwrite.
+	_, generated, err := EnsureFileSource(dir, true)
+	if err != nil {
+		t.Fatalf("second EnsureFileSource: %v", err)
+	}
+	if generated {
+		t.Error("expected generated=false when CA files already exist")
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "tls.crt"))
+	if err != nil {
+		t.Fatalf("re-read tls.crt: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("existing CA was overwritten; must be left intact")
+	}
+}
+
+func TestEnsureFileSource_PresentButInvalidNotOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	certP := filepath.Join(dir, "tls.crt")
+	keyP := filepath.Join(dir, "tls.key")
+	caP := filepath.Join(dir, "ca.crt")
+	garbage := []byte("not a pem\n")
+	// A COMPLETE set (all three present) that happens to be invalid.
+	for _, p := range []string{certP, keyP, caP} {
+		if err := os.WriteFile(p, garbage, 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	// A complete-but-invalid set must never be overwritten — return the loud
+	// load error instead of silently minting a new CA (protects a real
+	// mounted Secret). An INCOMPLETE set self-heals instead; see
+	// TestEnsureFileSource_SelfHealsIncompleteSet.
+	_, generated, err := EnsureFileSource(dir, true)
+	if err == nil {
+		t.Fatal("expected a load error for a present-but-invalid CA set")
+	}
+	if generated {
+		t.Error("must not generate/overwrite when a complete CA set is present but invalid")
+	}
+	if got, _ := os.ReadFile(certP); !bytes.Equal(got, garbage) {
+		t.Error("present-but-invalid tls.crt was overwritten")
+	}
+}
+
+// An INCOMPLETE on-disk set (a partial write: some but not all of
+// tls.crt/tls.key/ca.crt present) must self-heal under generate=true — mint a
+// fresh complete set rather than fail. Closes the orphaned-key crash loop (key
+// present, cert missing → NewFileSource would fatal on every boot) and the
+// lost-ca.crt trust gap. Regression for the #707 review findings.
+func TestEnsureFileSource_SelfHealsIncompleteSet(t *testing.T) {
+	cases := []struct {
+		name    string
+		present []string // pre-seeded (stale) files
+	}{
+		{"orphaned key (cert+ca.crt missing)", []string{"tls.key"}},
+		{"orphaned cert (key+ca.crt missing)", []string{"tls.crt"}},
+		{"cert+key present, ca.crt missing", []string{"tls.crt", "tls.key"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range tc.present {
+				if err := os.WriteFile(filepath.Join(dir, f), []byte("stale\n"), 0o600); err != nil {
+					t.Fatalf("seed %s: %v", f, err)
+				}
+			}
+			src, generated, err := EnsureFileSource(dir, true)
+			if err != nil {
+				t.Fatalf("EnsureFileSource: %v", err)
+			}
+			if !generated {
+				t.Error("expected generated=true (self-heal of an incomplete set)")
+			}
+			if src == nil {
+				t.Fatal("nil source")
+			}
+			// A complete, valid, reloadable set now exists on disk.
+			if _, err := NewFileSource(filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")); err != nil {
+				t.Fatalf("regenerated CA should reload via NewFileSource: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "ca.crt")); err != nil {
+				t.Errorf("ca.crt should be present after self-heal: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnsureFileSource_CreatesMissingParentDirs(t *testing.T) {
+	// ca_dir several levels deep with NONE of the intermediate parents present:
+	// generation must os.MkdirAll the whole chain, not just the leaf.
+	caDir := filepath.Join(t.TempDir(), "a", "b", "ca")
+	src, generated, err := EnsureFileSource(caDir, true)
+	if err != nil {
+		t.Fatalf("EnsureFileSource on nested-nonexistent ca_dir: %v", err)
+	}
+	if !generated {
+		t.Error("expected generated=true")
+	}
+	if src == nil {
+		t.Fatal("nil source")
+	}
+	for _, name := range []string{"tls.crt", "tls.key", "ca.crt"} {
+		if _, err := os.Stat(filepath.Join(caDir, name)); err != nil {
+			t.Errorf("expected %s in the freshly-created nested ca_dir: %v", name, err)
+		}
+	}
+	// Reload the persisted pair to prove it's a valid CA, not just files on disk.
+	if _, err := NewFileSource(filepath.Join(caDir, "tls.crt"), filepath.Join(caDir, "tls.key")); err != nil {
+		t.Fatalf("generated CA should reload via NewFileSource: %v", err)
+	}
 }

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -317,11 +317,18 @@ func main() {
 	// A nil *Engine leaves today's blind-tunnel behavior intact.
 	var bridge *tlsbridge.Engine
 	if cfg.TLSBridge != nil && cfg.TLSBridge.Mode == "enabled" {
-		// CA is always the operator-mounted cert-manager Secret (tls.crt/tls.key
-		// under ca_dir). EphemeralSource exists only for in-process tests.
-		src, cerr := tlsbridge.NewFileSource(cfg.TLSBridge.CADir+"/tls.crt", cfg.TLSBridge.CADir+"/tls.key")
+		// CA is normally the operator-mounted cert-manager Secret (tls.crt/tls.key
+		// under ca_dir). For standalone/demo use, generate_ca mints and persists a
+		// self-signed CA into ca_dir when those files are absent (default false, so
+		// in-cluster a missing Secret still fails loudly).
+		src, generated, cerr := tlsbridge.EnsureFileSource(cfg.TLSBridge.CADir, cfg.TLSBridge.GenerateCA)
 		if cerr != nil {
 			log.Fatalf("tls-bridge CA init failed: %v", cerr)
+		}
+		if generated {
+			slog.Warn("tls-bridge: generated self-signed CA (generate_ca=true; standalone/demo)",
+				"ca_dir", cfg.TLSBridge.CADir,
+				"hint", "clients must trust it, e.g. NODE_EXTRA_CA_CERTS="+cfg.TLSBridge.CADir+"/ca.crt")
 		}
 		var extra []byte
 		if cfg.TLSBridge.UpstreamCABundle != "" {


### PR DESCRIPTION
## Summary

Running `authbridge-proxy` standalone as a forward proxy with `tls_bridge` required minting a signing CA by hand (`openssl`) into `ca_dir` — `main.go` always loaded `tls.crt`/`tls.key` via `NewFileSource` and `log.Fatalf`'d when they were absent. That `openssl` step is the biggest friction point in the local demo.

## Change

Add `tls_bridge.generate_ca` (default **false**). When `true` **and** the `ca_dir` CA set is incomplete, the bridge mints a self-signed CA (reusing the existing ephemeral-CA machinery), persists `tls.crt`/`tls.key`/`ca.crt` into `ca_dir`, and logs the exact `NODE_EXTRA_CA_CERTS=<ca_dir>/ca.crt` line to trust. The local demo drops the whole `openssl` block:

```yaml
tls_bridge:
  mode: enabled
  ca_dir: /tmp/ab/ca
  generate_ca: true      # replaces the manual `openssl req ...`
```

then `HTTPS_PROXY=http://localhost:8081 NODE_EXTRA_CA_CERTS=/tmp/ab/ca/ca.crt claude`.

### Safety — in-cluster behavior unchanged

`generate_ca` defaults to false, so the operator/cluster path is untouched:
- `generate_ca=false` → always `NewFileSource`; a missing or invalid CA still `Fatal`s (fail-loud on a missing cert-manager Secret).
- `generate_ca=true` + a **complete** set present → loads it; a **complete-but-invalid** set is **never overwritten** (fails loud, so a real Secret is protected).

### Robustness against partial writes

`generate_ca=true` **self-heals an incomplete** on-disk set — any of `tls.crt`/`tls.key`/`ca.crt` missing → regenerate all three. This closes two partial-write failure modes:
- **orphaned `tls.key`** (killed/errored after the key write, before the cert) that would otherwise wedge every subsequent boot — `NewFileSource` fatals on the missing cert forever, reintroducing the manual `rm` this feature removes;
- **missing `ca.crt`** trust anchor that loads fine yet leaves clients unable to verify the forged leaves (no WARN, opaque client-side TLS errors).

The three files are also written **atomically** (temp + rename), so a reader never sees a half-written cert/key.

## Implementation

- `config`: `TLSBridgeConfig.GenerateCA` (`generate_ca`); doc notes `ca_dir` must persist across restarts (ephemeral storage re-mints each boot → clients re-trust).
- `tlsbridge`: factored `genSelfSignedCA` (now also emits the PKCS#8 key PEM); `NewEphemeralSource` delegates to it. `NewGeneratedFileSource` writes key `0600`, cert + `ca.crt` `0644` via an atomic temp+rename helper. `EnsureFileSource` loads a complete set, or self-heals an incomplete one.
- `cmd/authbridge-proxy`: call `EnsureFileSource`; `WARN` with the trust-cert hint when generated.

Discoverability is via the `generate_ca` doc comment and the startup `WARN` (which prints the exact `NODE_EXTRA_CA_CERTS` path) — no separate demo doc exists to update.

## Testing Instructions

```
go test ./...                          # full authlib module — pass
go vet ./tlsbridge/... ./config/...    # clean
go build ./cmd/authbridge-proxy        # builds
```

Tests cover: generated CA reloads via `NewFileSource` and is a valid signing CA; key not group/other-readable; generate-when-absent; fail-loud when `generate=false`; load-without-overwrite when the set is complete; **complete-but-invalid not overwritten**; **self-heal of incomplete sets** (orphaned key, orphaned cert, missing `ca.crt`); missing parent dirs created.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
