### PR TITLE
Feat: Select active proxies via listener.roles

### DIFF
--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -363,6 +363,17 @@ type ListenerConfig struct {
 	ReverseProxyAddr    string `yaml:"reverse_proxy_addr" json:"reverse_proxy_addr"`
 	ReverseProxyBackend string `yaml:"reverse_proxy_backend" json:"reverse_proxy_backend"`
 
+	// Roles selects which proxies run in proxy-sidecar mode. Empty (the
+	// default) runs BOTH the reverse proxy (inbound) and the forward proxy
+	// (outbound) — the full pod deployment, so existing configs are unchanged.
+	// Set a subset to run a single shape:
+	//   roles: [forward]   # egress-only (e.g. a laptop TLS-bridge demo)
+	//   roles: [reverse]   # inbound-only JWT validation
+	// Valid values: "reverse", "forward". The preset fills an addr default
+	// only for an active role, and reverse_proxy_backend is required only when
+	// the reverse role is active. Ignored outside proxy-sidecar mode.
+	Roles []string `yaml:"roles" json:"roles"`
+
 	// TransparentProxyAddr is the bind address for the outbound transparent
 	// listener used by proxy-sidecar enforce-redirect mode: iptables REDIRECTs
 	// the agent's bypass egress here, and the listener recovers the original
@@ -441,6 +452,27 @@ type ListenerConfig struct {
 	// enforcement. Mirrors the bypass-pattern guard added to ibac
 	// in #496.
 	SkipHosts []string `yaml:"skip_hosts" json:"skip_hosts"`
+}
+
+// Proxy roles selectable via ListenerConfig.Roles in proxy-sidecar mode.
+const (
+	RoleReverse = "reverse" // inbound reverse proxy
+	RoleForward = "forward" // outbound forward proxy
+)
+
+// ActiveRoles returns the set of proxy roles to run in proxy-sidecar mode. An
+// empty Roles list defaults to BOTH roles (the full pod deployment), so
+// existing configs and the operator path are unchanged; a non-empty list runs
+// exactly the roles named. Unknown values are surfaced by Validate, not here.
+func (l ListenerConfig) ActiveRoles() map[string]bool {
+	if len(l.Roles) == 0 {
+		return map[string]bool{RoleReverse: true, RoleForward: true}
+	}
+	set := make(map[string]bool, len(l.Roles))
+	for _, r := range l.Roles {
+		set[r] = true
+	}
+	return set
 }
 
 // StatsConfig represents the configuration for reporting config and statistics

--- a/authbridge/authlib/config/config_test.go
+++ b/authbridge/authlib/config/config_test.go
@@ -46,6 +46,49 @@ func TestApplyPreset_ProxySidecar(t *testing.T) {
 	}
 }
 
+func TestListenerConfig_ActiveRoles(t *testing.T) {
+	both := ListenerConfig{}.ActiveRoles()
+	if !both[RoleReverse] || !both[RoleForward] {
+		t.Errorf("empty Roles should default to both, got %v", both)
+	}
+	fwd := ListenerConfig{Roles: []string{RoleForward}}.ActiveRoles()
+	if fwd[RoleReverse] || !fwd[RoleForward] {
+		t.Errorf("roles=[forward] should be forward-only, got %v", fwd)
+	}
+	rev := ListenerConfig{Roles: []string{RoleReverse}}.ActiveRoles()
+	if !rev[RoleReverse] || rev[RoleForward] {
+		t.Errorf("roles=[reverse] should be reverse-only, got %v", rev)
+	}
+}
+
+func TestApplyPreset_ProxySidecar_ForwardOnly(t *testing.T) {
+	cfg := &Config{Mode: ModeProxySidecar, Listener: ListenerConfig{Roles: []string{RoleForward}}}
+	ApplyPreset(cfg)
+	if cfg.Listener.ReverseProxyAddr != "" {
+		t.Errorf("forward-only must not fill reverse_proxy_addr, got %q", cfg.Listener.ReverseProxyAddr)
+	}
+	if cfg.Listener.ForwardProxyAddr != ":8081" {
+		t.Errorf("forward_proxy_addr = %q, want :8081", cfg.Listener.ForwardProxyAddr)
+	}
+	if cfg.Listener.TransparentProxyAddr != ":8082" {
+		t.Errorf("transparent_proxy_addr = %q, want :8082", cfg.Listener.TransparentProxyAddr)
+	}
+}
+
+func TestApplyPreset_ProxySidecar_ReverseOnly(t *testing.T) {
+	cfg := &Config{Mode: ModeProxySidecar, Listener: ListenerConfig{Roles: []string{RoleReverse}}}
+	ApplyPreset(cfg)
+	if cfg.Listener.ReverseProxyAddr != ":8080" {
+		t.Errorf("reverse_proxy_addr = %q, want :8080", cfg.Listener.ReverseProxyAddr)
+	}
+	if cfg.Listener.ForwardProxyAddr != "" {
+		t.Errorf("reverse-only must not fill forward_proxy_addr, got %q", cfg.Listener.ForwardProxyAddr)
+	}
+	if cfg.Listener.TransparentProxyAddr != "" {
+		t.Errorf("reverse-only must not fill transparent_proxy_addr, got %q", cfg.Listener.TransparentProxyAddr)
+	}
+}
+
 func TestApplyPreset_UserOverride(t *testing.T) {
 	cfg := &Config{
 		Mode:     ModeEnvoySidecar,
@@ -97,6 +140,41 @@ func TestValidate_ProxySidecarRequiresBackend(t *testing.T) {
 	cfg := &Config{Mode: ModeProxySidecar}
 	if err := Validate(cfg); err == nil {
 		t.Error("expected error for proxy-sidecar without backend")
+	}
+}
+
+func TestValidate_ProxySidecarRoles(t *testing.T) {
+	// forward-only: reverse_proxy_backend is NOT required.
+	if err := Validate(&Config{Mode: ModeProxySidecar, Listener: ListenerConfig{Roles: []string{RoleForward}}}); err != nil {
+		t.Errorf("forward-only should not require reverse_proxy_backend: %v", err)
+	}
+	// reverse role without backend: error.
+	if err := Validate(&Config{Mode: ModeProxySidecar, Listener: ListenerConfig{Roles: []string{RoleReverse}}}); err == nil {
+		t.Error("reverse role without reverse_proxy_backend should error")
+	}
+	// reverse-only with backend: ok.
+	if err := Validate(&Config{Mode: ModeProxySidecar, Listener: ListenerConfig{Roles: []string{RoleReverse}, ReverseProxyBackend: "http://app"}}); err != nil {
+		t.Errorf("reverse-only with backend should be valid: %v", err)
+	}
+	// unknown role: error.
+	if err := Validate(&Config{Mode: ModeProxySidecar, Listener: ListenerConfig{Roles: []string{"sideways"}, ReverseProxyBackend: "http://app"}}); err == nil {
+		t.Error("unknown role should error")
+	}
+	// tls_bridge enabled without the forward role: error (it only affects outbound).
+	if err := Validate(&Config{
+		Mode:      ModeProxySidecar,
+		Listener:  ListenerConfig{Roles: []string{RoleReverse}, ReverseProxyBackend: "http://app"},
+		TLSBridge: &TLSBridgeConfig{Mode: "enabled", CADir: "/tmp/ca"},
+	}); err == nil {
+		t.Error("tls_bridge enabled without forward role should error")
+	}
+	// tls_bridge enabled WITH the forward role: ok.
+	if err := Validate(&Config{
+		Mode:      ModeProxySidecar,
+		Listener:  ListenerConfig{Roles: []string{RoleForward}},
+		TLSBridge: &TLSBridgeConfig{Mode: "enabled", CADir: "/tmp/ca"},
+	}); err != nil {
+		t.Errorf("tls_bridge with forward role should be valid: %v", err)
 	}
 }
 

--- a/authbridge/authlib/config/presets.go
+++ b/authbridge/authlib/config/presets.go
@@ -14,12 +14,20 @@ func ApplyPreset(cfg *Config) {
 		setDefault(&cfg.Listener.ForwardProxyAddr, ":8080")
 
 	case ModeProxySidecar:
-		setDefault(&cfg.Listener.ReverseProxyAddr, ":8080")
-		setDefault(&cfg.Listener.ForwardProxyAddr, ":8081")
-		// Outbound transparent listener for enforce-redirect mode. Binding it
-		// is harmless when nothing is redirected here (cooperative HTTP_PROXY
-		// deployments simply never receive connections on it).
-		setDefault(&cfg.Listener.TransparentProxyAddr, ":8082")
+		// Fill an addr default only for an active role (empty Roles => both),
+		// so a forward-only or reverse-only deployment doesn't bind the proxy
+		// it didn't ask for. main.go starts a proxy iff its role is active.
+		roles := cfg.Listener.ActiveRoles()
+		if roles[RoleReverse] {
+			setDefault(&cfg.Listener.ReverseProxyAddr, ":8080")
+		}
+		if roles[RoleForward] {
+			setDefault(&cfg.Listener.ForwardProxyAddr, ":8081")
+			// Outbound transparent listener for enforce-redirect mode. Binding it
+			// is harmless when nothing is redirected here (cooperative HTTP_PROXY
+			// deployments simply never receive connections on it).
+			setDefault(&cfg.Listener.TransparentProxyAddr, ":8082")
+		}
 	}
 
 	// Session events API is default-on for every mode. Operators who

--- a/authbridge/authlib/config/validate.go
+++ b/authbridge/authlib/config/validate.go
@@ -49,8 +49,22 @@ func validateListeners(cfg *Config) error {
 		if cfg.Listener.ExtAuthzAddr != "" {
 			return fmt.Errorf("proxy-sidecar mode does not support ext_authz_addr (use waypoint mode)")
 		}
-		if cfg.Listener.ReverseProxyBackend == "" {
-			return fmt.Errorf("proxy-sidecar mode requires listener.reverse_proxy_backend")
+		for _, r := range cfg.Listener.Roles {
+			if r != RoleReverse && r != RoleForward {
+				return fmt.Errorf("listener.roles: %q is not a valid role (use %q and/or %q)", r, RoleReverse, RoleForward)
+			}
+		}
+		roles := cfg.Listener.ActiveRoles()
+		// The reverse proxy forwards inbound traffic to reverse_proxy_backend,
+		// so it's required only when the reverse role is active. A forward-only
+		// deployment needs no backend.
+		if roles[RoleReverse] && cfg.Listener.ReverseProxyBackend == "" {
+			return fmt.Errorf("proxy-sidecar mode with the reverse role requires listener.reverse_proxy_backend")
+		}
+		// The TLS bridge only rewrites outbound (forward-proxy) traffic; enabling
+		// it without the forward role would be a silent no-op.
+		if cfg.TLSBridge != nil && cfg.TLSBridge.Mode == "enabled" && !roles[RoleForward] {
+			return fmt.Errorf("tls_bridge requires the forward role (it only affects outbound traffic)")
 		}
 	}
 	return nil

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -353,38 +353,49 @@ func main() {
 		slog.Info("tls-bridge enabled", "ca_dir", cfg.TLSBridge.CADir)
 	}
 
-	// Proxy-sidecar: reverse proxy on the inbound path + forward proxy
-	// on the outbound path.
-	rpSrv, err := reverseproxy.NewServer(inboundH, sessions, cfg.Listener.ReverseProxyBackend, rpMTLS)
-	if err != nil {
-		log.Fatalf("creating reverse proxy: %v", err)
-	}
-	fpSrv, err := forwardproxy.NewServer(outboundH, sessions, fpMTLS)
-	if err != nil {
-		log.Fatalf("creating forward proxy: %v", err)
-	}
-	// SkipHosts: outbound destinations that bypass the pipeline AND
-	// session recording entirely. See ListenerConfig.SkipHosts for the
-	// motivating case (chatty observability sidecars evicting the
-	// inbound A2A user intent from the session FIFO).
-	skipHosts, err := skiphost.New(cfg.Listener.SkipHosts)
-	if err != nil {
-		log.Fatalf("listener.skip_hosts: %v", err)
-	}
-	fpSrv.SkipHosts = skipHosts
-	fpSrv.TLSBridge = bridge
+	// Proxy-sidecar: reverse proxy (inbound) and/or forward proxy (outbound),
+	// selected by listener.roles (empty => both). sharedStore is created up
+	// front so whichever proxies run share one session store.
+	roles := cfg.Listener.ActiveRoles()
 	sharedStore := shared.New()
 	defer sharedStore.Close() // stop the TTL janitor on normal main return
-	rpSrv.Shared = sharedStore
-	fpSrv.Shared = sharedStore
-	httpServers = append(httpServers, startReverseProxyServer("reverse-proxy", rpSrv, cfg.Listener.ReverseProxyAddr))
-	httpServers = append(httpServers, startHTTPServer("forward-proxy", fpSrv.Handler(), cfg.Listener.ForwardProxyAddr))
 
-	// Outbound transparent listener (enforce-redirect mode). It shares the
-	// forward proxy's outbound pipeline via HandleTransparentConn, so explicit
-	// HTTP_PROXY egress and iptables-REDIRECTed bypass egress are gated and
-	// tunnelled identically. Closed explicitly on shutdown (not an *http.Server).
-	transparentLn := startTransparentProxy(fpSrv, cfg.Listener.TransparentProxyAddr)
+	if roles[config.RoleReverse] {
+		rpSrv, rerr := reverseproxy.NewServer(inboundH, sessions, cfg.Listener.ReverseProxyBackend, rpMTLS)
+		if rerr != nil {
+			log.Fatalf("creating reverse proxy: %v", rerr)
+		}
+		rpSrv.Shared = sharedStore
+		httpServers = append(httpServers, startReverseProxyServer("reverse-proxy", rpSrv, cfg.Listener.ReverseProxyAddr))
+	}
+
+	// The transparent (enforce-redirect) listener rides with the forward proxy;
+	// declared here so shutdown can close it whether or not the forward role ran.
+	var transparentLn *net.TCPListener
+	if roles[config.RoleForward] {
+		fpSrv, ferr := forwardproxy.NewServer(outboundH, sessions, fpMTLS)
+		if ferr != nil {
+			log.Fatalf("creating forward proxy: %v", ferr)
+		}
+		// SkipHosts: outbound destinations that bypass the pipeline AND
+		// session recording entirely. See ListenerConfig.SkipHosts for the
+		// motivating case (chatty observability sidecars evicting the
+		// inbound A2A user intent from the session FIFO).
+		skipHosts, serr := skiphost.New(cfg.Listener.SkipHosts)
+		if serr != nil {
+			log.Fatalf("listener.skip_hosts: %v", serr)
+		}
+		fpSrv.SkipHosts = skipHosts
+		fpSrv.TLSBridge = bridge
+		fpSrv.Shared = sharedStore
+		httpServers = append(httpServers, startHTTPServer("forward-proxy", fpSrv.Handler(), cfg.Listener.ForwardProxyAddr))
+
+		// Outbound transparent listener (enforce-redirect mode). It shares the
+		// forward proxy's outbound pipeline via HandleTransparentConn, so explicit
+		// HTTP_PROXY egress and iptables-REDIRECTed bypass egress are gated and
+		// tunnelled identically. Closed explicitly on shutdown (not an *http.Server).
+		transparentLn = startTransparentProxy(fpSrv, cfg.Listener.TransparentProxyAddr)
+	}
 
 	_ = mtlsMetrics // TODO Phase 2: surface metrics through /stats
 


### PR DESCRIPTION
## Summary

proxy-sidecar mode always started BOTH the reverse proxy (`:8080`, inbound) and the forward proxy (`:8081`, outbound), and `validate.go` unconditionally required `reverse_proxy_backend`. Real deployments come in three shapes — pods want both, a laptop/demo wants forward-only (egress TLS-bridge), and some cases want reverse-only — but only "both" was expressible, forcing egress-only users into a dummy `reverse_proxy_backend: http://127.0.0.1:9` plus a `reverse_proxy_addr` override (the default `:8080` collides with the kind cluster's port-forward).

## Change

Add `listener.roles` — a list of `reverse` and/or `forward`. **Empty (the default) = both**, so pods and every existing config (and the operator path) are unchanged. A subset runs a single shape:

| Deployment | Config | Listeners |
|---|---|---|
| Pod (default) | *(omit `roles`)* | reverse + forward + transparent + session API — as today |
| Laptop | `listener: {roles: [forward]}` | forward `:8081` (+ transparent `:8082`, session API `:9094`) |
| Reverse-only | `listener: {roles: [reverse], reverse_proxy_backend: ...}` | reverse `:8080` (+ session API) |

- **presets**: fills an addr default only for an active role — forward-only never binds `:8080`; reverse-only never binds `:8081`/`:8082`.
- **validate**: rejects unknown roles; requires `reverse_proxy_backend` only when the `reverse` role is active; rejects `tls_bridge` enabled without the `forward` role (it only affects outbound).
- **main**: starts each proxy (and the transparent listener, which rides with `forward`) only when its role is active, mirroring the existing empty-addr-skip pattern for the transparent proxy and session API.

This PR is **code-only** (the 5 Go files below); there's no in-repo demo config to edit — the local forward-proxy setup is an ad-hoc `local.yaml`. What this feature *enables*: that config can drop both prior workaround lines (`reverse_proxy_backend`, `reverse_proxy_addr`) down to `listener: {roles: [forward]}` (see Composition).

## Testing Instructions

```
go test ./...                 # full authlib module — pass
go vet ./... (authlib + cmd)  # clean
```

Unit tests: `ActiveRoles` default/subset; `ApplyPreset` fills only active-role addrs; validation for reverse-without-backend, unknown role, and tls_bridge-without-forward. Verified at runtime: forward-only binds `:8081`/`:8082`/`:9094` and **never `:8080`**; reverse-only without a backend fails validation with a clear message.

## Composition

Independent of #707 (`generate_ca`); together the laptop demo is `listener: {roles: [forward]}` + `tls_bridge: {mode: enabled, ca_dir, generate_ca: true}`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
