### PR TITLE
Feat: Publish prebuilt abctl and authbridge-proxy release binaries

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,93 @@
+name: Release binaries
+
+# Cross-compiles the standalone `abctl` and `authbridge-proxy` binaries and
+# attaches them (with SHA-256 checksums) to the GitHub Release for a `v*` tag.
+# Both are pure-Go (CGO_ENABLED=0); each cmd module resolves authlib via its
+# `replace => ../../authlib`, so builds run per-module with GOWORK=off — no
+# workspace needed. workflow_dispatch runs a dry build that only uploads
+# workflow artifacts (no Release), for testing.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version string to stamp for a dry-run build (no Release is created)'
+        required: false
+        default: 'dev'
+
+permissions:
+  contents: read
+
+jobs:
+  release-binaries:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the Release and upload assets (tag pushes only)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v5
+        with:
+          go-version-file: authbridge/cmd/authbridge-proxy/go.mod
+
+      - name: Build binaries (linux/darwin, amd64/arm64)
+        env:
+          # Untrusted input passed via env (never interpolated into the script).
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME}"
+          else
+            VERSION="${INPUT_TAG:-dev}"
+          fi
+          echo "Building version ${VERSION}"
+          mkdir -p dist
+          for bin in abctl authbridge-proxy; do
+            for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+              os="${target%/*}"
+              arch="${target#*/}"
+              echo "==> ${bin} ${os}/${arch}"
+              ( cd "authbridge/cmd/${bin}" && \
+                GOWORK=off CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
+                go build -trimpath \
+                  -ldflags "-s -w -X main.version=${VERSION}" \
+                  -o "${GITHUB_WORKSPACE}/dist/${bin}" . )
+              tar -C dist -czf "dist/${bin}_${VERSION}_${os}_${arch}.tar.gz" "${bin}"
+              rm -f "dist/${bin}"
+            done
+          done
+          ( cd dist && sha256sum ./*.tar.gz > checksums.txt )
+          ls -l dist
+
+      - name: Publish to GitHub Release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          notes="Prebuilt \`abctl\` and \`authbridge-proxy\` binaries for linux and macOS (amd64/arm64).
+
+          Verify downloads with \`sha256sum -c checksums.txt\`. On macOS, clear the Gatekeeper quarantine after extracting: \`xattr -dr com.apple.quarantine ./abctl\`."
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release upload "${TAG}" dist/*.tar.gz dist/checksums.txt --clobber
+          else
+            prerelease=""
+            case "${TAG}" in *-rc*|*-alpha*|*-beta*) prerelease="--prerelease" ;; esac
+            gh release create "${TAG}" dist/*.tar.gz dist/checksums.txt \
+              --title "${TAG}" --notes "${notes}" ${prerelease}
+          fi
+
+      - name: Upload dry-run artifacts
+        if: github.ref_type != 'tag'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: release-binaries
+          path: dist/*
+          if-no-files-found: error

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -4,6 +4,34 @@ AuthBridge provides **secure, transparent token management** for Kubernetes work
 
 > **📘 Looking to run the demo?** See the [Weather Agent](./demos/weather-agent/demo-ui.md) or [GitHub Issue Agent](./demos/github-issue/demo.md) demos for step-by-step instructions, and [Token-Exchange Routes](./demos/token-exchange-routes/README.md) for route configuration.
 
+## Download prebuilt binaries
+
+Prefer not to compile from source? Every `v*` release attaches prebuilt `abctl` (the
+session-inspector TUI) and `authbridge-proxy` binaries for linux and macOS (amd64 +
+arm64) on the [Releases page](https://github.com/rossoctl/cortex/releases).
+
+```sh
+VER=v0.1.0                 # a released tag
+OS=darwin ARCH=arm64       # one of: linux/darwin × amd64/arm64
+base="https://github.com/rossoctl/cortex/releases/download/${VER}"
+
+curl -fsSLO "${base}/abctl_${VER}_${OS}_${ARCH}.tar.gz"
+curl -fsSLO "${base}/checksums.txt"
+sha256sum -c checksums.txt --ignore-missing    # macOS: shasum -a 256 -c ... --ignore-missing
+tar xzf "abctl_${VER}_${OS}_${ARCH}.tar.gz"
+sudo mv abctl /usr/local/bin/                  # onto PATH
+abctl --version
+```
+
+`authbridge-proxy` ships the same way (`authbridge-proxy_${VER}_${OS}_${ARCH}.tar.gz`).
+
+- **Linux** binaries are fully static (`CGO_ENABLED=0`) — no libc dependency, run anywhere.
+- **macOS** binaries are portable but unsigned; after extracting, clear the Gatekeeper
+  quarantine once: `xattr -dr com.apple.quarantine ./abctl` (or `codesign --sign - ./abctl`).
+
+Building from source instead is just `cd authbridge/cmd/abctl && go build .` (likewise
+`cmd/authbridge-proxy`).
+
 ## Deployment Modes
 
 The [`cmd/authbridge/`](./cmd/authbridge/) directory contains a unified binary that supports three deployment modes in a single codebase. Two container images are published:

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -18,14 +18,21 @@ and read individual events as pretty-printed JSON.
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-## Build
+## Install
+
+Download a prebuilt `abctl` for your platform (linux/macOS, amd64/arm64) from the
+[Releases page](https://github.com/rossoctl/cortex/releases) — see
+[Download prebuilt binaries](../../README.md#download-prebuilt-binaries) for the download,
+checksum-verify, and macOS quarantine steps — and drop it on your PATH.
+
+Or build from source:
 
 ```sh
 cd authbridge/cmd/abctl
 go build .
 ```
 
-Produces a single static binary (~10 MB).
+Either way you get a single binary (~10 MB; the linux build is fully static).
 
 ## Run
 

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -20,10 +20,20 @@ import (
 	"github.com/rossoctl/cortex/authbridge/cmd/abctl/tui"
 )
 
+// version is the abctl build version, overridden at release time via
+// -ldflags "-X main.version=<tag>". Defaults to "dev" for local builds.
+var version = "dev"
+
 func main() {
 	endpoint := flag.String("endpoint", "",
 		"AuthBridge session API URL (e.g. http://localhost:9094). When omitted, abctl opens a Namespaces → Pods picker.")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println("abctl", version)
+		return
+	}
 
 	// Best-effort sweep of edit-tempfiles older than 24h. Tempfiles are
 	// intentionally left in place on every exit path (success / abort /

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -57,6 +57,10 @@ import (
 
 var logLevel = new(slog.LevelVar)
 
+// version is the authbridge-proxy build version, overridden at release time
+// via -ldflags "-X main.version=<tag>". Defaults to "dev" for local builds.
+var version = "dev"
+
 func initLogging() {
 	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
 	case "debug":
@@ -141,7 +145,13 @@ func pluginUsesSPIFFEIdentity(p config.PluginEntry) bool {
 
 func main() {
 	configPath := flag.String("config", "", "path to config YAML file")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println("authbridge-proxy", version)
+		return
+	}
 
 	initLogging()
 	startSignalToggle()
@@ -435,7 +445,7 @@ func main() {
 		}()
 	}
 
-	slog.Info("authbridge-proxy starting", "mode", cfg.Mode, "logLevel", logLevel.Level().String())
+	slog.Info("authbridge-proxy starting", "version", version, "mode", cfg.Mode, "logLevel", logLevel.Level().String())
 
 	go func() {
 		mux := http.NewServeMux()

--- a/authbridge/demos/weather-agent/demo-with-abctl.md
+++ b/authbridge/demos/weather-agent/demo-with-abctl.md
@@ -37,9 +37,14 @@ Verify by sending one chat message and getting a weather response. Once that wor
 
    Merging only the `pipeline:` key into the existing YAML is brittle across operator versions. If the patch above doesn't take effect, `kubectl edit configmap authbridge-runtime-config -n team1` and add the `pipeline:` section to the existing `config.yaml` by hand. See [mcp-parser demo](../mcp-parser/README.md) for the full config format and rationale.
 
-## 1. Build `abctl`
+## 1. Get `abctl`
 
-`abctl` lives in the `cortex` repo. Build it once:
+Download a prebuilt `abctl` (linux/macOS, amd64/arm64) from the
+[Releases page](https://github.com/rossoctl/cortex/releases) — see
+[Download prebuilt binaries](../../README.md#download-prebuilt-binaries) for verify + macOS
+quarantine steps — and put it on your PATH.
+
+Or build it from source:
 
 ```sh
 git clone https://github.com/rossoctl/cortex.git
@@ -47,7 +52,7 @@ cd cortex/authbridge/cmd/abctl
 go build .
 ```
 
-Produces a single ~10 MB binary at `./abctl`. See [the abctl README](../../cmd/abctl/README.md) for full flags and keybindings.
+Either way you get a single `abctl` binary. See [the abctl README](../../cmd/abctl/README.md) for full flags and keybindings.
 
 ## 2. Launch `abctl`
 


### PR DESCRIPTION
## Summary

New users currently have to `go build` `abctl` and `authbridge-proxy` locally. Both are pure-Go (`CGO_ENABLED=0`, no cgo in their trees), so this ships prebuilt, downloadable binaries on every `v*` tag — no local toolchain needed.

## Change

**`.github/workflows/release-binaries.yaml`** (new) — on a `v*` tag:
- cross-compiles `abctl` + `authbridge-proxy` for **linux + macOS × amd64 + arm64** (8 artifacts), using the same `GOWORK=off CGO_ENABLED=0` per-module build the Dockerfiles already use (each `cmd/*` resolves authlib via its `replace => ../../authlib`, so no workspace is needed), plus `-trimpath` and `-ldflags "-s -w -X main.version=<tag>"`;
- packages each as `<bin>_<tag>_<os>_<arch>.tar.gz`, generates `checksums.txt` (sha256), and attaches all to the GitHub Release via the `gh` CLI;
- `workflow_dispatch` does a dry build that uploads workflow artifacts only (no Release), for testing.
- All actions are pinned to commit SHAs (reusing the repo's existing pins) to satisfy **Verify Action Pinning**.

**Version stamping** — `cmd/abctl` and `cmd/authbridge-proxy` gain `var version = "dev"` + a `--version` flag (injected at release via `-ldflags -X main.version`); `authbridge-proxy` also logs its version at startup.

**Docs** — `authbridge/README.md` gains a "Download prebuilt binaries" section: download, checksum verify, the macOS Gatekeeper `xattr` note, and the static-vs-portable distinction.

## Notes

- **Static / portable:** linux binaries are fully static (`file` → `statically linked`); macOS binaries are portable but link `libSystem` (Go can't fully static-link darwin) and are **unsigned** — users clear the Gatekeeper quarantine once (`xattr -dr com.apple.quarantine`). Notarization (Apple Developer ID) is out of scope.
- **No go.mod change:** the "workspace-only replace" caveat only affects `go install`; a source-tree cross-build works as-is (proven by the existing Dockerfiles).

## Testing Instructions

- Cross-built all 8 os/arch combos locally; `--version` prints the injected tag; `file` confirms linux builds are statically linked; `gofmt`/`go vet` clean.
- End-to-end: push a throwaway `v0.0.0-test` tag on a fork to confirm the 8 tarballs + `checksums.txt` attach to that Release and `sha256sum -c` passes; on macOS the binary runs after clearing quarantine.

## Follow-up (not in this PR)

`abctl` has no PR-time CI today; adding it to `ci.yaml`'s Go matrix would catch a broken abctl before tag time. Kept separate to avoid surfacing pre-existing abctl lint in this PR.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable prebuilt binaries for `abctl` and `authbridge-proxy` across supported Linux and macOS platforms.
  * Added SHA-256 checksums for verifying downloaded archives.
  * Added `--version` support to `abctl` and `authbridge-proxy`.
  * Release builds now identify the included application version.

* **Documentation**
  * Added instructions for downloading, verifying, extracting, and running prebuilt binaries.
  * Added platform-specific notes for Linux and macOS.
  * Documented equivalent build-from-source commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->