### PR TITLE
Docs: Fix broken links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ cd authbridge && podman build -f cmd/authbridge-proxy/Dockerfile \
 
 ### Running the Full Demo
 
-1. Set up a Kind cluster with SPIRE + Keycloak (use [Rossoctl Ansible installer](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md))
+1. Set up a Kind cluster with SPIRE + Keycloak (use [Rossoctl installer](https://www.rossoctl.dev/docs/overview/quickstart))
 2. Deploy the webhook via [operator](https://github.com/rossoctl/operator)
 3. See the [AuthBridge demos index](authbridge/demos/README.md) for a recommended learning path:
    - **Getting started**: `authbridge/demos/weather-agent/demo-ui.md` (inbound validation, UI deployment)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ please report it responsibly.
 
 1. **Do NOT create public GitHub issues** for security vulnerabilities
 2. **Email**: Report vulnerabilities privately via GitHub Security Advisories
-   - Go to the [Security tab](../../security/advisories/new) and create a new advisory
+   - Go to the [Security tab](https://github.com/rossoctl/cortex/security/advisories/new) and create a new advisory
 3. **Include**: A clear description of the vulnerability, steps to reproduce,
    and potential impact
 

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -6,7 +6,7 @@ AuthBridge provides **secure, transparent token management** for Kubernetes work
 
 ## Deployment Modes
 
-The [`cmd/authbridge/`](./cmd/authbridge/) directory contains a unified binary that supports three deployment modes in a single codebase. Two container images are published:
+Two container images are published:
 
 | Image | Contents |
 |-------|----------|
@@ -344,7 +344,7 @@ sequenceDiagram
 
 ### Quick Setup
 
-The easiest way to get all prerequisites is to use the [Rossoctl Ansible installer](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md#ansible-based-installer-recommended).
+The easiest way to get all prerequisites is to use the [Rossoctl Quickstart](https://www.rossoctl.dev/docs/overview/quickstart).
 
 ## Getting Started
 
@@ -456,6 +456,6 @@ Keycloak client registration is handled by the [operator](https://github.com/ros
 
 ## References
 
-- [Rossoctl Installation](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md)
+- [Rossoctl Installation](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md)
 - [SPIRE Documentation](https://spiffe.io/docs/latest/)
 - [OAuth 2.0 Token Exchange (RFC 8693)](https://www.rfc-editor.org/rfc/rfc8693)

--- a/authbridge/cmd/README.md
+++ b/authbridge/cmd/README.md
@@ -60,7 +60,7 @@ ConfigMap contracts are documented in
 - **Default deployment**: use `authbridge-proxy`. No iptables, no
   Envoy, observable via abctl.
 - **Need ambient/transparent interception via Envoy**: use
-  `authbridge-envoy`. Requires the [`proxy-init`](../authproxy/)
+  `authbridge-envoy`. Requires the [`proxy-init`](../proxy-init/)
   iptables init container.
 - **Size-constrained, no protocol-aware events needed**: use the
   `authbridge-lite` image — the `authbridge-proxy` binary built with

--- a/authbridge/demos/README.md
+++ b/authbridge/demos/README.md
@@ -113,7 +113,7 @@ more AuthBridge capabilities.
 
 All demos require:
 - A Kubernetes cluster with the Rossoctl platform installed
-  ([Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md))
+  ([Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md))
 - Keycloak deployed in the `keycloak` namespace
 - SPIRE deployed (for demos using SPIFFE identity)
 
@@ -145,6 +145,4 @@ pip install -r requirements.txt
 ## Related Documentation
 
 - [AuthBridge Overview](../README.md) — Architecture and design
-- [AuthBridge Binary](../cmd/authbridge/README.md) — Unified authbridge binary
-  supporting ext_proc, ext_authz, and proxy modes
 - [Rossoctl Operator](https://github.com/rossoctl/operator) — Admission webhook for sidecar injection (migrated from this repo)

--- a/authbridge/demos/github-issue/demo-manual.md
+++ b/authbridge/demos/github-issue/demo-manual.md
@@ -1197,7 +1197,7 @@ kubectl delete mutatingwebhookconfiguration rossoctl-webhook-authbridge-mutating
 ## Next Steps
 
 - **UI Deployment**: See [demo-ui.md](demo-ui.md) for deploying via the Rossoctl dashboard
-- **AuthBridge Binary**: See the [AuthBridge README](../../cmd/authbridge/README.md) for inbound
+- **AuthBridge Binary**: See the [AuthBridge README](../../cmd/authbridge-envoy/README.md) for inbound
   JWT validation and outbound token exchange internals
 - **Token-Exchange Routes**: See the [routes-configuration guide](../token-exchange-routes/README.md) for
   route-based token exchange to multiple tool services

--- a/authbridge/demos/weather-agent/demo-ui.md
+++ b/authbridge/demos/weather-agent/demo-ui.md
@@ -88,7 +88,7 @@ plugin pipeline in real time while chatting with the agent, see
 ## Prerequisites
 
 Ensure you have completed the Rossoctl platform setup as described in the
-[Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md),
+[Installation Guide](https://www.rossoctl.dev/docs/getting-started/install),
 including the Rossoctl UI.
 
 You should also have:
@@ -789,7 +789,7 @@ kubectl delete namespace team1
 
 - **Advanced Demo**: See the [GitHub Issue Agent demo](../github-issue/demo.md) for
   outbound token exchange, scope-based access control, and Alice vs Bob scenarios
-- **AuthBridge Binary**: See the [AuthBridge README](../../cmd/authbridge/README.md) for inbound
+- **AuthBridge Binary**: See the [AuthBridge README](../../cmd/README.md) for inbound
   JWT validation and outbound token exchange internals
 - **Token-Exchange Routes**: See the [routes-configuration guide](../token-exchange-routes/README.md) for
   route-based token exchange to multiple tool services

--- a/authbridge/demos/weather-agent/demo-with-abctl.md
+++ b/authbridge/demos/weather-agent/demo-with-abctl.md
@@ -6,7 +6,7 @@ This demo extends the standard [Weather Agent demo](./demo-ui.md) with a live vi
 
 Before starting, complete these in order:
 
-1. **Install Rossoctl** (operator + Keycloak + UI + SPIFFE/SPIRE): [Rossoctl Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/install.md). Works on Kind (local) or OpenShift.
+1. **Install Rossoctl** (operator + Keycloak + UI + SPIFFE/SPIRE): [Rossoctl Installation Guide](https://github.com/rossoctl/rossoctl/blob/main/docs/getting-started/install.md). Works on Kind (local) or OpenShift.
 2. **Deploy the Weather Agent + Tool** through the Rossoctl UI: [Weather Agent Demo with AuthBridge](./demo-ui.md). At the end of that demo you'll have:
    - `weather-service` agent running in the `team1` namespace (with AuthBridge sidecars).
    - `weather-tool-mcp` MCP tool running in `team1`.

--- a/authbridge/docs/plugin-tutorial.md
+++ b/authbridge/docs/plugin-tutorial.md
@@ -396,6 +396,6 @@ All optional. A plugin that doesn't implement them is treated as
 - [`framework-architecture.md`](./framework-architecture.md) — how the pipeline
   composes plugins, the Run / RunResponse dispatch order, and the
   lifecycle hooks.
-- [`pipeline/plugin.go`](../pipeline/plugin.go) — the Plugin interface
+- [`pipeline/plugin.go`](../authlib/pipeline/plugin.go) — the Plugin interface
   and all optional interfaces (Initializer / Shutdowner / Readier /
   Configurable).


### PR DESCRIPTION
## Summary

Fix the broken links reported by `lychee --no-progress './**/*.md' --exclude-path aiac --exclude-path authbridge/demos/github-issue --exclude-path go/pkg/mod/github.com --exclude-path go/pkg/mod/golang.org --exclude-path docs/proposals`

Fixes #

Resolves #714 
Resolves #713
Resolves #712
Resolves #711
Resolves #697
Resolves #696
Resolves #695
Resolves #694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and setup links to current Rossoctl getting-started and quickstart guides.
  * Corrected links for AuthBridge binaries, prerequisites, plugins, and demo walkthroughs.
  * Updated security reporting instructions to link directly to the advisory submission page.
  * Refined deployment and related documentation for improved accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->