### PR TITLE
fix(sparc-service): strip agent-injected keys before SPARC evaluates tool calls

### DIFF
--- a/authbridge/sparc-service/sparc_service/__main__.py
+++ b/authbridge/sparc-service/sparc_service/__main__.py
@@ -8,6 +8,8 @@ from .settings import Settings
 
 
 def main() -> None:
+    import logging
+    logging.basicConfig(level=logging.INFO)
     settings = Settings.from_env()
     uvicorn.run("sparc_service.api:app", host=settings.host, port=settings.port, log_level="info")
 

--- a/authbridge/sparc-service/sparc_service/__main__.py
+++ b/authbridge/sparc-service/sparc_service/__main__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 import uvicorn
 
 from .settings import Settings
 
 
 def main() -> None:
-    import logging
     logging.basicConfig(level=logging.INFO)
     settings = Settings.from_env()
     uvicorn.run("sparc_service.api:app", host=settings.host, port=settings.port, log_level="info")

--- a/authbridge/sparc-service/sparc_service/api.py
+++ b/authbridge/sparc-service/sparc_service/api.py
@@ -8,7 +8,9 @@ Endpoints:
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
@@ -18,6 +20,37 @@ from .models import ReflectRequest, ReflectResponse
 from .settings import Settings
 
 log = logging.getLogger(__name__)
+
+# When SPARC_LOG_REQUESTS=true, log the full incoming ReflectRequest JSON so
+# you can inspect exactly what the caller sends (useful for diagnosing
+# unexpected tool argument keys). Disabled by default — payloads can be large.
+_LOG_REQUESTS = os.getenv("SPARC_LOG_REQUESTS", "").strip().lower() in {"1", "true", "yes"}
+
+# When SPARC_STRIP_TOOL_ARG_KEYS is set (comma-separated key names), those keys
+# are removed from every tool_calls[].function.arguments JSON object before the
+# request reaches SPARC. Use to drop agent-injected keys that are not in the
+# tool spec and would cause SPARC to reject the call.
+# Example: SPARC_STRIP_TOOL_ARG_KEYS=session_id,request_id
+_STRIP_KEYS: frozenset[str] = frozenset(
+    k.strip() for k in os.getenv("SPARC_STRIP_TOOL_ARG_KEYS", "").split(",") if k.strip()
+)
+
+
+def _strip_tool_arg_keys(tool_calls: list[dict], keys: frozenset[str]) -> list[dict]:
+    """Return a copy of tool_calls with the named argument keys removed."""
+    result = []
+    for tc in tool_calls:
+        fn = tc.get("function", {})
+        raw_args = fn.get("arguments", "")
+        try:
+            args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+            if isinstance(args, dict):
+                args = {k: v for k, v in args.items() if k not in keys}
+            new_args = json.dumps(args) if isinstance(args, dict) else raw_args
+        except (json.JSONDecodeError, TypeError):
+            new_args = raw_args
+        result.append({**tc, "function": {**fn, "arguments": new_args}})
+    return result
 
 
 def create_app(engine: ReflectionEngine | None = None) -> FastAPI:
@@ -51,6 +84,16 @@ def create_app(engine: ReflectionEngine | None = None) -> FastAPI:
 
     @app.post("/reflect", response_model=ReflectResponse)
     async def reflect(request: ReflectRequest) -> ReflectResponse:
+        if _LOG_REQUESTS:
+            log.info("incoming reflect request: %s", request.model_dump_json())
+
+        if _STRIP_KEYS and request.tool_calls:
+            request = request.model_copy(
+                update={"tool_calls": _strip_tool_arg_keys(request.tool_calls, _STRIP_KEYS)}
+            )
+            if _LOG_REQUESTS:
+                log.info("after strip (%s): tool_calls=%s", sorted(_STRIP_KEYS), request.tool_calls)
+
         # SPARCReflectionComponent.process is synchronous (and CPU/IO bound on the
         # LLM call); run it off the event loop so the service stays responsive.
         try:

--- a/authbridge/sparc-service/sparc_service/api.py
+++ b/authbridge/sparc-service/sparc_service/api.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
@@ -21,26 +20,18 @@ from .settings import Settings
 
 log = logging.getLogger(__name__)
 
-# When SPARC_LOG_REQUESTS=true, log the full incoming ReflectRequest JSON so
-# you can inspect exactly what the caller sends (useful for diagnosing
-# unexpected tool argument keys). Disabled by default — payloads can be large.
-_LOG_REQUESTS = os.getenv("SPARC_LOG_REQUESTS", "").strip().lower() in {"1", "true", "yes"}
-
-# When SPARC_STRIP_TOOL_ARG_KEYS is set (comma-separated key names), those keys
-# are removed from every tool_calls[].function.arguments JSON object before the
-# request reaches SPARC. Use to drop agent-injected keys that are not in the
-# tool spec and would cause SPARC to reject the call.
-# Example: SPARC_STRIP_TOOL_ARG_KEYS=session_id,request_id
-_STRIP_KEYS: frozenset[str] = frozenset(
-    k.strip() for k in os.getenv("SPARC_STRIP_TOOL_ARG_KEYS", "").split(",") if k.strip()
-)
+# _LOG_REQUESTS and _STRIP_KEYS are now read from Settings (via Settings.from_env)
+# so all config comes from a single place. See settings.py.
 
 
 def _strip_tool_arg_keys(tool_calls: list[dict], keys: frozenset[str]) -> list[dict]:
     """Return a copy of tool_calls with the named argument keys removed."""
     result = []
     for tc in tool_calls:
-        fn = tc.get("function", {})
+        fn = tc.get("function") or {}
+        if not isinstance(fn, dict):
+            result.append(tc)
+            continue
         raw_args = fn.get("arguments", "")
         try:
             args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
@@ -84,15 +75,15 @@ def create_app(engine: ReflectionEngine | None = None) -> FastAPI:
 
     @app.post("/reflect", response_model=ReflectResponse)
     async def reflect(request: ReflectRequest) -> ReflectResponse:
-        if _LOG_REQUESTS:
+        if settings.log_requests:
             log.info("incoming reflect request: %s", request.model_dump_json())
 
-        if _STRIP_KEYS and request.tool_calls:
+        if settings.strip_tool_arg_keys and request.tool_calls:
             request = request.model_copy(
-                update={"tool_calls": _strip_tool_arg_keys(request.tool_calls, _STRIP_KEYS)}
+                update={"tool_calls": _strip_tool_arg_keys(request.tool_calls, settings.strip_tool_arg_keys)}
             )
-            if _LOG_REQUESTS:
-                log.info("after strip (%s): tool_calls=%s", sorted(_STRIP_KEYS), request.tool_calls)
+            if settings.log_requests:
+                log.info("after strip (%s): tool_calls=%s", sorted(settings.strip_tool_arg_keys), request.tool_calls)
 
         # SPARCReflectionComponent.process is synchronous (and CPU/IO bound on the
         # LLM call); run it off the event loop so the service stays responsive.

--- a/authbridge/sparc-service/sparc_service/settings.py
+++ b/authbridge/sparc-service/sparc_service/settings.py
@@ -98,6 +98,10 @@ class Settings:
     host: str = "0.0.0.0"
     port: int = 8090
 
+    # Request logging / arg-stripping (see api.py).
+    log_requests: bool = False
+    strip_tool_arg_keys: frozenset = field(default_factory=frozenset)
+
     # Validation errors collected at load time (provider creds missing, etc.).
     errors: tuple[str, ...] = field(default_factory=tuple)
 
@@ -152,6 +156,12 @@ class Settings:
                 f"provider={provider} requires SPARC_MODEL (e.g. azure/<deployment> or anthropic/claude-3-5-sonnet)"
             )
 
+        strip_tool_arg_keys: frozenset[str] = frozenset(
+            k.strip()
+            for k in os.getenv("SPARC_STRIP_TOOL_ARG_KEYS", "").split(",")
+            if k.strip()
+        )
+
         return cls(
             provider=provider,
             model=model,
@@ -171,5 +181,7 @@ class Settings:
             llm_registry_id=os.getenv("SPARC_LLM_REGISTRY_ID", "").strip(),
             host=os.getenv("HOST", "0.0.0.0"),
             port=_int_env("PORT", 8090),
+            log_requests=_truthy(os.getenv("SPARC_LOG_REQUESTS", "")),
+            strip_tool_arg_keys=strip_tool_arg_keys,
             errors=tuple(errors),
         )


### PR DESCRIPTION
## Problem

Exgentic wraps every agent response as a fake `message` tool call and
injects a `session_id` key into its JSON arguments (e.g.
`{"content": "...", "session_id": "912ebc98-..."}`). This key is not
declared in any tool spec, so SPARC's static layer correctly rejects the
call — but the rejection is spurious: it's a structural technicality, not
a real policy violation, and it short-circuits SPARC's semantic evaluation
before it ever runs.

Verified live: a real Tau2 `exchange_delivered_order_items` WRITE call was
static-layer-rejected purely because of the injected `session_id`
(`decision=reject score=- ms=4.1`).

## Fix

- `SPARC_STRIP_TOOL_ARG_KEYS=<comma-separated keys>` — removes the named
  keys from every `tool_calls[].function.arguments` before SPARC evaluates
  the call. No-op when unset.
- `SPARC_LOG_REQUESTS=true` — logs the full incoming `ReflectRequest` JSON
  at DEBUG level, for diagnosing unexpected argument keys without
  rebuilding. No-op when unset.
- Root logger configuration so `log.info()`/`log.debug()` output from
  `sparc_service.*` loggers actually reaches stdout (uvicorn's
  `log_level="info"` only configures uvicorn's own logger, not the Python
  root logger, so application-level logs were silently dropped).

## Verification

Set `SPARC_STRIP_TOOL_ARG_KEYS=session_id`, re-ran the same tool call:
`decision=approve score=1.00 ms=6990.7` — no `session_id` in the
evaluated args, and the ~7s latency confirms a genuine LLM-backed semantic
evaluation ran this time (vs. the ~4ms static-layer short-circuit before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable request logging to support troubleshooting and monitoring.
  - Added configurable sanitization of selected tool arguments before requests are processed.
  - Sanitized request details can be recorded for improved visibility while helping protect sensitive values.
  - Added clearer startup logging for improved service visibility.

- **Bug Fixes**
  - Preserved malformed or non-dictionary tool arguments unchanged instead of altering or rejecting them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->