### PR TITLE
docs(sparc-service): document SPARC_LOG_REQUESTS and SPARC_STRIP_TOOL_ARG_KEYS

### DIFF
--- a/authbridge/sparc-service/README.md
+++ b/authbridge/sparc-service/README.md
@@ -101,6 +101,8 @@ supports** works by setting the model string and (optionally) extra client kwarg
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | ollama endpoint |
 | `OPENAI_API_KEY` / `OPENAI_BASE_URL` | — | openai creds (LiteLLM also reads provider keys from env: `OPENAI_API_KEY`, `AZURE_API_KEY`, `ANTHROPIC_API_KEY`, …) |
 | `HOST` / `PORT` | `0.0.0.0` / `8090` | bind address |
+| `SPARC_LOG_REQUESTS` | `false` | When `true`, log every incoming `/reflect` request (including tool arguments) at INFO. Off by default because arguments can carry PII, payment ids, and other payload data. |
+| `SPARC_STRIP_TOOL_ARG_KEYS` | — | Comma-separated argument keys to remove from every `tool_calls[].function.arguments` object before SPARC evaluates the call, e.g. `SPARC_STRIP_TOOL_ARG_KEYS=session_id,request_id`. Useful when an agent injects keys that aren't in the tool spec, which would otherwise make SPARC reject the call. |
 
 ### Provider examples
 


### PR DESCRIPTION
## Summary

Documents two `sparc-service` env vars that were introduced by PR #738 (merged 2026-08-10) but never added to the README's Configuration table:

- `SPARC_LOG_REQUESTS`
- `SPARC_STRIP_TOOL_ARG_KEYS`

Addresses part of the "Undocumented env vars" item flagged in the PR #739 review (https://github.com/rossoctl/cortex/pull/739#issuecomment-5230465955, section 7).

## Scope

Deliberately partial — only vars present on `main` today. The remaining ones (`SPARC_SKIP_TOOLS`, `SPARC_DEBUG_LLM`, `SPARC_SCHEMA_IN_PROMPT`) are introduced by PR #739 and will be documented in a follow-up doc-only PR once that merges, to keep this PR narrow and mergeable independently.

## Test plan

- [x] README renders — no other content touched
- [x] Sign-off included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to log incoming reflection requests at INFO level.
  * Added an option to remove specified tool-call argument keys before evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->