### PR TITLE
chore(sparc-service): bump agent-lifecycle-toolkit to 0.11.0

### DIFF
--- a/authbridge/sparc-service/pyproject.toml
+++ b/authbridge/sparc-service/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 dependencies = [
     # The SPARC engine itself, consumed directly from PyPI (no vendoring).
-    "agent-lifecycle-toolkit==0.10.1",
+    "agent-lifecycle-toolkit==0.11.0",
     "fastapi>=0.110",
     "uvicorn[standard]>=0.27",
     "pydantic>=2",


### PR DESCRIPTION
## Summary

One-line pin bump: `agent-lifecycle-toolkit==0.10.1` → `==0.11.0` in `authbridge/sparc-service/pyproject.toml`.

ALTK 0.11.0 was released 2026-08-10 (PyPI upload 19:52 UTC, git tag `v0.11.0` at commit `3199e7e`). It's the first release that includes [ALTK PR #116](https://github.com/AgentToolkit/altk-boost/pull/116) — the structured-output fix for reasoning models (schema-in-system-prompt fallback based on litellm's `supports_response_schema`) plus a widened `except ValueError` in `_parse_llm_response`'s retry loop.

Until 0.11.0 was cut, the newest PyPI release (0.10.1, from 2026-03-16) predated PR #116 by four months. That's why this service ships runtime monkeypatches in `sparc_service/providers.py` (`_patch_watsonx_for_reasoning_models`, `_patch_empty_response_retry`) to route around the missing upstream fix.

## What this PR does NOT touch

Deliberately kept out of scope:

- **The runtime monkeypatches themselves.** They stay in this PR so a regression on this bump remains bisectable. A follow-up will delete them once titan runs green on 0.11.0 for at least one benchmark. Order matters: bump the pin first, verify live, then remove the workaround.
- **Two remaining strict-schema gaps** (nested `$defs` missing `additionalProperties`, free-form `type:object` rendering `additionalProperties: true`) — those are real defects PR #116 didn't fully close and need a new upstream ALTK fix, not a pin bump.

## Test plan

- [x] Diff is a single-line pin change in one file
- [ ] After merge: rebuild `sparc-service` image, redeploy, and verify `kubectl exec … pip show agent-lifecycle-toolkit | grep Version` reports `0.11.0`
- [ ] Sanity: `kubectl exec … python3 -c "from altk.core.llm.providers.litellm.litellm import LiteLLMClient; assert hasattr(LiteLLMClient, 'supports_native_structured_output')"` (PR #116 marker)
- [ ] End-to-end `/reflect` smoke test returns `approve` or `reject`, not `error`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Agent Lifecycle Toolkit dependency to version 0.11.0 for improved compatibility and access to the latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->