### PR TITLE
chore(sparc-service): temporarily pin agent-lifecycle-toolkit to Osher's fork

### DIFF
--- a/authbridge/sparc-service/pyproject.toml
+++ b/authbridge/sparc-service/pyproject.toml
@@ -10,8 +10,11 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 dependencies = [
-    # The SPARC engine itself, consumed directly from PyPI (no vendoring).
-    "agent-lifecycle-toolkit==0.11.0",
+    # The SPARC engine itself. Temporarily pinned to a fork branch commit
+    # containing OsherElhadad's bundled fix for altk-boost #118, #119, #120
+    # (native structured-output compatibility with strict providers).
+    # Reverts to a PyPI version once the fix is merged upstream and released.
+    "agent-lifecycle-toolkit @ git+https://github.com/OsherElhadad/altk-boost@bbd47da842d753aac1ca91a6d328af3c36e27178",
     "fastapi>=0.110",
     "uvicorn[standard]>=0.27",
     "pydantic>=2",


### PR DESCRIPTION
## Summary

One-line pin swap: `agent-lifecycle-toolkit==0.11.0` → `git+https://github.com/OsherElhadad/altk-boost@bbd47da842d753aac1ca91a6d328af3c36e27178`.

`OsherElhadad` shipped a bundled fix on his fork branch [`fix/native-schema-provider-compat`](https://github.com/OsherElhadad/altk-boost/tree/fix/native-schema-provider-compat) covering the three ALTK strict-mode defects `sparc-service` currently carries local workarounds for:

- [altk-boost#118](https://github.com/AgentToolkit/altk-boost/issues/118) — SPARC metric schemas emit `integer` + `minimum`/`maximum`, rejected by Bedrock structured output
- [altk-boost#119](https://github.com/AgentToolkit/altk-boost/issues/119) — `supports_native_structured_output` fail-open sent `response_format` to unknown models
- [altk-boost#120](https://github.com/AgentToolkit/altk-boost/issues/120) — `extra="forbid"` reached only the outermost generated model; nested `$defs` and free-form objects rendered permissive schemas

His own verification against real providers: **0/35 → 32/35** raw Bedrock+Azure calls succeed; **98/98** end-to-end `SPARCReflectionComponent` reflections. He asked for cluster validation before opening the upstream PR into `AgentToolkit/altk-boost:main`.

## Why pin by SHA and not branch name

The branch is coordinated (Osher pings before force-pushing), but a commit SHA gives reproducibility of "what code ran when" regardless of what happens to the branch pointer later. Same reason we pinned `==0.11.0` and not `>=0.11`.

## Why this is temporary

The pin reverts to a PyPI version once Osher merges his fork branch upstream and `AgentToolkit/altk-boost` cuts a release. Follow-up PR at that point.

## Test plan

- [x] Diff is one-line pin change in `authbridge/sparc-service/pyproject.toml`
- [ ] After merge: rebuild `sparc-service` image `--no-cache`, redeploy to `kind-rossoctl`, run `/reflect` smoke test with the current downstream `configure_validation` workaround still in place — confirms Osher's ALTK is at least not a regression (Phase A of [`docs/runbooks/titan-altk-osher-fork-verification.md`](https://github.ibm.com/MLT/rosso-sparc/blob/master/docs/runbooks/titan-altk-osher-fork-verification.md) in the rosso-sparc repo)
- [ ] Remove `configure_validation(prompt_based_validation=True)` calls (uncommitted rebuild), retest `/reflect` — this is what proves Osher's ALTK actually fixes Bedrock end-to-end (Phase B)
- [ ] Report Phase B outcome to Osher; he opens the upstream PR

Downstream task tracking: [TASK-020](https://github.ibm.com/MLT/rosso-sparc/blob/master/docs/tasks/rosso-cortex/TASK-020-pin-altk-osher-fork.md), [TASK-021](https://github.ibm.com/MLT/rosso-sparc/blob/master/docs/tasks/rosso-cortex/TASK-021-verify-osher-altk-cluster.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the SPARC service’s lifecycle tooling to include an upstream fix and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->