### PR TITLE
fix: :bug: dependabot-tidy workflow with stale cmd modules

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -1,0 +1,82 @@
+name: Dependabot go mod tidy
+
+# When Dependabot bumps a dep in authbridge/authlib, the cmd/* modules'
+# go.sum files go stale — they reference authlib's transitive deps via
+# replace directives but Dependabot only tidies the directory it updated.
+# CI's `go fmt`/`go vet` then fails with "updates to go.mod needed".
+#
+# Runs only on Dependabot PRs. Human PRs are untouched.
+
+on:
+  pull_request:
+    paths:
+      - "authbridge/authlib/go.mod"
+      - "authbridge/authlib/go.sum"
+      - "authbridge/cmd/*/go.mod"
+      - "authbridge/cmd/*/go.sum"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  tidy:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOWORK: "off"
+      GOTOOLCHAIN: local
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: authbridge/authlib/go.mod
+
+      - name: Run go mod tidy in every module
+        run: |
+          set -euo pipefail
+          for mod in \
+            authbridge/authlib \
+            authbridge/cmd/authbridge-proxy \
+            authbridge/cmd/authbridge-envoy \
+            authbridge/cmd/abctl; do
+            if [ -f "$mod/go.mod" ]; then
+              echo "::group::go mod tidy in $mod"
+              (cd "$mod" && go mod tidy)
+              echo "::endgroup::"
+            fi
+          done
+
+      - name: Commit and push if changed
+        id: commit
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes after tidy."
+            exit 0
+          fi
+          git config user.name  "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git add -A
+          git commit -s -m "chore: go mod tidy across modules
+
+          Auto-tidied by dependabot-tidy workflow to keep cmd/* go.sum
+          files in sync with authlib after a Dependabot bump."
+          git push
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      # Commits pushed with the default GITHUB_TOKEN do not re-trigger other
+      # workflows. Close + reopen forces CI to re-run on the new commit.
+      # (@dependabot rebase would discard our tidy commit, so it's not usable.)
+      - name: Re-trigger CI on the PR
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr close  "${{ github.event.pull_request.number }}"
+          gh pr reopen "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

We have various dependabot auto-updates that run into issues with `go mod` e.g. https://github.com/rossoctl/cortex/pull/770

Adds a Dependabot-only workflow that runs `go mod tidy` across authlib and every `cmd/*` module after Dependabot updates a Go dep, then closes and reopens the PR to re-trigger CI on the tidy commit.

Dependabot tidies only the directory it updates. When it bumps a dep in `authbridge/authlib`, the `cmd/*` modules link in the same transitive deps via `replace` directives and their `go.sum` files go stale. Dependabot also has no cross-directory group primitive so a `dependabot.yml` update alone couldn't address this - leaving the auto-tidy as a workaround. 

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

## (Optional) Testing Instructions
Tested on own fork https://github.com/evaline-ju/kagenti-extensions/pull/1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency maintenance for Go modules.
  * Updates module files when relevant dependency configuration changes.
  * Automatically commits maintenance updates and retriggers validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->