### PR TITLE
docs(weather-agent): drop obsolete keycloak-admin-secret guidance

### DIFF
--- a/authbridge/demos/weather-agent/demo-ui.md
+++ b/authbridge/demos/weather-agent/demo-ui.md
@@ -107,12 +107,24 @@ In **`team1`**: `authbridge-config`, `authbridge-runtime-config`, `spiffe-helper
 `envoy-config`. No extra Secrets or ConfigMaps are required for this demo (outbound
 passthrough; inbound JWT uses issuer/signature checks).
 
-**`keycloak-admin-secret` is not in `team1`.** Operator 0.2+ keeps it in
-**`rossoctl-system`** for client registration. `NotFound` in `team1` is expected:
+**No `keycloak-admin-secret` is required — in `team1` or `rossoctl-system`.** On the
+current operator (v0.7.0) the operator registers Keycloak clients using its own **SPIFFE
+workload identity** (federated into Keycloak by the `rossoctl-operator-client-bootstrap`
+post-install job in the `keycloak` namespace), not an admin username/password Secret.
+A `NotFound` for `keycloak-admin-secret` in **either** namespace is expected. Confirm
+registration by the per-workload client credentials the operator writes instead:
 
 ```bash
-kubectl get secret keycloak-admin-secret -n rossoctl-system
+# One Secret per registered workload:
+kubectl get secret -n team1 | grep rossoctl-keycloak-client-credentials
+# ...and/or watch the operator apply registrations:
+kubectl logs -n rossoctl-system deployment/rossoctl-controller-manager \
+  | grep "client registration applied" | tail
 ```
+
+> Older docs (operator 0.2+) referenced a `keycloak-admin-secret` in `rossoctl-system`.
+> The Helm install no longer creates or uses it; the admin credentials the bootstrap job
+> needs are read from `keycloak-initial-admin` in the `keycloak` namespace.
 
 UI login: secret **`rossoctl-test-user`** in namespace **`keycloak`** (`admin` + password).
 Realm **`rossoctl`** is created by the platform installer.
@@ -567,15 +579,19 @@ kubectl delete pod test-client -n team1 --ignore-not-found
 
 **Symptom:** `{"error":"invalid_client","error_description":"Invalid client or Invalid client credentials"}`
 
-**Cause:** The `keycloak-admin-secret` Secret or `authbridge-config` ConfigMap was missing
-or incorrect at startup, so the operator's `ClientRegistrationReconciler` couldn't reach
-Keycloak to register the client.
+**Cause:** The operator's `ClientRegistrationReconciler` couldn't complete registration —
+usually because the `authbridge-config` ConfigMap had the wrong realm, or the operator's
+SPIFFE identity was not yet federated into Keycloak (the `rossoctl-operator-client-bootstrap`
+job). On v0.7.0 the operator authenticates via its SPIFFE workload identity, so there is
+**no** `keycloak-admin-secret` to check.
 
 **Fix:**
 
 ```bash
-# 1. Verify the keycloak-admin-secret exists (operator 0.2+ keeps it in rossoctl-system)
-kubectl get secret keycloak-admin-secret -n rossoctl-system
+# 1. Confirm the operator registered a client for the workload
+kubectl get secret -n team1 | grep rossoctl-keycloak-client-credentials
+kubectl logs -n rossoctl-system deployment/rossoctl-controller-manager \
+  | grep -iE "clientregistration|client registration applied" | tail
 
 # 2. Verify the authbridge-config ConfigMap has the correct realm
 kubectl get configmap authbridge-config -n team1 -o jsonpath='{.data.KEYCLOAK_REALM}'


### PR DESCRIPTION
## Problem

`authbridge/demos/weather-agent/demo-ui.md` instructs users to verify a
`keycloak-admin-secret` in `rossoctl-system` ("Operator 0.2+ keeps it in rossoctl-system
for client registration"). On the current operator (**v0.7.0**) this Secret does not
exist in a Helm-based install and is not used — so the instruction points users at an
expected `NotFound`.

Verified on a fresh quickstart cluster:

- `keycloak-admin-secret` is absent in **both** `team1` and `rossoctl-system`.
- The `rossoctl-controller-manager` has no admin env vars and cannot read the admin
  secret, yet client registration still succeeds:
  ```
  "operator client registration applied" ... workload=weather-tool namespace=team1
  secret=rossoctl-keycloak-client-credentials-<hash>
  ```
- The operator authenticates to Keycloak via its **SPIFFE workload identity**, federated
  by the `rossoctl-operator-client-bootstrap` post-install job (in the `keycloak` ns). The
  admin credentials that job needs come from `keycloak-initial-admin` in the `keycloak`
  namespace (Helm default `keycloak.adminSecretName=keycloak-initial-admin`).

## Changes

- **Installer-Provided Resources:** replace the `keycloak-admin-secret` /
  `rossoctl-system` note with the SPIFFE-based reality; verify registration via the
  per-workload `rossoctl-keycloak-client-credentials-*` Secret and the operator log.
- **Troubleshooting → Invalid Client:** rewrite the cause and drop the
  `keycloak-admin-secret` check in favor of the operator client-registration log/secret.

The "Check operator-managed client registration" section was already correct and is left
unchanged.

Closes #790

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the weather agent demo guide to reflect operator-managed Keycloak client registration.
  * Documented SPIFFE-based authentication, expected missing-secret behavior, and verification commands.
  * Revised troubleshooting guidance for realm configuration and SPIFFE federation issues.
  * Removed obsolete admin-secret verification instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->