### PR TITLE
chore: :recycle: Dynamic discovery of modules to dependabot tidy

### DIFF
--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -10,14 +10,19 @@ name: Dependabot go mod tidy
 on:
   pull_request:
     paths:
-      - "authbridge/authlib/go.mod"
-      - "authbridge/authlib/go.sum"
-      - "authbridge/cmd/*/go.mod"
-      - "authbridge/cmd/*/go.sum"
+      - "authbridge/**/go.mod"
+      - "authbridge/**/go.sum"
 
 permissions:
   contents: write
   pull-requests: write
+
+# A Dependabot force-push (rebase) landing while a tidy is in flight would
+# otherwise produce two jobs racing to push the same ref; the loser fails
+# non-fast-forward. Cancel the older run — its tidy is already superseded.
+concurrency:
+  group: dependabot-tidy-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   tidy:
@@ -39,17 +44,12 @@ jobs:
       - name: Run go mod tidy in every module
         run: |
           set -euo pipefail
-          for mod in \
-            authbridge/authlib \
-            authbridge/cmd/authbridge-proxy \
-            authbridge/cmd/authbridge-envoy \
-            authbridge/cmd/abctl; do
-            if [ -f "$mod/go.mod" ]; then
-              echo "::group::go mod tidy in $mod"
-              (cd "$mod" && go mod tidy)
-              echo "::endgroup::"
-            fi
-          done
+          while IFS= read -r -d '' go_mod; do
+            mod=$(dirname "$go_mod")
+            echo "::group::go mod tidy in $mod"
+            (cd "$mod" && go mod tidy)
+            echo "::endgroup::"
+          done < <(find authbridge -name go.mod -not -path '*/demos/*' -print0 | sort -z)
 
       - name: Commit and push if changed
         id: commit


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Follow-up to some comments on #789 to:
-  account for multiple synchronize events e.g. Dependabot force-push while tidy is running
- dynamic module discovery

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency maintenance for all applicable Go modules.
  * Dependabot runs now cancel outdated duplicate jobs for the same pull request.
  * Dependency cleanup is triggered when module dependency files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->