### PR TITLE
fix(authbridge): Raise the workspace Go directive to 1.26.5

### DIFF
--- a/authbridge/authlib/go.mod
+++ b/authbridge/authlib/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/authlib
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/contextforge-org/cpex/go/cpex v0.2.2

--- a/authbridge/cmd/abctl/go.mod
+++ b/authbridge/cmd/abctl/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/cmd/abctl
 
-go 1.26.4
+go 1.26.5
 
 // Workspace-only: this replace is satisfied by authbridge/go.work during
 // local development. Standalone `go get` / `go install` outside the

--- a/authbridge/cmd/authbridge-cpex/go.mod
+++ b/authbridge/cmd/authbridge-cpex/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/cmd/authbridge-cpex
 
-go 1.26.4
+go 1.26.5
 
 require github.com/rossoctl/cortex/authbridge/authlib v0.0.0-00010101000000-000000000000
 

--- a/authbridge/cmd/authbridge-envoy/go.mod
+++ b/authbridge/cmd/authbridge-envoy/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/cmd/authbridge-envoy
 
-go 1.26.4
+go 1.26.5
 
 replace (
 	github.com/rossoctl/cortex/authbridge/authlib => ../../authlib

--- a/authbridge/cmd/authbridge-praxis/go.mod
+++ b/authbridge/cmd/authbridge-praxis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/cmd/authbridge-praxis
 
-go 1.26.4
+go 1.26.5
 
 require github.com/rossoctl/cortex/authbridge/authlib v0.0.0-20260819180630-8386e3004363
 

--- a/authbridge/cmd/authbridge-proxy/go.mod
+++ b/authbridge/cmd/authbridge-proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/cmd/authbridge-proxy
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/rossoctl/cortex/authbridge/authlib v0.0.0

--- a/authbridge/go.work
+++ b/authbridge/go.work
@@ -1,4 +1,4 @@
-go 1.26.4
+go 1.26.5
 
 use (
 	./authlib

--- a/authbridge/storage/redis/go.mod
+++ b/authbridge/storage/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/rossoctl/cortex/authbridge/storage/redis
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
## Problem

Any dependency update that raises a module's minimum Go version fails
`Go CI (authlib)`, and reports it as four broken modules rather than one. From
#771 (`bifrost/core` 1.7.0 → 1.7.13):

```
go: module . listed in go.work file requires go >= 1.26.5, but go.work lists go 1.26.4
go: module ../cmd/abctl listed in go.work file requires go >= 1.26.5, ...
go: module ../cmd/authbridge-envoy listed in go.work file requires go >= 1.26.5, ...
go: module ../cmd/authbridge-proxy listed in go.work file requires go >= 1.26.5, ...
```

`go-ci-authlib` is the only Go job that reads `go.work` — the `cmd/*` matrix
(`ci.yaml:86`) and `dependabot-tidy` (`dependabot-tidy.yml:33`) both set
`GOWORK: "off"` — which is why one dependency bump surfaces as a single check
failing about four modules.

Dependabot only edits the directory it is updating, and `authbridge/go.work` sits
outside every configured `gomod` directory, so no Dependabot PR can fix it. Left
alone this recurs on every toolchain-raising bump.

## Why `go.work` alone is not enough

The first attempt here bumped only `go.work`, and CI rejected it:

```
go: ../go.work requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

`actions/setup-go` exports `GOTOOLCHAIN=local` itself — it is absent from
`ci.yaml`, which makes it easy to assume the default `auto` — and installs the
version named by `go-version-file: authbridge/authlib/go.mod`. A toolchain pinned
at 1.26.4 and forbidden from upgrading can never satisfy a `go.work` asking for
1.26.5.

So the module directives must move with `go.work`: `authlib/go.mod` is what
selects the CI toolchain, and no module that `replace`s authlib may declare an
older Go than authlib.

## Change

`go 1.26.4` → `go 1.26.5`, one line each, across `go.work` and all seven
workspace modules. No `toolchain` directives exist in any of them, and no
`go.sum` is affected.

This is not speculative: #771 already raises four of the seven, so the floor is
moving regardless. Doing it deliberately keeps `GOTOOLCHAIN=local` hermetic and
turns #771's rebase into a no-op on these lines.

## Collateral checked

| Consumer | Effect |
|---|---|
| `Go CI (authlib)` | installs 1.26.5 from `authlib/go.mod`; `go.work` satisfied |
| `Go CI (authbridge proxy/envoy)` | installs 1.26.5 from its own `go.mod`; `GOWORK: "off"` |
| `dependabot-tidy` | reads the same `authlib/go.mod`, so `GOTOOLCHAIN: local` stays satisfied |
| `cmd/*` Dockerfiles | `golang:1.26-alpine`; 1.26.7 is released |
| `abctl`, `cpex`, `praxis`, `storage/redis` | no CI job, but they `replace` authlib so they move with it |

Demo modules are untouched — they are standalone (`golang:1.24-alpine`) and do not
replace authlib.

## Unblocks

- #771 — `bifrost/core` 1.7.0 → 1.7.13 (rebase after this merges)
- Any future bump that raises a module's Go floor

_Assisted-By: Claude Code_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.26.5 across AuthBridge components.
  * No user-facing functionality or API behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->