### PR TITLE
docs(authbridge): fetch demo admin token from master realm (fixes null token)

### DIFF
--- a/authbridge/demos/github-issue/demo-aiac.md
+++ b/authbridge/demos/github-issue/demo-aiac.md
@@ -415,7 +415,7 @@ Authbridge outbound check will exchange the token, then deny the request since t
 
 REALM_NAME="rossoctl"
 
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/${REALM_NAME}/protocol/openid-connect/token \
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \
@@ -628,7 +628,7 @@ Test the policy by getting tokens for different users:
 
 REALM_NAME="rossoctl"
 
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/${REALM_NAME}/protocol/openid-connect/token \
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \

--- a/authbridge/demos/github-issue/demo-manual.md
+++ b/authbridge/demos/github-issue/demo-manual.md
@@ -667,8 +667,8 @@ kubectl exec -it test-client -n team1 -- sh
 Inside the test-client pod, run:
 
 ```bash
-# Get a Keycloak admin token from the rossoctl realm
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+# Get a Keycloak admin token from the master realm (admin/admin; the rossoctl realm admin password is randomly generated)
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \
@@ -896,7 +896,7 @@ Inside the test-client pod, get the agent's client credentials (needed to reques
 user tokens that include the agent's audience):
 
 ```bash
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \

--- a/authbridge/demos/github-issue/demo-rbac.md
+++ b/authbridge/demos/github-issue/demo-rbac.md
@@ -667,8 +667,8 @@ kubectl exec -it test-client -n team1 -- sh
 Inside the test-client pod, run:
 
 ```bash
-# Get a Keycloak admin token from the rossoctl realm
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+# Get a Keycloak admin token from the master realm (admin/admin; the rossoctl realm admin password is randomly generated)
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \
@@ -879,7 +879,7 @@ Inside the test-client pod, get the agent's client credentials (needed to reques
 user tokens that include the agent's audience):
 
 ```bash
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \

--- a/authbridge/demos/github-issue/demo-ui.md
+++ b/authbridge/demos/github-issue/demo-ui.md
@@ -672,8 +672,8 @@ kubectl exec -it test-client -n team1 -- sh
 Inside the pod, get credentials and send a request:
 
 ```bash
-# Get a Keycloak admin token from the rossoctl realm
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+# Get a Keycloak admin token from the master realm (admin/admin; the rossoctl realm admin password is randomly generated)
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \
@@ -848,7 +848,7 @@ jwt_payload() {
   echo "$p" | base64 -d
 }
 
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \

--- a/authbridge/demos/weather-agent/demo-ui.md
+++ b/authbridge/demos/weather-agent/demo-ui.md
@@ -490,8 +490,8 @@ kubectl exec -it test-client -n team1 -- sh
 Inside the pod, get credentials and send a request:
 
 ```bash
-# Get a Keycloak admin token from the rossoctl realm
-ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/rossoctl/protocol/openid-connect/token \
+# Get a Keycloak admin token from the master realm (admin/admin; the rossoctl realm admin password is randomly generated)
+ADMIN_TOKEN=$(curl -s http://keycloak-service.keycloak.svc:8080/realms/master/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=admin-cli" \
   -d "username=admin" \


### PR DESCRIPTION
## Problem

Following the AuthBridge demos (starting with `weather-agent/demo-ui.md`), the "Inside the pod, get credentials and send a request" step fails — `ADMIN_TOKEN` and the agent `TOKEN` both come back `null`.

The admin-token step does a password grant against the **`rossoctl`** realm with `admin`/`admin`:

```sh
ADMIN_TOKEN=$(curl -s .../realms/rossoctl/protocol/openid-connect/token \
  -d grant_type=password -d client_id=admin-cli -d username=admin -d password=admin | jq -r .access_token)
```

But `admin`/`admin` is the **`master`** realm credential. The `rossoctl` realm admin user has a **randomly generated** password (per `show-services.sh`). The grant returns `401 invalid_grant`, `jq` yields the literal `null`, and everything downstream cascades to `null`.

## Fix

Fetch the **admin** token from the **`master`** realm. `admin/admin` is stable and documented, and the master admin has cross-realm rights, so `/admin/realms/rossoctl/clients` still resolves. The client lookup and the agent `client_credentials` grant stay on the `rossoctl` realm.

Applied to all 9 admin-token password grants across 5 demo docs:
- `weather-agent/demo-ui.md`
- `github-issue/demo-ui.md` (×2)
- `github-issue/demo-manual.md` (×2)
- `github-issue/demo-rbac.md` (×2)
- `github-issue/demo-aiac.md` (×2, via `REALM_NAME`)

Misleading "from the rossoctl realm" comments updated to match.

**Deliberately left unchanged:** the `WRONG_ISSUER_TOKEN` master-realm negative test in `demo-manual.md`/`demo-rbac.md`, the `client_credentials` agent-token grants (correctly `rossoctl`), and `/admin/realms/rossoctl/clients` admin-API paths.

## Verification

Ran the full sequence on a local Kind cluster with only the realm changed to `master`:

```
admin token len: 766
CLIENT_ID=spiffe://localtest.me/ns/team1/sa/weather-service  secret_len=32
agent token http=200  token_len=1262
```

Closes #797

Assisted-By: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and demo instructions to obtain administrator tokens from Keycloak’s `master` realm.
  * Clarified administrator credentials and noted that the application realm’s administrator password is randomly generated.
  * Corrected token-generation examples across GitHub issue, RBAC, UI, and weather-agent demos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->