### PR TITLE
fix(authbridge): Bump langchain-core to 1.6.0 to unbreak requirements.txt

### DIFF
--- a/authbridge/requirements.txt
+++ b/authbridge/requirements.txt
@@ -2,7 +2,7 @@ python-keycloak>=7.1.1,<8
 PyYAML>=6.0.3
 
 langgraph==1.2.9
-langchain-core==1.5.5
+langchain-core==1.6.0
 langchain-openai==1.6.0
 pydantic==2.13.4
 


### PR DESCRIPTION
## `main` is currently broken

`authbridge/requirements.txt` on `main` cannot be resolved:

```
langgraph==1.2.9
langchain-core==1.5.5      ← too old
langchain-openai==1.6.0    ← requires langchain-core>=1.6.0,<2.0.0
pydantic==2.13.4
```

Reproduced rather than inferred from metadata:

```
$ pip install --dry-run 'langchain-openai==1.6.0' 'langchain-core==1.5.5'
ERROR: Cannot install langchain-core==1.5.5 and langchain-openai==1.6.0
       because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

## Fix

`langchain-core==1.5.5` → `1.6.0`. One line.

1.6.0 is the current release, so this is not a leapfrog. Verified two ways:

| Combination | Resolves |
|---|---|
| core 1.6.0 + openai 1.6.0 + **langgraph 1.2.9** (main's pin today) | ✅ |
| core 1.6.0 + openai 1.6.0 + **langgraph 1.2.11** (#765's target) | ✅ |

So this is safe to land on its own and does not need bundling with #765, in
either merge order.

## How it happened

Worth recording, because the failure mode is repeatable:

1. **#769** pinned `langchain-core` to 1.5.5.
2. **#767** was opened against `langchain-openai` **1.5.1**, which requires
   `langchain-core>=1.5.4` — compatible, and reviewed on that basis.
3. A rebase of #767 **silently retargeted it to 1.6.0**, which requires
   `langchain-core>=1.6.0`. Title and diff both changed.
4. `dismiss_stale_reviews` is `false`, so the approval granted for 1.5.1
   carried over onto 1.6.0 untouched, and #767 merged looking fully green.

## Why no check caught it

- **`Python Tests` never installs `authbridge/requirements.txt`** — it finishes
  in ~12s, so nothing validates that these pins resolve together.
- **`main` has no required status checks**, so an approval alone is sufficient
  to merge.

Two follow-ups worth considering, both outside this PR:

- A check that actually resolves `requirements.txt` (`pip install --dry-run -r`
  would be enough, and fast).
- Enabling `dismiss_stale_reviews`, so a rebase that changes the proposed
  version also drops the approval that was granted for the old one.

_Assisted-By: Claude Code_
