### PR TITLE
fix: :bug: Fallback for default session ID

### DIFF
--- a/authbridge/authlib/plugins/sessionbudget/plugin.go
+++ b/authbridge/authlib/plugins/sessionbudget/plugin.go
@@ -24,19 +24,19 @@ import (
 )
 
 type config struct {
-	RedisURL           string `json:"redis_url" required:"true" description:"Redis/Valkey connection URL."`
-	MaxTokens          int64  `json:"max_tokens" description:"Cumulative token ceiling per session. 0 = no limit."`
-	MaxCalls           int64  `json:"max_calls" description:"Max LLM/inference calls per session. Only inference-parser output increments this counter; MCP tool calls and other outbound traffic do not. Once the limit is reached, all subsequent outbound requests (including MCP tool calls) are blocked until the session resets. 0 = no limit."`
-	MaxDurationSeconds int64  `json:"max_duration_seconds" description:"Wall-clock session lifetime in seconds. 0 = no limit."`
-	OnExceed           string `json:"on_exceed" description:"Action on breach: deny, observe (shadow), or pause (HITL webhook approval)." default:"deny" enum:"deny,observe,pause"`
-	PauseWebhook       string `json:"pause_webhook" description:"URL to POST for approval when on_exceed=pause. Required when on_exceed=pause."`
-	PauseTimeout       string `json:"pause_timeout" description:"How long to wait for webhook response." default:"30s"`
-	PauseTimeoutAction string `json:"pause_timeout_action" description:"Action on webhook timeout/error: deny or allow." default:"deny" enum:"deny,allow"`
-	PauseGracePeriod   string `json:"pause_grace_period" description:"After approval, suppress further webhooks for this duration." default:"5m"`
-	SessionTTLSeconds  int    `json:"session_ttl_seconds" description:"Redis key TTL; should be >= max_duration_seconds." default:"7200"`
-	RefreshInterval    string `json:"refresh_interval" description:"How often to sync local cache from Redis." default:"5s"`
-	RedisUnavailable   string `json:"redis_unavailable" description:"Behavior when Redis is unreachable. Only fail_open is supported; fail_closed is reserved." default:"fail_open"`
-	DefaultSessionFallback bool `json:"default_session_fallback" description:"Pool sessionless traffic into a shared 'default' bucket. Off by default. Single-workload only." default:"false"`
+	RedisURL               string `json:"redis_url" required:"true" description:"Redis/Valkey connection URL."`
+	MaxTokens              int64  `json:"max_tokens" description:"Cumulative token ceiling per session. 0 = no limit."`
+	MaxCalls               int64  `json:"max_calls" description:"Max LLM/inference calls per session. Only inference-parser output increments this counter; MCP tool calls and other outbound traffic do not. Once the limit is reached, all subsequent outbound requests (including MCP tool calls) are blocked until the session resets. 0 = no limit."`
+	MaxDurationSeconds     int64  `json:"max_duration_seconds" description:"Wall-clock session lifetime in seconds. 0 = no limit."`
+	OnExceed               string `json:"on_exceed" description:"Action on breach: deny, observe (shadow), or pause (HITL webhook approval)." default:"deny" enum:"deny,observe,pause"`
+	PauseWebhook           string `json:"pause_webhook" description:"URL to POST for approval when on_exceed=pause. Required when on_exceed=pause."`
+	PauseTimeout           string `json:"pause_timeout" description:"How long to wait for webhook response." default:"30s"`
+	PauseTimeoutAction     string `json:"pause_timeout_action" description:"Action on webhook timeout/error: deny or allow." default:"deny" enum:"deny,allow"`
+	PauseGracePeriod       string `json:"pause_grace_period" description:"After approval, suppress further webhooks for this duration." default:"5m"`
+	SessionTTLSeconds      int    `json:"session_ttl_seconds" description:"Redis key TTL; should be >= max_duration_seconds." default:"7200"`
+	RefreshInterval        string `json:"refresh_interval" description:"How often to sync local cache from Redis." default:"5s"`
+	RedisUnavailable       string `json:"redis_unavailable" description:"Behavior when Redis is unreachable. Only fail_open is supported; fail_closed is reserved." default:"fail_open"`
+	DefaultSessionFallback bool   `json:"default_session_fallback" description:"Pool sessionless traffic into a shared 'default' bucket. Off by default. Single-workload only." default:"false"`
 }
 
 // approvalFlight carries the outcome of one webhook call. The leader writes

--- a/authbridge/authlib/plugins/sessionbudget/plugin.go
+++ b/authbridge/authlib/plugins/sessionbudget/plugin.go
@@ -36,6 +36,7 @@ type config struct {
 	SessionTTLSeconds  int    `json:"session_ttl_seconds" description:"Redis key TTL; should be >= max_duration_seconds." default:"7200"`
 	RefreshInterval    string `json:"refresh_interval" description:"How often to sync local cache from Redis." default:"5s"`
 	RedisUnavailable   string `json:"redis_unavailable" description:"Behavior when Redis is unreachable. Only fail_open is supported; fail_closed is reserved." default:"fail_open"`
+	DefaultSessionFallback bool `json:"default_session_fallback" description:"Pool sessionless traffic into a shared 'default' bucket. Off by default. Single-workload only." default:"false"`
 }
 
 // approvalFlight carries the outcome of one webhook call. The leader writes
@@ -666,11 +667,13 @@ func (p *SessionBudget) sessionID(pctx *pipeline.Context) string {
 	if pctx.Session != nil && pctx.Session.ID != "" {
 		return pctx.Session.ID
 	}
-	// Forward-proxy egress with no prior inbound A2A leaves pctx.Session
-	// nil. Fall back to the well-known default bucket so single-workload
-	// demos and any traffic ahead of the first inbound request still get
-	// budgeted, matching the listener's own DefaultSessionID fallback.
-	return session.DefaultSessionID
+	// Opt-in fallback for single-workload deployments where all sessionless
+	// egress should share one bucket. Off by default; callers with no
+	// session then skip enforcement (existing no_session_id path).
+	if p.cfg.DefaultSessionFallback {
+		return session.DefaultSessionID
+	}
+	return ""
 }
 
 func (p *SessionBudget) redisKey(sessionID string) string {

--- a/authbridge/authlib/plugins/sessionbudget/plugin.go
+++ b/authbridge/authlib/plugins/sessionbudget/plugin.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 	"github.com/rossoctl/cortex/authbridge/authlib/storage"
 	"golang.org/x/sync/singleflight"
 )
@@ -665,7 +666,11 @@ func (p *SessionBudget) sessionID(pctx *pipeline.Context) string {
 	if pctx.Session != nil && pctx.Session.ID != "" {
 		return pctx.Session.ID
 	}
-	return ""
+	// Forward-proxy egress with no prior inbound A2A leaves pctx.Session
+	// nil. Fall back to the well-known default bucket so single-workload
+	// demos and any traffic ahead of the first inbound request still get
+	// budgeted, matching the listener's own DefaultSessionID fallback.
+	return session.DefaultSessionID
 }
 
 func (p *SessionBudget) redisKey(sessionID string) string {

--- a/authbridge/authlib/plugins/sessionbudget/plugin_test.go
+++ b/authbridge/authlib/plugins/sessionbudget/plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 	"github.com/rossoctl/cortex/authbridge/authlib/storage"
 )
 
@@ -258,6 +259,36 @@ func TestOnRequest_NoSession(t *testing.T) {
 	action := p.OnRequest(context.Background(), pctx)
 	if action.Type != pipeline.Continue {
 		t.Fatalf("expected Continue for nil session, got %v", action.Type)
+	}
+}
+
+// Pins the default-session fallback on the response path: forward-proxy egress
+// with no inbound A2A leaves pctx.Session nil, and the plugin must still
+// accumulate under session.DefaultSessionID so budgets are enforced instead of
+// silently skipped.
+func TestOnResponseFrame_NoSession_UsesDefaultBucket(t *testing.T) {
+	p := newTestPlugin(1000, 0, 0)
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Headers:   http.Header{},
+		Extensions: pipeline.Extensions{
+			Inference: &pipeline.InferenceExtension{TotalTokens: 42},
+		},
+	}
+
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	p.mu.RLock()
+	c := p.cache[session.DefaultSessionID]
+	p.mu.RUnlock()
+	if c == nil {
+		t.Fatalf("expected cache entry under %q, got none", session.DefaultSessionID)
+	}
+	if c.tokens != 42 {
+		t.Errorf("tokens = %d, want 42", c.tokens)
+	}
+	if c.calls != 1 {
+		t.Errorf("calls = %d, want 1", c.calls)
 	}
 }
 

--- a/authbridge/authlib/plugins/sessionbudget/plugin_test.go
+++ b/authbridge/authlib/plugins/sessionbudget/plugin_test.go
@@ -146,14 +146,19 @@ func init() {
 }
 
 func newTestPlugin(maxTokens, maxCalls, maxDuration int64) *SessionBudget {
+	return newTestPluginWithFallback(maxTokens, maxCalls, maxDuration, false)
+}
+
+func newTestPluginWithFallback(maxTokens, maxCalls, maxDuration int64, defaultSessionFallback bool) *SessionBudget {
 	p := New()
 	cfg := fmt.Sprintf(`{
 		"redis_url": "mem://test",
 		"max_tokens": %d,
 		"max_calls": %d,
 		"max_duration_seconds": %d,
-		"refresh_interval": "100ms"
-	}`, maxTokens, maxCalls, maxDuration)
+		"refresh_interval": "100ms",
+		"default_session_fallback": %t
+	}`, maxTokens, maxCalls, maxDuration, defaultSessionFallback)
 	if err := p.Configure(json.RawMessage(cfg)); err != nil {
 		panic(err)
 	}
@@ -260,14 +265,26 @@ func TestOnRequest_NoSession(t *testing.T) {
 	if action.Type != pipeline.Continue {
 		t.Fatalf("expected Continue for nil session, got %v", action.Type)
 	}
+
+	// Pin the mechanism, not just the outcome: with fallback off (the
+	// default), sessionless traffic must record a no_session_id skip so
+	// operators can distinguish it from real-session traffic.
+	if pctx.Extensions.Invocations == nil {
+		t.Fatal("expected invocation recorded, got none")
+	}
+	out := pctx.Extensions.Invocations.Outbound
+	if len(out) != 1 {
+		t.Fatalf("expected 1 outbound invocation, got %d", len(out))
+	}
+	if out[0].Action != pipeline.ActionSkip || out[0].Reason != "no_session_id" {
+		t.Errorf("invocation = {%s, %s}, want {skip, no_session_id}", out[0].Action, out[0].Reason)
+	}
 }
 
-// Pins the default-session fallback on the response path: forward-proxy egress
-// with no inbound A2A leaves pctx.Session nil, and the plugin must still
-// accumulate under session.DefaultSessionID so budgets are enforced instead of
-// silently skipped.
+// With default_session_fallback enabled, sessionless response frames
+// accumulate under session.DefaultSessionID instead of being skipped.
 func TestOnResponseFrame_NoSession_UsesDefaultBucket(t *testing.T) {
-	p := newTestPlugin(1000, 0, 0)
+	p := newTestPluginWithFallback(1000, 0, 0, true)
 	pctx := &pipeline.Context{
 		Direction: pipeline.Outbound,
 		Headers:   http.Header{},
@@ -289,6 +306,28 @@ func TestOnResponseFrame_NoSession_UsesDefaultBucket(t *testing.T) {
 	}
 	if c.calls != 1 {
 		t.Errorf("calls = %d, want 1", c.calls)
+	}
+}
+
+// With default_session_fallback disabled (the default), sessionless response
+// frames are skipped and nothing accumulates.
+func TestOnResponseFrame_NoSession_FallbackOff_Skips(t *testing.T) {
+	p := newTestPlugin(1000, 0, 0)
+	pctx := &pipeline.Context{
+		Direction: pipeline.Outbound,
+		Headers:   http.Header{},
+		Extensions: pipeline.Extensions{
+			Inference: &pipeline.InferenceExtension{TotalTokens: 42},
+		},
+	}
+
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	p.mu.RLock()
+	_, ok := p.cache[session.DefaultSessionID]
+	p.mu.RUnlock()
+	if ok {
+		t.Errorf("expected no cache entry under %q when fallback is off", session.DefaultSessionID)
 	}
 }
 

--- a/authbridge/docs/session-budget-plugin.md
+++ b/authbridge/docs/session-budget-plugin.md
@@ -56,6 +56,7 @@ pipeline:
 | `session_ttl_seconds` | 7200 | Redis key TTL. Must be ≥ `max_duration_seconds` when the latter is set (rejected at Configure time otherwise). |
 | `refresh_interval` | `5s` | Local-cache sync interval |
 | `redis_unavailable` | `fail_open` | Only `fail_open` supported today |
+| `default_session_fallback` | `false` | Pool sessionless traffic into a shared `"default"` bucket. Single-workload only — one caller exhausting the budget denies the rest. Under `max_duration_seconds`, continuous traffic refreshes the TTL, so once elapsed exceeds the limit requests stay denied until the key expires or is deleted. |
 
 At least one of `max_tokens`, `max_calls`, `max_duration_seconds` must be > 0.
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

The session budget plugin keyed Redis off the active A2A session ID, which only exists once an inbound request has tagged one. Egress that precedes any inbound request like single-workload demos, egress-only deployments, pre-first-turn traffic produced an empty ID and was silently skipped, affecting/bypassing budget enforcement. The forward-proxy listener already normalizes this case to a default session bucket when writing session events, so we make the same fallback available here as an opt-in `default_session_fallback` flag (off by default) so multi-tenant deployments keep today's skip behavior while single-workload demos can pool sessionless egress into the shared bucket.

Part of: #708 

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in fallback that assigns sessionless requests to a shared default session budget.
  * When disabled, sessionless requests retain the existing behavior and are skipped without a session ID.
  * Response frames accumulate under the default session only when fallback is enabled.
  * The shared default budget supports a single workload and uses duration-based expiration.

* **Documentation**
  * Documented the new default session fallback configuration and its limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->