### PR TITLE
Docs: Fix advanced weather-agent demo (token-exchange E2E verified)

### DIFF
--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -273,10 +273,14 @@ kubectl logs "$AGENT_POD" -n team1 -c authbridge-proxy 2>&1 | grep -E "Resolver|
 Delete via the Rossoctl UI (Tool Catalog / Agent Catalog), or via CLI.
 
 **Delete the `AgentRuntime` CRs — they are the parent resource.** The agent runs
-as a `Sandbox` and the tool as a `Deployment`, both owned by an AgentRuntime. If
-you delete the child workload (Sandbox/Deployment) but leave the AgentRuntime, the
-operator enters a reconcile error loop (`Failed to resolve targetRef ... not
-found`) every ~30s. Deleting the AgentRuntime cascades to its children:
+as a `Sandbox` and the tool as a `Deployment`, both owned by an AgentRuntime.
+Deleting the AgentRuntime cascades to its children, so always delete the parent:
+
+> On the operator this demo targets (v0.7.0), deleting the child workload
+> (Sandbox/Deployment) while leaving the AgentRuntime puts the operator in a
+> reconcile error loop (`Failed to resolve targetRef ... not found`) every ~30s.
+> [operator#529](https://github.com/rossoctl/operator/pull/529) will make that
+> case degrade gracefully; until it ships, delete the parent AgentRuntime.
 
 ```bash
 kubectl delete agentruntime -n team1 \

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -168,24 +168,24 @@ Now the UI flow (order matches the actual import form top-to-bottom):
    > `kubectl apply -f authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml`)
    > and skip this expander. Same content, list-shaped `routes.yaml`.
 
-8. **Service Port** `8080` · **Target Port** `8000`.
-9. Under **Environment Variables**, click **Import from File/URL** → **From
-   URL**, paste one of the beginner agent's env files, and click
-   **Fetch & Parse**:
-   - OpenAI: `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.openai`
-   - Ollama: `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.ollama`
+8. **(Ollama only)** Expand **AuthBridge Advanced Configuration** and set
+   **Bypass AuthBridge on these outbound ports** to `11434`. OpenAI uses HTTPS
+   and needs no exclusion.
+9. **Service Port** `8080` · **Target Port** `8000`.
+10. Under **Environment Variables**, click **Import from File/URL** → **From
+    URL**, paste one of the beginner agent's env files, and click
+    **Fetch & Parse**:
+    - OpenAI: `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.openai`
+    - Ollama: `https://raw.githubusercontent.com/rossoctl/examples/refs/heads/main/a2a/weather_service/.env.ollama`
 
-   The OpenAI variant adds `LLM_API_KEY` and `OPENAI_API_KEY` as **Secret**
-   entries pointing at `openai-secret`.
+    The OpenAI variant adds `LLM_API_KEY` and `OPENAI_API_KEY` as **Secret**
+    entries pointing at `openai-secret`.
 
-   After import, **edit `MCP_URL`** in the variable list to point at the
-   advanced tool service:
-   ```text
-   MCP_URL=http://weather-tool-advanced-mcp:8000/mcp
-   ```
-10. **(Ollama only)** Expand **AuthBridge Advanced Configuration** and set
-    **Bypass AuthBridge on these outbound ports** to `11434`. OpenAI uses HTTPS
-    and needs no exclusion.
+    After import, **edit `MCP_URL`** in the variable list to point at the
+    advanced tool service:
+    ```text
+    MCP_URL=http://weather-tool-advanced-mcp:8000/mcp
+    ```
 11. Click **Build & Deploy Agent**.
 
 After the agent pod is **Ready**, re-run the Keycloak script so the agent's

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -14,19 +14,20 @@ turned on.
 | `authproxy-routes` | Not used | One outbound route, set in the UI |
 | Resource names | `weather-service`, `weather-tool` | `weather-service-advanced`, `weather-tool-advanced` |
 
-The advanced names live alongside the beginner names so both demos can run in
-the same namespace.
+The `-advanced` names live alongside the beginner names, so both demos can run
+in the same namespace. **Use them exactly** — the Keycloak script registers
+SPIFFE / audience scopes for the `-advanced` ServiceAccounts, so a wrong name
+breaks `MCP_URL`, the outbound route, and token-exchange audiences.
 
 ## Prerequisites
 
 - Beginner [demo-ui.md prerequisites](demo-ui.md#prerequisites) (Rossoctl UI
   reachable, an LLM provider).
 - In **`team1`**: installer-provided `authbridge-config`,
-  `authbridge-runtime-config`, `spiffe-helper-config`, `envoy-config`. No
-  extra Secrets or ConfigMaps are required up front. **No `keycloak-admin-secret`
-  is required in `team1` or `rossoctl-system`.** On the current operator (v0.7.0)
-  client registration uses the operator's own SPIFFE workload identity, not an
-  admin username/password Secret; a `NotFound` in **either** namespace is expected.
+  `authbridge-runtime-config`, `spiffe-helper-config`, `envoy-config`. No extra
+  Secrets or ConfigMaps up front — in particular **no `keycloak-admin-secret`**
+  in `team1` *or* `rossoctl-system` (v0.7.0 registers clients via the operator's
+  own SPIFFE identity, so a `NotFound` in either namespace is expected).
 - Python 3.10+ for the Keycloak setup script (Step 1).
 - For OpenAI: a `team1` Secret named `openai-secret` (created in Step 3).
 
@@ -51,39 +52,30 @@ python demos/weather-agent/setup_keycloak_weather_advanced.py \
   -n team1 --wait-tool-client
 ```
 
-> **Do not `kubectl port-forward` Keycloak on port 8080.** On a `localtest.me`
-> ingress setup, `keycloak.localtest.me:8080` is already reachable directly, and a
-> port-forward binding local `:8080` hijacks all `:8080` traffic — including the
-> Rossoctl UI at `rossoctl-ui.localtest.me:8080`, which will then redirect into the
-> Keycloak admin console. If you truly need a forward, use a different local port
-> and set `KEYCLOAK_URL` to match.
+> **Do not `kubectl port-forward` Keycloak on `:8080`.** `keycloak.localtest.me:8080`
+> is already reachable directly; a forward on local `:8080` hijacks the Rossoctl UI
+> (`rossoctl-ui.localtest.me:8080`) into the Keycloak admin console. If you must
+> forward, use another local port and set `KEYCLOAK_URL` to match.
 
-> **Timing:** `--wait-tool-client` blocks for ~5 minutes waiting for the tool's
-> SPIFFE client to register, then times out. Rather than race that window, the
-> simplest order is to **deploy the tool (Step 2) first**, then run this script —
-> it finds the tool client immediately. If it does time out, just re-run it after
-> the tool is up (the scopes/clients it created persist; the script is idempotent).
+> **Timing:** `--wait-tool-client` blocks ~5 min for the tool's SPIFFE client, then
+> times out. Simplest: **deploy the tool (Step 2) first**, then run this — it finds
+> the client immediately. On timeout, just re-run after the tool is up (idempotent).
 
 **Re-run the same command (without `--wait-tool-client`) after Step 3** so the
-agent client picks up the optional exchange scope. The script:
+agent client picks up the optional exchange scope.
 
-- Adds realm default scope `agent-team1-weather-service-advanced-aud` (puts the
-  agent SPIFFE in `aud` for UI / `alice` tokens).
-- Adds optional scope `weather-tool-exchange-aud` (puts the tool SPIFFE in
-  `aud` during token exchange).
-- Enables token exchange on both Keycloak clients.
-- Creates demo user `alice` (used by the optional CLI verify in Step 5).
+The script (idempotent) adds the default scope `agent-team1-weather-service-advanced-aud`
+(agent SPIFFE in `aud` for UI / `alice` tokens) and the optional scope
+`weather-tool-exchange-aud` (tool SPIFFE in `aud` during exchange), enables token
+exchange on both clients, and creates demo user `alice` (for the Step 5 CLI verify).
 
 ---
 
 ## Step 2: Import the Weather Tool via Rossoctl UI
 
-> ⚠️ **Use the `-advanced` names exactly.** **Tool Name** must be
-> `weather-tool-advanced` (not `weather-tool`). The Keycloak script in
-> Step 1 registered SPIFFE / audience scopes for the `-advanced`
-> ServiceAccount; if you import as `weather-tool`, the Service ends up as
-> `weather-tool-mcp` instead of `weather-tool-advanced-mcp` and the
-> `MCP_URL` + outbound route in Step 3 won't resolve.
+> ⚠️ **Tool Name** must be `weather-tool-advanced` exactly (see [naming](#how-this-differs-from-the-standard-demo)).
+> Import as `weather-tool` and the Service becomes `weather-tool-mcp`, so the
+> Step 3 `MCP_URL` + outbound route won't resolve.
 
 1. Open [Import Tool](http://rossoctl-ui.localtest.me:8080/tools/import).
 2. **Namespace**: `team1` · **Tool Name**: `weather-tool-advanced` (exact).
@@ -102,35 +94,26 @@ Wait for the tool pod to be **Ready**. Once it registers in Keycloak, the
 
 ```bash
 kubectl get pods -n team1 -l app.kubernetes.io/name=weather-tool-advanced
-# Expect 2/2 (mcp + authbridge-proxy) in proxy-sidecar mode.
-# No separate spiffe-helper container: the authbridge-proxy sidecar sources its
-# SPIRE credentials in-process (the spiffe.Provider mirrors the SVID to disk),
-# so the count is 2/2 rather than 3/3.
+# Expect 2/2 (mcp + authbridge-proxy). No separate spiffe-helper container —
+# authbridge-proxy sources its SPIRE credentials in-process — so it's 2/2, not 3/3.
 ```
 
 ---
 
 ## Step 3: Import the Weather Agent via Rossoctl UI
 
-(If you're using OpenAI, create the secret first — replace `<YOUR_OPENAI_API_KEY>`
-with your real key; the shell variable expansion shown is intentional and works
-only if you've already `export`ed it.)
+If you're using OpenAI, create the secret first (replace `<YOUR_OPENAI_API_KEY>`
+with your real key — an empty secret makes the agent fail with `Error: No LLM API
+key configured.`, see [Troubleshooting](#troubleshooting)):
 
 ```bash
 kubectl create secret generic openai-secret -n team1 \
   --from-literal=apikey="<YOUR_OPENAI_API_KEY>"
 ```
 
-> The UI agent import references `openai-secret` for both `LLM_API_KEY` and
-> `OPENAI_API_KEY`. If the secret is empty (e.g. `$OPENAI_API_KEY` wasn't
-> exported), the agent fails with `Error: No LLM API key configured.` — see
-> [Troubleshooting](#troubleshooting).
-
-> ⚠️ **Use the `-advanced` name exactly.** **Agent Name** must be
-> `weather-service-advanced` (not `weather-service`). The Keycloak script
-> in Step 1 registered SPIFFE / audience scopes for the `-advanced`
-> ServiceAccount; the wrong name lands you with mismatched audiences and
-> a 401/503 from token exchange.
+> ⚠️ **Agent Name** must be `weather-service-advanced` exactly (see
+> [naming](#how-this-differs-from-the-standard-demo)); a wrong name gives
+> mismatched audiences and a 401/503 from token exchange.
 
 Now the UI flow (order matches the actual import form top-to-bottom):
 
@@ -199,28 +182,23 @@ python demos/weather-agent/setup_keycloak_weather_advanced.py -n team1
 
 ## Step 4: Chat via Rossoctl UI
 
-> **Expected catalog quirk.** The **Agent Catalog** shows **two** entries:
-> `weather-service-advanced` *and* `weather-tool-advanced`. The **Tool
-> Catalog** is empty. This is by design — the tool's AgentRuntime CR
-> uses `type: agent` so the operator applies `rossoctl.io/type=agent`
-> and AuthBridge gets injected (the `injectTools` feature gate is off
-> by default; see the [kubectl appendix](#operator-gotchas)). Pick
+> **Expected catalog quirk.** The **Agent Catalog** shows **two** entries
+> (`weather-service-advanced` *and* `weather-tool-advanced`) and the **Tool
+> Catalog** is empty — by design, because the tool's AgentRuntime uses
+> `type: agent` (see [Operator gotchas](#operator-gotchas)). Pick
 > `weather-service-advanced` for chat.
 
 1. **Agent Catalog** → namespace `team1` → `weather-service-advanced` →
    **View Details**. The agent card should render (proves the agent is up and
    `/.well-known/*` is bypassed).
 2. In the **Chat** panel, ask: *"What is the weather in New York?"*
-3. The response should be live weather. Behind the scenes:
-   - UI's JWT (audience `agent-...-advanced-aud`) hits the agent's AuthBridge
-     ingress.
-   - AuthBridge on the agent matches the outbound route, exchanges for a token
-     with `aud = weather-tool-advanced` SPIFFE.
-   - AuthBridge on the tool validates that JWT before MCP sees it.
+3. The response should be live weather. Behind the scenes: the UI's JWT hits the
+   agent's AuthBridge ingress → the agent matches the outbound route and exchanges
+   for a token with `aud = weather-tool-advanced` SPIFFE → the tool's AuthBridge
+   validates that JWT before MCP sees it.
 
-If chat returns `Connection error` or `No LLM API key configured`, see
-[Troubleshooting](#troubleshooting) — those are LLM-side failures, not
-AuthBridge failures.
+`Connection error` or `No LLM API key configured` are LLM-side failures, not
+AuthBridge — see [Troubleshooting](#troubleshooting).
 
 ---
 
@@ -247,30 +225,19 @@ is the usual choice — the bare command re-applies the manifests, which the
 idempotent; if the run aborts with `verify pod produced no MCP_HTTP_CODE line`,
 just re-run it (see [Troubleshooting](#troubleshooting)).
 
-What it does:
+What it does: password-grants `alice`, token-exchanges to the tool SPIFFE audience
+(scope `openid weather-tool-exchange-aud`), then `POST /mcp` **with** the exchanged
+token → expects **2xx** (JWT accepted, `initialize` completes) and **without** an
+`Authorization` header → expects **401** (AuthBridge rejects before MCP). It sends
+`Accept: application/json, text/event-stream` so streamable HTTP doesn't return 406.
 
-1. Password-grants `alice` against the `weather-advanced-e2e` Keycloak client.
-2. Token-exchanges to the tool SPIFFE audience with scope
-   `openid weather-tool-exchange-aud`.
-3. `POST /mcp` with the exchanged token → expects **2xx** (JWT accepted, MCP
-   `initialize` handshake completes). Sends
-   `Accept: application/json, text/event-stream` so streamable HTTP doesn't
-   return 406.
-4. Repeats `POST /mcp` **without** an `Authorization` header → expects **401**
-   (AuthBridge rejects before MCP runs).
+> **It does NOT call the LLM** — so it can pass while UI chat still returns
+> `Connection error` (see Troubleshooting).
 
-> **`deploy_and_verify_advanced.sh` does NOT call the LLM.** It can succeed
-> while UI chat still returns `Connection error` — see Troubleshooting.
-
-Useful env knobs:
-
-| Variable | Purpose |
-|----------|---------|
-| `NAMESPACE` | Default `team1` |
-| `SKIP_DEPLOY=1` | Verify only, skip the apply step (resources must exist — the default after Steps 2–3) |
-| `KC_INTERNAL` | Keycloak base URL inside the cluster (default `keycloak-service.keycloak.svc:8080`) |
-| `KC_USER_CLIENT_ID` | Public client for password grant (default `weather-advanced-e2e`) |
-| `KEYCLOAK_ADMIN_USERNAME` / `KEYCLOAK_ADMIN_PASSWORD` | Admin REST credentials |
+Env knobs: `SKIP_DEPLOY=1` (verify only — the default after Steps 2–3) and
+`NAMESPACE` (default `team1`) are the common ones. Advanced overrides —
+`KC_INTERNAL`, `KC_USER_CLIENT_ID`, `KEYCLOAK_ADMIN_USERNAME` /
+`KEYCLOAK_ADMIN_PASSWORD` — are documented in the script header.
 
 ---
 
@@ -287,21 +254,19 @@ Useful env knobs:
 | `invalid_scope` / `503` from agent | Optional exchange scope not on agent client | Re-run `setup_keycloak_weather_advanced.py -n team1` **after** the agent is running. |
 | Token exchange denied | Tool client missing `standard.token.exchange.enabled` | Re-run setup with `--wait-tool-client` after the tool pod registers. |
 | Tool pod CrashLoopBackOff (`mcp` container) | The `weather_tool` image runs as UID 1001; a `securityContext` overriding the user breaks `uv run` | Use the manifests in `k8s/` as-is (they set `runAsUser/Group/fsGroup: 1001`). On OpenShift, see the [upstream Dockerfile](https://github.com/rossoctl/examples/blob/main/mcp/weather_tool/Dockerfile). |
-| Tool ingress logs missing `[Inbound]` | Combined sidecar uses different log text | Grep for `Token validated` instead, or increase log window. |
+| Tool ingress logs missing `[Inbound]` | The `authbridge-proxy` sidecar uses different log text | Grep for `Token validated` instead, or widen the log window. |
 | Deleted the agent or tool, but the Deployment + Service reappear within seconds | The Rossoctl backend's reconciliation service finalizes "orphaned" Shipwright builds by re-creating workloads | Also delete the Shipwright `Build` and `BuildRun` (see the [Cleanup](#cleanup) snippet). |
 | Chat returns `Cannot connect to MCP weather service at http://weather-tool-advanced-mcp:8000/mcp` | UI import used the standard names (`weather-tool` / `weather-service`) instead of `-advanced`, so the actual Service is `weather-tool-mcp` and `MCP_URL` doesn't resolve | Re-import using the exact `-advanced` names. The Keycloak script from Step 1 also expects those names. |
 
-Tool ingress and agent outbound logs (container name varies by AuthBridge mode
-— `authbridge-proxy` for proxy-sidecar default, `envoy-proxy` for envoy-sidecar):
-
-The tool is a **Deployment**, so `deploy/...` works for it. The agent is a
-**Sandbox** (bare pod, no Deployment) — resolve its pod name via label selector:
+AuthBridge logs (sidecar is `authbridge-proxy` in the default mode, `envoy-proxy`
+in envoy-sidecar). The tool is a **Deployment** (`deploy/...` works); the agent is
+a **Sandbox**, so resolve its pod name first:
 
 ```bash
-# Tool ingress (Deployment):
+# Tool ingress:
 kubectl logs deploy/weather-tool-advanced -n team1 -c authbridge-proxy 2>&1 | grep -E "Inbound|Token validated"
 
-# Agent outbound (Sandbox — resolve the pod name first):
+# Agent outbound (Sandbox):
 AGENT_POD=$(kubectl get pod -n team1 -l app.kubernetes.io/name=weather-service-advanced \
   -o jsonpath='{.items[0].metadata.name}')
 kubectl logs "$AGENT_POD" -n team1 -c authbridge-proxy 2>&1 | grep -E "Resolver|exchange|Injecting token"
@@ -383,9 +348,9 @@ kubectl patch deploy weather-service-advanced -n team1 --type=json -p='[
 ]'
 ```
 
-(The `LLM_API_KEY-` clears the literal `"ollama"` value from the manifest;
-the `patch` re-adds it as a secret reference. Without the clear, both
-definitions exist and the secret wins, but it's noisy in `kubectl describe`.)
+(The `LLM_API_KEY-` clears the manifest's literal `"ollama"` value before the
+`patch` re-adds it as a secret reference — otherwise both exist, and while the
+secret wins it's noisy in `kubectl describe`.)
 
 ### Operator gotchas
 

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -103,8 +103,9 @@ Wait for the tool pod to be **Ready**. Once it registers in Keycloak, the
 ```bash
 kubectl get pods -n team1 -l app.kubernetes.io/name=weather-tool-advanced
 # Expect 2/2 (mcp + authbridge-proxy) in proxy-sidecar mode.
-# spiffe-helper is bundled inside the combined AuthBridge image, not a separate
-# container, so the count is 2/2 rather than 3/3.
+# No separate spiffe-helper container: the authbridge-proxy sidecar sources its
+# SPIRE credentials in-process (the spiffe.Provider mirrors the SVID to disk),
+# so the count is 2/2 rather than 3/3.
 ```
 
 ---
@@ -266,10 +267,11 @@ Useful env knobs:
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | UI returns `Error: LLM execution failed: Connection error.` | Agent can't reach its LLM. Ollama not running, or **Bypass AuthBridge on these outbound ports** not set to `11434`. `deploy_and_verify_advanced.sh` doesn't catch this — it never calls the LLM. | Start Ollama (`ollama serve` + `ollama pull llama3.2:3b-instruct-fp16`), or re-import with the OpenAI `.env` URL. |
-| UI returns `Error: No LLM API key configured. Set the LLM_API_KEY environment variable.` | `openai-secret` is empty (often because `$OPENAI_API_KEY` wasn't exported when you ran `kubectl create secret`), or the agent wasn't restarted after fixing it. | Recreate with the literal value, then verify `kubectl get secret openai-secret -n team1 -o jsonpath='{.data.apikey}' \| base64 -d \| wc -c` is non-zero, then `kubectl rollout restart deploy/weather-service-advanced -n team1`. |
+| UI returns `Error: No LLM API key configured. Set the LLM_API_KEY environment variable.` | `openai-secret` is empty (often because `$OPENAI_API_KEY` wasn't exported when you ran `kubectl create secret`), or the agent wasn't restarted after fixing it. | Recreate with the literal value, then verify `kubectl get secret openai-secret -n team1 -o jsonpath='{.data.apikey}' \| base64 -d \| wc -c` is non-zero. The agent runs as a **Sandbox** (bare pod, no Deployment), so `kubectl rollout restart deploy/...` fails; restart by deleting the pod — the `Sandbox` CR recreates it: `kubectl delete pod -n team1 -l app.kubernetes.io/name=weather-service-advanced`. |
 | UI: **Outbound Routing Rules** expander missing | Rossoctl backend pre-dates [rossoctl#1194](https://github.com/rossoctl/rossoctl/pull/1194) | `kubectl apply -f authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml` and skip the UI step. |
 | UI: agent card not available | AuthBridge failed to load `authproxy-routes` (invalid YAML shape) | See the same section in the [GitHub Issue UI demo](../github-issue/demo-ui.md#agent-card-not-available-in-the-ui). |
 | `401` on tool MCP from CLI verify | Wrong `target_audience` or scope mapper | `target_audience` must equal the tool SPIFFE; scope `weather-tool-exchange-aud` must map that audience. Re-run `setup_keycloak_weather_advanced.py`. |
+| CLI verify aborts with `ERROR: verify pod produced no MCP_HTTP_CODE line` | Transient: the ephemeral `netshoot` verify pod was torn down (`--rm`) before it printed a result — a slow first-run pod start, not an auth failure. Its stderr is lost, so the message looks alarming. | Just re-run the script — it's idempotent. To see the pod's own diagnostics on a genuine failure, capture stderr too: `SKIP_DEPLOY=1 ./...deploy_and_verify_advanced.sh 2>&1 \| tee /tmp/v.log`. |
 | `invalid_scope` / `503` from agent | Optional exchange scope not on agent client | Re-run `setup_keycloak_weather_advanced.py -n team1` **after** the agent is running. |
 | Token exchange denied | Tool client missing `standard.token.exchange.enabled` | Re-run setup with `--wait-tool-client` after the tool pod registers. |
 | Tool pod CrashLoopBackOff (`mcp` container) | The `weather_tool` image runs as UID 1001; a `securityContext` overriding the user breaks `uv run` | Use the manifests in `k8s/` as-is (they set `runAsUser/Group/fsGroup: 1001`). On OpenShift, see the [upstream Dockerfile](https://github.com/rossoctl/examples/blob/main/mcp/weather_tool/Dockerfile). |
@@ -280,9 +282,17 @@ Useful env knobs:
 Tool ingress and agent outbound logs (container name varies by AuthBridge mode
 — `authbridge-proxy` for proxy-sidecar default, `envoy-proxy` for envoy-sidecar):
 
+The tool is a **Deployment**, so `deploy/...` works for it. The agent is a
+**Sandbox** (bare pod, no Deployment) — resolve its pod name via label selector:
+
 ```bash
+# Tool ingress (Deployment):
 kubectl logs deploy/weather-tool-advanced -n team1 -c authbridge-proxy 2>&1 | grep -E "Inbound|Token validated"
-kubectl logs deploy/weather-service-advanced -n team1 -c authbridge-proxy 2>&1 | grep -E "Resolver|exchange|Injecting token"
+
+# Agent outbound (Sandbox — resolve the pod name first):
+AGENT_POD=$(kubectl get pod -n team1 -l app.kubernetes.io/name=weather-service-advanced \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs "$AGENT_POD" -n team1 -c authbridge-proxy 2>&1 | grep -E "Resolver|exchange|Injecting token"
 ```
 
 ---

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -23,12 +23,10 @@ the same namespace.
   reachable, an LLM provider).
 - In **`team1`**: installer-provided `authbridge-config`,
   `authbridge-runtime-config`, `spiffe-helper-config`, `envoy-config`. No
-  extra Secrets or ConfigMaps are required up front. **`keycloak-admin-secret`
-  is not in `team1`.** Operator 0.2+ keeps it in **`rossoctl-system`** for
-  client registration; `NotFound` in `team1` is expected:
-  ```bash
-  kubectl get secret keycloak-admin-secret -n rossoctl-system
-  ```
+  extra Secrets or ConfigMaps are required up front. **No `keycloak-admin-secret`
+  is required in `team1` or `rossoctl-system`.** On the current operator (v0.7.0)
+  client registration uses the operator's own SPIFFE workload identity, not an
+  admin username/password Secret; a `NotFound` in **either** namespace is expected.
 - Python 3.10+ for the Keycloak setup script (Step 1).
 - For OpenAI: a `team1` Secret named `openai-secret` (created in Step 3).
 
@@ -49,16 +47,25 @@ cd authbridge
 python -m venv venv && source venv/bin/activate
 pip install -r requirements.txt
 
-# Port-forward Keycloak if your shell can't reach keycloak.localtest.me directly
-kubectl port-forward -n keycloak svc/keycloak-service 8080:8080 &
-
 python demos/weather-agent/setup_keycloak_weather_advanced.py \
   -n team1 --wait-tool-client
 ```
 
-`--wait-tool-client` blocks until the tool pod (Step 2) registers its SPIFFE
-client. **Re-run the same command after Step 3** so the agent client picks up
-the optional exchange scope. The script:
+> **Do not `kubectl port-forward` Keycloak on port 8080.** On a `localtest.me`
+> ingress setup, `keycloak.localtest.me:8080` is already reachable directly, and a
+> port-forward binding local `:8080` hijacks all `:8080` traffic — including the
+> Rossoctl UI at `rossoctl-ui.localtest.me:8080`, which will then redirect into the
+> Keycloak admin console. If you truly need a forward, use a different local port
+> and set `KEYCLOAK_URL` to match.
+
+> **Timing:** `--wait-tool-client` blocks for ~5 minutes waiting for the tool's
+> SPIFFE client to register, then times out. Rather than race that window, the
+> simplest order is to **deploy the tool (Step 2) first**, then run this script —
+> it finds the tool client immediately. If it does time out, just re-run it after
+> the tool is up (the scopes/clients it created persist; the script is idempotent).
+
+**Re-run the same command (without `--wait-tool-client`) after Step 3** so the
+agent client picks up the optional exchange scope. The script:
 
 - Adds realm default scope `agent-team1-weather-service-advanced-aud` (puts the
   agent SPIFFE in `aud` for UI / `alice` tokens).
@@ -95,7 +102,9 @@ Wait for the tool pod to be **Ready**. Once it registers in Keycloak, the
 
 ```bash
 kubectl get pods -n team1 -l app.kubernetes.io/name=weather-tool-advanced
-# Expect 3/3 (mcp + authbridge-proxy + spiffe-helper) in proxy-sidecar mode
+# Expect 2/2 (mcp + authbridge-proxy) in proxy-sidecar mode.
+# spiffe-helper is bundled inside the combined AuthBridge image, not a separate
+# container, so the count is 2/2 rather than 3/3.
 ```
 
 ---
@@ -131,17 +140,26 @@ Now the UI flow (order matches the actual import form top-to-bottom):
    - Git Branch or Tag: `main`
    - Select Agent: `Weather Service Agent`
    - Source Subfolder: `a2a/weather_service`
-4. **Protocol**: `A2A` · **Workload Type**: `Deployment`.
+4. **Protocol**: `A2A` · **Workload Type**: leave the default `Sandbox`.
+
+   > ⚠️ **Do not select `Deployment` for the agent.** Choosing `Deployment`
+   > currently fails: the source build succeeds but the workload create is
+   > rejected by the `agent-label-protection` admission policy (the
+   > `rossoctl.io/type` label may only be set by the operator via an
+   > AgentRuntime CR), so **no agent pod and no AgentRuntime are created**.
+   > The `Sandbox` default goes through the operator and works. The agent
+   > then runs as a bare pod owned by a `Sandbox` CR — verify/exec commands
+   > below use label selectors rather than `deploy/...`.
 5. **Secure with AuthBridge**: ✅ (default).
 6. **Enable SPIRE identity (JWT-SVID via spiffe-helper)**: ✅ (default).
-7. Expand **Outbound Routing Rules** and add one route — this is what
-   triggers the RFC 8693 exchange when the agent calls the tool. The form
-   has three fields (currently unlabeled in the UI); fill them in this
-   order:
+7. Expand **Outbound OIDC token exchange rules** and add one route — this is
+   what triggers the RFC 8693 exchange when the agent calls the tool. The
+   table has three columns; after you add the route the header should read
+   **(1 route)**:
 
-   1. Host: `weather-tool-advanced-mcp`
-   2. Target Audience: `spiffe://localtest.me/ns/team1/sa/weather-tool-advanced`
-   3. Token Scopes: `openid weather-tool-exchange-aud`
+   - **Host Pattern**: `weather-tool-advanced-mcp`
+   - **Target OIDC Audience**: `spiffe://localtest.me/ns/team1/sa/weather-tool-advanced`
+   - **OIDC Token Scopes**: `openid weather-tool-exchange-aud`
 
    > If **Outbound Routing Rules** is missing or unresponsive, your Rossoctl
    > backend may pre-date [rossoctl#1194](https://github.com/rossoctl/rossoctl/pull/1194).
@@ -271,17 +289,21 @@ kubectl logs deploy/weather-service-advanced -n team1 -c authbridge-proxy 2>&1 |
 
 ## Cleanup
 
-Delete via the Rossoctl UI (Tool Catalog / Agent Catalog), or via CLI:
+Delete via the Rossoctl UI (Tool Catalog / Agent Catalog), or via CLI.
+
+**Delete the `AgentRuntime` CRs — they are the parent resource.** The agent runs
+as a `Sandbox` and the tool as a `Deployment`, both owned by an AgentRuntime. If
+you delete the child workload (Sandbox/Deployment) but leave the AgentRuntime, the
+operator enters a reconcile error loop (`Failed to resolve targetRef ... not
+found`) every ~30s. Deleting the AgentRuntime cascades to its children:
 
 ```bash
-kubectl delete deployment,svc,sa -n team1 \
-  -l app.kubernetes.io/name=weather-service-advanced --ignore-not-found
-kubectl delete deployment,svc,sa -n team1 \
-  -l app.kubernetes.io/name=weather-tool-advanced --ignore-not-found
+kubectl delete agentruntime -n team1 \
+  weather-service-advanced weather-tool-advanced --ignore-not-found
 
 # Also delete the Shipwright Build/BuildRun, otherwise the Rossoctl
 # backend's reconciliation service treats them as "orphaned" and
-# recreates the Deployment + Service + ServiceAccount within seconds:
+# recreates the workload within seconds:
 kubectl delete build.shipwright.io,buildrun.shipwright.io -n team1 \
   -l app.kubernetes.io/name=weather-service-advanced --ignore-not-found
 kubectl delete build.shipwright.io,buildrun.shipwright.io -n team1 \

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -124,16 +124,10 @@ Now the UI flow (order matches the actual import form top-to-bottom):
    - Git Branch or Tag: `main`
    - Select Agent: `Weather Service Agent`
    - Source Subfolder: `a2a/weather_service`
-4. **Protocol**: `A2A` · **Workload Type**: leave the default `Sandbox`.
-
-   > ⚠️ **Do not select `Deployment` for the agent.** Choosing `Deployment`
-   > currently fails: the source build succeeds but the workload create is
-   > rejected by the `agent-label-protection` admission policy (the
-   > `rossoctl.io/type` label may only be set by the operator via an
-   > AgentRuntime CR), so **no agent pod and no AgentRuntime are created**.
-   > The `Sandbox` default goes through the operator and works. The agent
-   > then runs as a bare pod owned by a `Sandbox` CR — verify/exec commands
-   > below use label selectors rather than `deploy/...`.
+4. **Protocol**: `A2A` · **Workload Type**: leave the default `Sandbox`. The
+   agent then runs as a bare pod owned by a `Sandbox` CR (not a Deployment), so
+   the verify/exec commands below resolve it via label selector rather than
+   `deploy/...`.
 5. **Secure with AuthBridge**: ✅ (default).
 6. **Enable SPIRE identity (JWT-SVID via spiffe-helper)**: ✅ (default).
 7. Expand **Outbound OIDC token exchange rules** and add one route — this is

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -231,9 +231,21 @@ end-to-end **without an LLM**. It's the right tool to confirm token exchange
 and ingress validation when you want to isolate AuthBridge from agent-side
 issues.
 
+Pick the invocation based on the current cluster state:
+
 ```bash
+# You got here via Steps 2–3 (tool + agent already deployed): verify only.
+SKIP_DEPLOY=1 ./authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
+
+# Starting from scratch / CLI-only (nothing deployed yet): deploy, then verify.
 ./authbridge/demos/weather-agent/deploy_and_verify_advanced.sh
 ```
+
+Most readers reach this step **after** deploying via the UI, so `SKIP_DEPLOY=1`
+is the usual choice — the bare command re-applies the manifests, which the
+[kubectl-only appendix](#appendix-kubectl-only-path) path uses. Both are
+idempotent; if the run aborts with `verify pod produced no MCP_HTTP_CODE line`,
+just re-run it (see [Troubleshooting](#troubleshooting)).
 
 What it does:
 
@@ -255,7 +267,7 @@ Useful env knobs:
 | Variable | Purpose |
 |----------|---------|
 | `NAMESPACE` | Default `team1` |
-| `SKIP_DEPLOY=1` | Verify only, skip the apply step (resources must exist) |
+| `SKIP_DEPLOY=1` | Verify only, skip the apply step (resources must exist — the default after Steps 2–3) |
 | `KC_INTERNAL` | Keycloak base URL inside the cluster (default `keycloak-service.keycloak.svc:8080`) |
 | `KC_USER_CLIENT_ID` | Public client for password grant (default `weather-advanced-e2e`) |
 | `KEYCLOAK_ADMIN_USERNAME` / `KEYCLOAK_ADMIN_PASSWORD` | Admin REST credentials |

--- a/authbridge/demos/weather-agent/demo-ui-advanced.md
+++ b/authbridge/demos/weather-agent/demo-ui-advanced.md
@@ -56,7 +56,7 @@ python demos/weather-agent/setup_keycloak_weather_advanced.py \
 > is already reachable directly; a forward on local `:8080` hijacks the Rossoctl UI
 > (`rossoctl-ui.localtest.me:8080`) into the Keycloak admin console. If you must
 > forward, use another local port and set `KEYCLOAK_URL` to match.
-
+>
 > **Timing:** `--wait-tool-client` blocks ~5 min for the tool's SPIFFE client, then
 > times out. Simplest: **deploy the tool (Step 2) first**, then run this — it finds
 > the client immediately. On timeout, just re-run after the tool is up (idempotent).
@@ -110,6 +110,9 @@ key configured.`, see [Troubleshooting](#troubleshooting)):
 kubectl create secret generic openai-secret -n team1 \
   --from-literal=apikey="<YOUR_OPENAI_API_KEY>"
 ```
+
+`--from-literal` is fine for a local demo but records the key in shell history;
+for shared clusters, prefer `--from-file` or your secret manager.
 
 > ⚠️ **Agent Name** must be `weather-service-advanced` exactly (see
 > [naming](#how-this-differs-from-the-standard-demo)); a wrong name gives
@@ -203,7 +206,9 @@ end-to-end **without an LLM**. It's the right tool to confirm token exchange
 and ingress validation when you want to isolate AuthBridge from agent-side
 issues.
 
-Pick the invocation based on the current cluster state:
+Run these **from the repository root** (if you're still in `authbridge/` from
+Step 1, `cd ..` first — the paths below are repo-root-relative). Pick the
+invocation based on the current cluster state:
 
 ```bash
 # You got here via Steps 2–3 (tool + agent already deployed): verify only.
@@ -240,11 +245,11 @@ Env knobs: `SKIP_DEPLOY=1` (verify only — the default after Steps 2–3) and
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | UI returns `Error: LLM execution failed: Connection error.` | Agent can't reach its LLM. Ollama not running, or **Bypass AuthBridge on these outbound ports** not set to `11434`. `deploy_and_verify_advanced.sh` doesn't catch this — it never calls the LLM. | Start Ollama (`ollama serve` + `ollama pull llama3.2:3b-instruct-fp16`), or re-import with the OpenAI `.env` URL. |
-| UI returns `Error: No LLM API key configured. Set the LLM_API_KEY environment variable.` | `openai-secret` is empty (often because `$OPENAI_API_KEY` wasn't exported when you ran `kubectl create secret`), or the agent wasn't restarted after fixing it. | Recreate with the literal value, then verify `kubectl get secret openai-secret -n team1 -o jsonpath='{.data.apikey}' \| base64 -d \| wc -c` is non-zero. The agent runs as a **Sandbox** (bare pod, no Deployment), so `kubectl rollout restart deploy/...` fails; restart by deleting the pod — the `Sandbox` CR recreates it: `kubectl delete pod -n team1 -l app.kubernetes.io/name=weather-service-advanced`. |
+| UI returns `Error: No LLM API key configured. Set the LLM_API_KEY environment variable.` | `openai-secret` is empty (often because `$OPENAI_API_KEY` wasn't exported when you ran `kubectl create secret`), or the agent wasn't restarted after fixing it. | Recreate with the literal value, then verify `kubectl get secret openai-secret -n team1 -o jsonpath='{.data.apikey}' \| base64 -d \| wc -c` is non-zero. The UI path runs the agent as a **Sandbox** (bare pod, no Deployment), so `kubectl rollout restart deploy/...` fails; restart by deleting the pod — the `Sandbox` CR recreates it: `kubectl delete pod -n team1 -l app.kubernetes.io/name=weather-service-advanced`. (The [kubectl-only appendix](#appendix-kubectl-only-path) creates a real Deployment instead, where `kubectl rollout restart deploy/weather-service-advanced -n team1` is correct.) |
 | UI: **Outbound Routing Rules** expander missing | Rossoctl backend pre-dates [rossoctl#1194](https://github.com/rossoctl/rossoctl/pull/1194) | `kubectl apply -f authbridge/demos/weather-agent/k8s/configmaps-advanced.yaml` and skip the UI step. |
 | UI: agent card not available | AuthBridge failed to load `authproxy-routes` (invalid YAML shape) | See the same section in the [GitHub Issue UI demo](../github-issue/demo-ui.md#agent-card-not-available-in-the-ui). |
 | `401` on tool MCP from CLI verify | Wrong `target_audience` or scope mapper | `target_audience` must equal the tool SPIFFE; scope `weather-tool-exchange-aud` must map that audience. Re-run `setup_keycloak_weather_advanced.py`. |
-| CLI verify aborts with `ERROR: verify pod produced no MCP_HTTP_CODE line` | Transient: the ephemeral `netshoot` verify pod was torn down (`--rm`) before it printed a result — a slow first-run pod start, not an auth failure. Its stderr is lost, so the message looks alarming. | Just re-run the script — it's idempotent. To see the pod's own diagnostics on a genuine failure, capture stderr too: `SKIP_DEPLOY=1 ./...deploy_and_verify_advanced.sh 2>&1 \| tee /tmp/v.log`. |
+| CLI verify aborts with `ERROR: verify pod produced no MCP_HTTP_CODE line` | Transient: the ephemeral `netshoot` verify pod was torn down (`--rm`) before it printed a result — a slow first-run pod start, not an auth failure. Its stderr is lost, so the message looks alarming. | Just re-run the script — it's idempotent. To see the pod's own diagnostics on a genuine failure, capture stderr too: `SKIP_DEPLOY=1 ./authbridge/demos/weather-agent/deploy_and_verify_advanced.sh 2>&1 \| tee /tmp/v.log`. |
 | `invalid_scope` / `503` from agent | Optional exchange scope not on agent client | Re-run `setup_keycloak_weather_advanced.py -n team1` **after** the agent is running. |
 | Token exchange denied | Tool client missing `standard.token.exchange.enabled` | Re-run setup with `--wait-tool-client` after the tool pod registers. |
 | Tool pod CrashLoopBackOff (`mcp` container) | The `weather_tool` image runs as UID 1001; a `securityContext` overriding the user breaks `uv run` | Use the manifests in `k8s/` as-is (they set `runAsUser/Group/fsGroup: 1001`). On OpenShift, see the [upstream Dockerfile](https://github.com/rossoctl/examples/blob/main/mcp/weather_tool/Dockerfile). |


### PR DESCRIPTION
## Summary

Corrections to the **advanced** weather-agent demo (`authbridge/demos/weather-agent/demo-ui-advanced.md`), found while running it end-to-end on Kind/macOS.

**Update:** the demo is now **verified end-to-end** — no longer a partial run. ✅ Successfully tested on Kind (macOS, operator v0.7.0), both the CLI verify and the UI chat.

- **CLI verify** (`deploy_and_verify_advanced.sh`, SKIP_DEPLOY=1): `alice` password grant → RFC 8693 exchange to the tool's SPIFFE audience → tool AuthBridge validated the JWT (MCP `initialize` → **200**), unauthenticated negative check → **401**. Agent `authbridge-proxy` logs show the outbound exchange.
- **UI chat** (full stack incl. LLM): logged in as `alice`, Agent Catalog → `weather-service-advanced` → Chat → *"What is the weather in New York?"* → live weather answer. This exercises the complete path the CLI verify does not: UI JWT → agent AuthBridge → RFC 8693 exchange → tool AuthBridge → MCP → LLM.

## Confirmed fixes

- **Workload Type — leave the default `Sandbox`.** The agent runs as a bare pod owned by a `Sandbox` CR (not a Deployment), which is why the verify/exec commands use label selectors rather than `deploy/...`.
- **Prerequisites:** no `keycloak-admin-secret` is required in `team1` **or** `rossoctl-system` on operator v0.7.0 (SPIFFE-identity based). Dropped the stale `rossoctl-system` check.
- **Keycloak Step 1:** do **not** `kubectl port-forward` Keycloak on `:8080` — on a `localtest.me` ingress it hijacks the Rossoctl UI (redirects into the Keycloak admin console). Deploy the tool **first** to avoid the `--wait-tool-client` 300s timeout race; the script is idempotent.
- **Tool pod is 2/2** (mcp + authbridge-proxy), not 3/3. Corrected the reason: there is no bundled `spiffe-helper` container — the `authbridge-proxy` sidecar sources its SPIRE credentials in-process via the `spiffe.Provider`.
- **Step 3 order** now matches the current import form (AuthBridge Advanced Configuration / bypass ports sits directly after the Outbound OIDC rules, above Service Port and Env Vars).
- **Outbound route control** is labeled **Outbound OIDC token exchange rules** with columns **Host Pattern / Target OIDC Audience / OIDC Token Scopes**, and shows a live route count.
- **Cleanup:** delete the **AgentRuntime CRs** (the parents). Deleting only the child Sandbox/Deployment leaves the operator in a ~30s reconcile error loop.

## Fixes from the verified E2E run

- **Sandbox vs Deployment in Step 5 / Troubleshooting.** The agent runs as a **Sandbox** (bare pod), so `kubectl rollout restart deploy/weather-service-advanced` and `kubectl logs deploy/weather-service-advanced` fail. Converted the agent commands to label-selector pod resolution; the **tool** stays `deploy/...` (it *is* a Deployment). Restart the agent by deleting its pod — the Sandbox CR recreates it.
- **New Troubleshooting row** for the transient `ERROR: verify pod produced no MCP_HTTP_CODE line`: the ephemeral `netshoot` verify pod is torn down (`--rm`) before printing on a slow first start — not an auth failure. Re-run (idempotent); capture stderr (`2>&1 | tee`) to see real failures.

## Still deferred (out of scope for this PR)

- The **kubectl-only appendix** is left as-is. Its raw manifests create a real *Deployment* (so its `deploy/...` commands are correct for that path), but it was not exercised this run.

Pairs with #818 (basic demo fixes). Related product bugs filed separately.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the advanced Weather Agent UI guide with current deployment and setup steps.
  - Clarified direct Keycloak access, Sandbox-based agents, credential configuration, and outbound OIDC token exchange.
  - Added guidance for naming conventions, OpenAI secrets, catalog behavior, CLI verification, and AuthBridge logs.
  - Expanded troubleshooting for Sandbox cleanup, transient verification failures, and deployment-specific issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->