### PR TITLE
Fix: Set content-length on ext_proc body mutations

### DIFF
--- a/authbridge/authlib/listener/extproc/server.go
+++ b/authbridge/authlib/listener/extproc/server.go
@@ -669,6 +669,9 @@ func (s *Server) handleResponseBody(ctx context.Context, body []byte, pctx *pipe
 			Response: &extprocv3.ProcessingResponse_ResponseBody{
 				ResponseBody: &extprocv3.BodyResponse{
 					Response: &extprocv3.CommonResponse{
+						HeaderMutation: &extprocv3.HeaderMutation{
+							SetHeaders: []*corev3.HeaderValueOption{contentLength(pctx.ResponseBody)},
+						},
 						BodyMutation: &extprocv3.BodyMutation{
 							Mutation: &extprocv3.BodyMutation_Body{
 								Body: pctx.ResponseBody,
@@ -840,8 +843,9 @@ func passBodyResponse() *extprocv3.ProcessingResponse {
 
 // withBodyMutation optionally decorates a RequestBody ProcessingResponse
 // with an ext_proc BodyMutation when the pipeline rewrote pctx.Body.
-// Envoy replaces the buffered body with the new bytes and recomputes
-// Content-Length for the upstream. We also clear content-encoding
+// Envoy replaces the buffered body with the new bytes but, in BUFFERED +
+// SEND mode, leaves content-length to the processor (processing_mode.proto,
+// BodySendMode) and rejects a mismatch. We also clear content-encoding
 // because the plugin may have decompressed + rewritten in plaintext;
 // shipping plain bytes without the old encoding header is safer than
 // shipping a malformed archive.
@@ -867,7 +871,14 @@ func withBodyMutation(resp *extprocv3.ProcessingResponse, pctx *pipeline.Context
 		cr.HeaderMutation = &extprocv3.HeaderMutation{}
 	}
 	cr.HeaderMutation.RemoveHeaders = append(cr.HeaderMutation.RemoveHeaders, "content-encoding")
+	cr.HeaderMutation.SetHeaders = append(cr.HeaderMutation.SetHeaders, contentLength(pctx.Body))
 	return resp
+}
+
+// contentLength is the SetHeaders entry a body-mutation reply must carry in
+// BUFFERED + SEND mode (processing_mode.proto, BodySendMode).
+func contentLength(body []byte) *corev3.HeaderValueOption {
+	return &corev3.HeaderValueOption{Header: &corev3.HeaderValue{Key: "content-length", RawValue: []byte(strconv.Itoa(len(body)))}}
 }
 
 func allowBodyResponse() *extprocv3.ProcessingResponse {

--- a/authbridge/authlib/listener/extproc/server.go
+++ b/authbridge/authlib/listener/extproc/server.go
@@ -670,7 +670,8 @@ func (s *Server) handleResponseBody(ctx context.Context, body []byte, pctx *pipe
 				ResponseBody: &extprocv3.BodyResponse{
 					Response: &extprocv3.CommonResponse{
 						HeaderMutation: &extprocv3.HeaderMutation{
-							SetHeaders: []*corev3.HeaderValueOption{contentLength(pctx.ResponseBody)},
+							SetHeaders:    []*corev3.HeaderValueOption{contentLength(pctx.ResponseBody)},
+							RemoveHeaders: []string{"content-encoding"},
 						},
 						BodyMutation: &extprocv3.BodyMutation{
 							Mutation: &extprocv3.BodyMutation_Body{

--- a/authbridge/authlib/listener/extproc/server_contentlength_test.go
+++ b/authbridge/authlib/listener/extproc/server_contentlength_test.go
@@ -1,0 +1,67 @@
+package extproc
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// Envoy's ext_proc contract for the mode this listener runs (BUFFERED body,
+// SEND headers), from api/envoy/extensions/filters/http/ext_proc/v3/
+// processing_mode.proto, BodySendMode (v1.37.1):
+//
+//	In BUFFERED mode with SEND header mode, content length header is
+//	allowed but it is external processor's responsibility to set the
+//	content length correctly matched to the length of mutated body.
+//
+// These tests pin our side of that contract: a body-mutation reply carries
+// content-length equal to the mutated body. They do not exercise Envoy.
+// Envoy's side is pinned by its own integration test at the same tag,
+// test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+// MismatchedContentLengthAndBodyLength: BUFFERED + SEND, the processor
+// replaces "Replace this!" with "Hello, World!" and sets content-length to
+// the wrong value → the upstream is never reached, downstream gets 500. The
+// bodies below are the same, so the two tests read as one experiment.
+
+func TestWithBodyMutation_SetsContentLength(t *testing.T) {
+	pctx := &pipeline.Context{Body: []byte("Replace this!")}
+	pctx.SetBody([]byte("Hello, World!"))
+
+	hm := withBodyMutation(passBodyResponse(), pctx).GetRequestBody().GetResponse().GetHeaderMutation()
+	if got, want := mutationHeaderValue(hm, "content-length"), strconv.Itoa(len(pctx.Body)); got != want {
+		t.Fatalf("content-length = %q, want %q", got, want)
+	}
+}
+
+func TestHandleResponseBody_SetsContentLength(t *testing.T) {
+	newBody := []byte("Hello, World!")
+	p, err := pipeline.New([]pipeline.Plugin{&responseMutator{newBody}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &Server{OutboundPipeline: pipeline.NewHolder(p)}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{}}
+
+	resp := srv.handleResponseBody(context.Background(), []byte("Replace this!"), pctx, "")
+	hm := resp.GetResponseBody().GetResponse().GetHeaderMutation()
+	if got, want := mutationHeaderValue(hm, "content-length"), strconv.Itoa(len(newBody)); got != want {
+		t.Fatalf("content-length = %q, want %q", got, want)
+	}
+}
+
+type responseMutator struct{ newBody []byte }
+
+func (*responseMutator) Name() string { return "response-mutator" }
+func (*responseMutator) Capabilities() pipeline.PluginCapabilities {
+	return pipeline.PluginCapabilities{WritesBody: true}
+}
+func (*responseMutator) OnRequest(context.Context, *pipeline.Context) pipeline.Action {
+	return pipeline.Action{Type: pipeline.Continue}
+}
+func (m *responseMutator) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	pctx.SetResponseBody(m.newBody)
+	return pipeline.Action{Type: pipeline.Continue}
+}

--- a/authbridge/authlib/listener/extproc/server_contentlength_test.go
+++ b/authbridge/authlib/listener/extproc/server_contentlength_test.go
@@ -44,12 +44,15 @@ func TestHandleResponseBody_SetsContentLength(t *testing.T) {
 		t.Fatal(err)
 	}
 	srv := &Server{OutboundPipeline: pipeline.NewHolder(p)}
-	pctx := &pipeline.Context{ResponseHeaders: http.Header{}}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{"Content-Encoding": {"gzip"}}}
 
 	resp := srv.handleResponseBody(context.Background(), []byte("Replace this!"), pctx, "")
 	hm := resp.GetResponseBody().GetResponse().GetHeaderMutation()
 	if got, want := mutationHeaderValue(hm, "content-length"), strconv.Itoa(len(newBody)); got != want {
 		t.Fatalf("content-length = %q, want %q", got, want)
+	}
+	if !mutationRemovesHeader(hm, "content-encoding") {
+		t.Fatalf("content-encoding not removed: %+v", hm)
 	}
 }
 

--- a/authbridge/authlib/listener/extproc/server_contentlength_test.go
+++ b/authbridge/authlib/listener/extproc/server_contentlength_test.go
@@ -24,11 +24,12 @@ import (
 // MismatchedContentLengthAndBodyLength: BUFFERED + SEND, the processor
 // replaces "Replace this!" with "Hello, World!" and sets content-length to
 // the wrong value → the upstream is never reached, downstream gets 500. The
-// bodies below are the same, so the two tests read as one experiment.
+// original body below is the same; the replacement is deliberately longer,
+// so a reply that merely echoed the original length would fail too.
 
 func TestWithBodyMutation_SetsContentLength(t *testing.T) {
 	pctx := &pipeline.Context{Body: []byte("Replace this!")}
-	pctx.SetBody([]byte("Hello, World!"))
+	pctx.SetBody([]byte("Hello, World! (longer)"))
 
 	hm := withBodyMutation(passBodyResponse(), pctx).GetRequestBody().GetResponse().GetHeaderMutation()
 	if got, want := mutationHeaderValue(hm, "content-length"), strconv.Itoa(len(pctx.Body)); got != want {
@@ -37,7 +38,7 @@ func TestWithBodyMutation_SetsContentLength(t *testing.T) {
 }
 
 func TestHandleResponseBody_SetsContentLength(t *testing.T) {
-	newBody := []byte("Hello, World!")
+	newBody := []byte("Hello, World! (longer)")
 	p, err := pipeline.New([]pipeline.Plugin{&responseMutator{newBody}})
 	if err != nil {
 		t.Fatal(err)

--- a/authbridge/docs/framework-architecture.md
+++ b/authbridge/docs/framework-architecture.md
@@ -610,7 +610,7 @@ The flags (not byte-compare) are the source of truth. A rewrite that produces by
 
 | Listener | Request body | Response body |
 |---|---|---|
-| `extproc` | `withBodyMutation` helper wraps the `RequestBody ProcessingResponse` with an ext_proc `BodyMutation`. Envoy replaces the buffered body and recomputes `Content-Length`. | Same pattern in the response-body handler. |
+| `extproc` | `withBodyMutation` helper wraps the `RequestBody ProcessingResponse` with an ext_proc `BodyMutation`. Envoy replaces the buffered body; in BUFFERED + SEND mode the processor must set `Content-Length` itself (`processing_mode.proto`, `BodySendMode`), so the helper does. | Same pattern in the response-body handler. |
 | `forwardproxy` | On mutation, rebuild `r.Body` from `pctx.Body`, set `r.ContentLength` + `Content-Length` header. | Replace `resp.Body` + `resp.ContentLength` + `Content-Length`. |
 | `reverseproxy` | Same as forwardproxy on the inbound request before handing to `httputil.ReverseProxy`. | Same as forwardproxy on the response from the upstream. |
 


### PR DESCRIPTION
## Summary

Fixes #820

A `WritesBody` plugin under the envoy-sidecar (ext_proc) listener could only rewrite a body to
exactly its original length; any other length made Envoy answer 500 before the upstream saw the
request (`mismatch between content length and the length of the mutated body`). The response
path failed the same way. Reported by @lernerjenny.

Envoy's ext_proc API makes this the processor's job in the mode this listener uses —
[`processing_mode.proto`, `BodySendMode`](https://github.com/envoyproxy/envoy/blob/v1.37.1/api/envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto):

> In BUFFERED mode with SEND header mode, content length header is allowed but it is external
> processor's responsibility to set the content length correctly matched to the length of mutated body.

### Why this wasn't caught earlier

- **The comment was once true.** Until Envoy 1.29, a buffered body mutation made the filter drop `content-length` unconditionally (`processor_state.cc` at v1.28: "Always reset the content length here to prevent later problems"). envoyproxy/envoy#29536 (merged 2023-11-02, fixing #28515) introduced the current rule and the sentence quoted above. The comment and `docs/framework-architecture.md` §6 describe the pre-1.29 behaviour; `withBodyMutation` was written against an image already pinned to 1.37.1.
- **CI could not see it.** The listener's tests drive `extproc.Server` with a mock stream; they assert the `BodyMutation` and the `content-encoding` removal, but nothing in the harness models what Envoy does with the reply. The proxy listeners set `ContentLength` themselves in the same commit and were never affected.
- **Nobody had exercised it.** envoy-sidecar is the secondary mode and none of its demos runs a `WritesBody` plugin; the first length-changing body mutation through ext_proc is the one reported in #820.

The listener runs BUFFERED + SEND (`ModeOverride` on top of the chart's SEND/NONE filter config),
so `withBodyMutation()` and the response-body handler now set `content-length` to the mutated
body's length in the body reply's `HeaderMutation`, which Envoy applies before
`validateContentLength`. The comment that said Envoy recomputes it is corrected.

Tests call the two mutation paths directly with the same bodies as Envoy's `MismatchedContentLengthAndBodyLength` (`Replace this!` → `Hello, World!`) and assert the reply carries `content-length: 13` — our side of the contract, quoted in the test file. They do not exercise Envoy: both fail on `main`, pass here.

Envoy's side is pinned by Envoy's own integration tests at the same tag —
[`MismatchedContentLengthAndBodyLength`](https://github.com/envoyproxy/envoy/blob/v1.37.1/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc)
(BUFFERED, headers SEND, processor-set `content-length` ≠ mutated body → upstream never reached, downstream 500) and
`RemoveRequestContentLengthInBufferedMode` (headers **SKIP** → Envoy removes the header itself, 200).

The reproduction from #820 (static Envoy 1.37.1 + echo upstream + a plugin that wraps every body) passes with this
commit: both requests 200 instead of 500 — the upstream receives `content-length: 30` for the 30-byte wrapped
request, the client receives `content-length: 124` for the wrapped reply. Same result on Envoy 1.36.3
(istio proxyv2 1.28.0).

`withHeaderMutation` deliberately skips `Content-Length`/`Content-Encoding` — the body path owns them, which is where this lands.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mutated request and response bodies so their `Content-Length` headers accurately reflect the replacement body size.
  * Improved compatibility with Envoy buffered body processing.

* **Documentation**
  * Updated architecture documentation to clarify how `Content-Length` is handled for body mutations.

* **Tests**
  * Added coverage verifying correct `Content-Length` values for mutated request and response bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->