### PR TITLE
Fix: inference-parser misses /chat/completions from /v1-less proxies (opencode, litellm)

### DIFF
--- a/authbridge/authlib/plugins/inferenceparser/plugin.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin.go
@@ -56,7 +56,7 @@ func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) p
 	// "inference-parser is in this pipeline" from config, not per-event rows.
 	var ext *pipeline.InferenceExtension
 	switch endpointPath(pctx) {
-	case "/v1/chat/completions", "/v1/completions":
+	case "/v1/chat/completions", "/v1/completions", "/chat/completions", "/completions":
 		ext = parseOpenAIRequest(pctx.Body)
 	case anthropicMessagesPath:
 		ext = parseAnthropicRequest(pctx.Body)

--- a/authbridge/authlib/plugins/inferenceparser/plugin_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin_test.go
@@ -289,6 +289,50 @@ func TestInferenceParser_OnResponse_CapturesToolCalls(t *testing.T) {
 	}
 }
 
+// TestInferenceParser_VlessPath covers OpenAI-compatible proxies (e.g. opencode via
+// litellm) that strip the /v1 prefix and post directly to /chat/completions or
+// /completions. Without these path variants the parser falls to the default arm
+// and records no inference telemetry.
+func TestInferenceParser_VlessPath_ChatCompletions(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/chat/completions",
+		Body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":false}`),
+	}
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatal("Extensions.Inference is nil for /chat/completions")
+	}
+	if ext.Model != "gpt-4" {
+		t.Errorf("Model = %q, want gpt-4", ext.Model)
+	}
+	if !ext.IsAction {
+		t.Error("IsAction should be true")
+	}
+}
+
+func TestInferenceParser_VlessPath_Completions(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: "/completions",
+		Body: []byte(`{"model":"codellama","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	if pctx.Extensions.Inference == nil {
+		t.Fatal("Extensions.Inference is nil for /completions")
+	}
+	if pctx.Extensions.Inference.Model != "codellama" {
+		t.Errorf("Model = %q, want codellama", pctx.Extensions.Inference.Model)
+	}
+}
+
 func TestInferenceParser_NonMatchingPath(t *testing.T) {
 	p := NewInferenceParser()
 	pctx := &pipeline.Context{


### PR DESCRIPTION
## Why

OpenAI-compatible proxies such as **litellm** (used by opencode) post to `/chat/completions` without the `/v1` prefix. The `OnRequest` dispatch switch in `inference-parser` only matched `/v1/chat/completions` and `/v1/completions`, so these requests fell through to the `default: return Continue` arm — `pctx.Extensions.Inference` was never populated and `abctl` showed `—` for model, method, and token counts on every opencode request.

Observed before the fix:
```
9    14:13:56.91   out   │┌ req   —    —                    ete-litellm.ai-mode…
9    14:13:59.27   out   │└ resp  —    —    200  2.36s       ete-litellm.ai-mode…
```

## What changed

**`authbridge/authlib/plugins/inferenceparser/plugin.go`**
- Extended the `OnRequest` switch case to also match `/chat/completions` and `/completions`.

**`authbridge/authlib/plugins/inferenceparser/plugin_test.go`**
- Added `TestInferenceParser_VlessPath_ChatCompletions` and `TestInferenceParser_VlessPath_Completions`.

No changes to `OnResponse` or `OnResponseFrame` — the `default` branch there already routes to the OpenAI parsers, which is correct.

## Testing

```
$ cd authbridge/authlib && go test ./plugins/inferenceparser/...
ok  github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser
```

Verified end-to-end: opencode requests through `authbridge-proxy --demo` now show model, token counts, and method in `abctl`.

## Related issue(s)

Fixes #822

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for OpenAI-compatible `/chat/completions` and `/completions` endpoints without the `/v1` prefix.
  * Requests through compatible proxies are now correctly parsed, including model details and action tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->