### PR TITLE
chore: bump bifrost/core to v1.7.15

### DIFF
--- a/authbridge/authlib/go.mod
+++ b/authbridge/authlib/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gobwas/glob v0.2.3
 	github.com/lestrrat-go/jwx/v2 v2.1.7
-	github.com/maximhq/bifrost/core v1.7.13
+	github.com/maximhq/bifrost/core v1.7.15
 	github.com/open-policy-agent/opa v1.20.1
 	github.com/rossoctl/context-guru v0.1.0
 	github.com/spiffe/go-spiffe/v2 v2.8.1

--- a/authbridge/authlib/go.sum
+++ b/authbridge/authlib/go.sum
@@ -160,8 +160,8 @@ github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy
 github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
-github.com/maximhq/bifrost/core v1.7.13 h1:BQoIWq3/ee5IrNiNDJMQ2HmxwbIUu++VwLBRsi6j3kU=
-github.com/maximhq/bifrost/core v1.7.13/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
+github.com/maximhq/bifrost/core v1.7.15 h1:LOq+gnxqpex6Kok0l3GxyMoi04IBOT9uhzvkgV+uUv4=
+github.com/maximhq/bifrost/core v1.7.15/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/authbridge/cmd/authbridge-envoy/go.mod
+++ b/authbridge/cmd/authbridge-envoy/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mark3labs/mcp-go v0.43.2 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
-	github.com/maximhq/bifrost/core v1.7.13 // indirect
+	github.com/maximhq/bifrost/core v1.7.15 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-policy-agent/opa v1.20.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/authbridge/cmd/authbridge-envoy/go.sum
+++ b/authbridge/cmd/authbridge-envoy/go.sum
@@ -164,8 +164,8 @@ github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy
 github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
-github.com/maximhq/bifrost/core v1.7.13 h1:BQoIWq3/ee5IrNiNDJMQ2HmxwbIUu++VwLBRsi6j3kU=
-github.com/maximhq/bifrost/core v1.7.13/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
+github.com/maximhq/bifrost/core v1.7.15 h1:LOq+gnxqpex6Kok0l3GxyMoi04IBOT9uhzvkgV+uUv4=
+github.com/maximhq/bifrost/core v1.7.15/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/authbridge/cmd/authbridge-proxy/go.mod
+++ b/authbridge/cmd/authbridge-proxy/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mark3labs/mcp-go v0.43.2 // indirect
 	github.com/mattn/go-pointer v0.0.1 // indirect
-	github.com/maximhq/bifrost/core v1.7.13 // indirect
+	github.com/maximhq/bifrost/core v1.7.15 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/open-policy-agent/opa v1.20.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/authbridge/cmd/authbridge-proxy/go.sum
+++ b/authbridge/cmd/authbridge-proxy/go.sum
@@ -158,8 +158,8 @@ github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy
 github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
 github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
-github.com/maximhq/bifrost/core v1.7.13 h1:BQoIWq3/ee5IrNiNDJMQ2HmxwbIUu++VwLBRsi6j3kU=
-github.com/maximhq/bifrost/core v1.7.13/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
+github.com/maximhq/bifrost/core v1.7.15 h1:LOq+gnxqpex6Kok0l3GxyMoi04IBOT9uhzvkgV+uUv4=
+github.com/maximhq/bifrost/core v1.7.15/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
## Summary

Supersedes #830, which proposed **v1.8.4**. This takes **v1.7.15** instead — the last release that does not force a Go toolchain migration.

## Why #830 fails

bifrost **v1.8.0** raised its own `go` directive to `1.27.0`. Go propagates that into every module in the workspace, so Dependabot's PR rewrote `go 1.26.5` → `go 1.27.0` in all **seven** `go.mod` files while `authbridge/go.work` stayed at `1.26.5`:

```
go: module . listed in go.work file requires go >= 1.27.0,
    but go.work lists go 1.26.5
```

That also explains the odd file list on #830 — seven `go.mod` edits but only three matching `go.sum`, because most modules changed only their `go` directive.

## Why v1.7.15

| bifrost/core | `go` directive |
|---|---|
| v1.7.13 (current) | `go 1.26.5` |
| v1.7.14, **v1.7.15** | `go 1.26.5` |
| v1.8.0 → v1.8.4 | **`go 1.27.0`** |

The requirement arrives at v1.8.0, so v1.7.15 gets two patch releases with zero toolchain change. Dependabot only ever proposes the newest version, so this middle ground was never surfaced.

## What adopting v1.8.x would actually cost

Not the one-line `go.work` bump it looks like:

- `authbridge/go.work` → `1.27.0`
- **four digest-pinned `golang:1.26-alpine` builders** in `cmd/authbridge-{envoy,proxy,praxis,cpex}/Dockerfile` → 1.27 plus new digests. Those stages set `GOWORK=off` but **not** `GOTOOLCHAIN`, so they would not fail — they would silently download the 1.27 toolchain mid-build and ship images where a pinned 1.26 base bootstraps an unpinned 1.27. Worse than a clean failure.
- every developer moves to Go 1.27.0, roughly a month old at time of writing

CI itself is fine either way; it reads `go-version-file: authbridge/authlib/go.mod`.

And it buys nothing today. authlib touches exactly **three** bifrost symbols — `bschemas.ModelProvider`, `bschemas.Anthropic`, `bschemas.OpenAI` — in one six-line function in `plugins/contextguru/plugin.go`:

```go
func providerFor(path string) bschemas.ModelProvider {
	if strings.HasSuffix(path, "/v1/messages") {
		return bschemas.Anthropic
	}
	return bschemas.OpenAI
}
```

Nothing in bifrost 1.8 is reachable from our code, and #830 carries no security label.

## Good news for later

The code side of v1.8.x is already clear. I built and tested v1.8.4 locally with `go.work` at `1.27.0`: it compiles and the full authlib suite passes. **There is no API break waiting** — whenever the Go 1.27 move happens deliberately, it is purely a toolchain exercise.

## Verification

- every module's `go` directive and `go.work` unchanged at `1.26.5` (confirmed explicitly, since that is the whole point)
- `go build ./... && go vet ./...` for every authbridge module: pass (all but `cmd/authbridge-cpex`, which has no packages without `-tags cpex` and cannot link locally without `libcpex_ffi`)
- `go test ./...` across authlib: pass, 48 packages
- `cmd/*` `go.sum` files tidied by hand, mirroring `dependabot-tidy.yml` — that workflow is gated on `if: github.actor == 'dependabot[bot]'` and will not run on this branch

Diff is 6 files, 9 insertions, 9 deletions: pure version bump in the three modules that reference bifrost.

Companion change: #838 gates `>=1.8.0` in `.github/dependabot.yml` so v1.8.x is not re-proposed weekly while 1.7.x patches keep flowing.

Closes #830

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Bifrost core component to version 1.7.15 across Authbridge modules.
  * Ensures all related Authbridge components use the same updated core version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->