### PR TITLE
chore: gate bifrost v1.8+ behind the Go 1.27 move

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,22 @@ updates:
       # ignore once OPA is on the glob v1 API.
       - dependency-name: "github.com/gobwas/glob"
         update-types: ["version-update:semver-major"]
+      # bifrost/core v1.8.0 raised its own go directive to 1.27.0, which Go
+      # propagates into every module in the workspace. Adopting it is a Go
+      # 1.27 migration, not a dependency bump: it needs authbridge/go.work
+      # bumped and the four digest-pinned golang:1.26-alpine builders in
+      # cmd/*/Dockerfile moved to 1.27 (they set GOWORK=off but not
+      # GOTOOLCHAIN, so they would silently download the 1.27 toolchain
+      # mid-build rather than fail). authlib uses three symbols from
+      # core/schemas, so v1.8 buys nothing today.
+      #
+      # Range rather than update-types, so v1.7.x patches keep flowing —
+      # v1.7.15 is the newest release still on go 1.26.5 (see #840). There is
+      # no API break waiting: v1.8.4 was built and tested against authlib
+      # with go.work at 1.27.0 and the suite passed. Drop this range when the
+      # Go 1.27 move is made deliberately.
+      - dependency-name: "github.com/maximhq/bifrost/core"
+        versions: [">=1.8.0"]
 
   # Go - mode-specific binaries
   - package-ecosystem: gomod
@@ -41,6 +57,10 @@ updates:
       # See the authlib entry above for why glob v1 is blocked.
       - dependency-name: "github.com/gobwas/glob"
         update-types: ["version-update:semver-major"]
+      # Indirect via authlib. See the authlib entry above for why bifrost
+      # v1.8+ is gated on the Go 1.27 move.
+      - dependency-name: "github.com/maximhq/bifrost/core"
+        versions: [">=1.8.0"]
   - package-ecosystem: gomod
     directory: /authbridge/cmd/authbridge-envoy
     schedule:
@@ -49,6 +69,10 @@ updates:
       # See the authlib entry above for why glob v1 is blocked.
       - dependency-name: "github.com/gobwas/glob"
         update-types: ["version-update:semver-major"]
+      # Indirect via authlib. See the authlib entry above for why bifrost
+      # v1.8+ is gated on the Go 1.27 move.
+      - dependency-name: "github.com/maximhq/bifrost/core"
+        versions: [">=1.8.0"]
   # Go - abctl TUI
   - package-ecosystem: gomod
     directory: /authbridge/cmd/abctl


### PR DESCRIPTION
## Summary

Follow-up to #838. That PR was merged before this commit landed on its branch, so the bifrost half of the gate never reached `main` — only the glob half did. Same change, on its own PR.

Stops Dependabot re-proposing bifrost v1.8.x weekly while its blocker is a toolchain decision nobody has made yet.

## Why

bifrost/core **v1.8.0** raised its own `go` directive to `1.27.0`, which Go propagates into every module in the workspace. #830 (v1.8.4) therefore rewrote `go 1.26.5` → `go 1.27.0` in all seven `go.mod` files and failed CI against `go.work`, which still says `1.26.5`:

```
go: module . listed in go.work file requires go >= 1.27.0,
    but go.work lists go 1.26.5
```

Adopting v1.8.x is a **Go 1.27 migration**, not a dependency bump:

- `authbridge/go.work` → `1.27.0`
- the four digest-pinned `golang:1.26-alpine` builders in `cmd/*/Dockerfile` → 1.27. Those set `GOWORK=off` but **not** `GOTOOLCHAIN`, so they would not fail — they would silently download the 1.27 toolchain mid-build and ship images where a pinned 1.26 base bootstraps an unpinned 1.27.
- every developer moves to Go 1.27.0

It buys nothing today: authlib touches three symbols from `core/schemas` — `ModelProvider`, `Anthropic`, `OpenAI` — in one six-line function in `plugins/contextguru/plugin.go`. Nothing in bifrost 1.8 is reachable from our code, and #830 carried no security label.

## Scoped as a version range, not update-types

`versions: [">=1.8.0"]` so **v1.7.x patches keep flowing**. #840 takes v1.7.15, the newest release still on `go 1.26.5`.

There is **no API break waiting**: v1.8.4 was built and tested against authlib with `go.work` at `1.27.0` and the full suite passed (48 packages). This gates only the toolchain decision — drop the range when that move is made deliberately.

Applied to the three directories that require bifrost and have a Dependabot entry: `authlib` directly, `authbridge-proxy` and `authbridge-envoy` indirectly via authlib. `abctl` and `storage/redis` do not require it.

Validated as parsable YAML with the expected ignore entries per directory, on top of the glob entries #838 added.

Related: #840 (bifrost v1.7.15), #830 (closed).

Assisted-By: Claude Code