### PR TITLE
build: :construction_worker: Add variants to release binaries

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -48,18 +48,45 @@ jobs:
           fi
           echo "Building version ${VERSION}"
           mkdir -p dist
-          for bin in abctl authbridge-proxy; do
-            for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
-              os="${target%/*}"
-              arch="${target#*/}"
-              echo "==> ${bin} ${os}/${arch}"
-              ( cd "authbridge/cmd/${bin}" && \
-                GOWORK=off CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
-                go build -trimpath \
-                  -ldflags "-s -w -X main.version=${VERSION}" \
-                  -o "${GITHUB_WORKSPACE}/dist/${bin}" . )
-              tar -C dist -czf "dist/${bin}_${VERSION}_${os}_${arch}.tar.gz" "${bin}"
-              rm -f "dist/${bin}"
+
+          # authbridge-proxy variants: "<suffix>:<build-tags>". Empty
+          # suffix is the default plugin set. One variant per opt-in
+          # plugin (or one combined "full") — never enumerate combos.
+          declare -a proxy_variants=(
+            ":"
+            "lite:exclude_plugin_a2aparser,exclude_plugin_ibac,exclude_plugin_inferenceparser,exclude_plugin_mcpparser,exclude_plugin_opa,exclude_plugin_sparc,exclude_plugin_tokenbroker"
+            "sessionbudget:include_plugin_sessionbudget"
+          )
+
+          build_proxy() {
+            local variant="$1" tags="$2" os="$3" arch="$4"
+            local suffix=""; [ -n "${variant}" ] && suffix="-${variant}"
+            local archive="dist/authbridge-proxy${suffix}_${VERSION}_${os}_${arch}.tar.gz"
+            echo "==> authbridge-proxy${suffix} ${os}/${arch}"
+            ( cd authbridge/cmd/authbridge-proxy && \
+              GOWORK=off CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
+              go build -trimpath \
+                -tags "${tags}" \
+                -ldflags "-s -w -X main.version=${VERSION}" \
+                -o "${GITHUB_WORKSPACE}/dist/authbridge-proxy" . )
+            tar -C dist -czf "${archive}" authbridge-proxy
+            rm -f dist/authbridge-proxy
+          }
+
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${target%/*}"; arch="${target#*/}"
+
+            echo "==> abctl ${os}/${arch}"
+            ( cd authbridge/cmd/abctl && \
+              GOWORK=off CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
+              go build -trimpath \
+                -ldflags "-s -w -X main.version=${VERSION}" \
+                -o "${GITHUB_WORKSPACE}/dist/abctl" . )
+            tar -C dist -czf "dist/abctl_${VERSION}_${os}_${arch}.tar.gz" abctl
+            rm -f dist/abctl
+
+            for entry in "${proxy_variants[@]}"; do
+              build_proxy "${entry%%:*}" "${entry#*:}" "${os}" "${arch}"
             done
           done
           ( cd dist && sha256sum ./*.tar.gz > checksums.txt )
@@ -73,6 +100,8 @@ jobs:
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           notes="Prebuilt \`abctl\` and \`authbridge-proxy\` binaries for linux and macOS (amd64/arm64).
+
+          \`authbridge-proxy\` ships in variants matching the container images: unqualified (default plugin set, matches the \`authbridge\` image), \`-lite\` (auth-only, matches \`authbridge-lite\`), plus one variant per opt-in plugin currently offered for try-out (today: \`-sessionbudget\`). Variants track opt-in plugins one-for-one; arbitrary combinations are not published.
 
           Verify downloads with \`sha256sum -c checksums.txt\`. On macOS, clear the Gatekeeper quarantine after extracting: \`xattr -dr com.apple.quarantine ./abctl\`."
           if gh release view "${TAG}" >/dev/null 2>&1; then

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -52,9 +52,13 @@ jobs:
           # authbridge-proxy variants: "<suffix>:<build-tags>". Empty
           # suffix is the default plugin set. One variant per opt-in
           # plugin (or one combined "full") — never enumerate combos.
+          lite_tags="exclude_plugin_a2aparser,exclude_plugin_ibac"
+          lite_tags="${lite_tags},exclude_plugin_inferenceparser"
+          lite_tags="${lite_tags},exclude_plugin_mcpparser,exclude_plugin_opa"
+          lite_tags="${lite_tags},exclude_plugin_sparc,exclude_plugin_tokenbroker"
           declare -a proxy_variants=(
             ":"
-            "lite:exclude_plugin_a2aparser,exclude_plugin_ibac,exclude_plugin_inferenceparser,exclude_plugin_mcpparser,exclude_plugin_opa,exclude_plugin_sparc,exclude_plugin_tokenbroker"
+            "lite:${lite_tags}"
             "sessionbudget:include_plugin_sessionbudget"
           )
 
@@ -99,11 +103,21 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          notes="Prebuilt \`abctl\` and \`authbridge-proxy\` binaries for linux and macOS (amd64/arm64).
-
-          \`authbridge-proxy\` ships in variants matching the container images: unqualified (default plugin set, matches the \`authbridge\` image), \`-lite\` (auth-only, matches \`authbridge-lite\`), plus one variant per opt-in plugin currently offered for try-out (today: \`-sessionbudget\`). Variants track opt-in plugins one-for-one; arbitrary combinations are not published.
-
-          Verify downloads with \`sha256sum -c checksums.txt\`. On macOS, clear the Gatekeeper quarantine after extracting: \`xattr -dr com.apple.quarantine ./abctl\`."
+          # Build release notes as printf lines so no single string exceeds
+          # yamllint's 150-char cap. Single-quoted %s formats keep backticks
+          # literal (no shell expansion).
+          notes=""
+          add() { notes="${notes}${1}"$'\n'; }
+          add 'Prebuilt `abctl` and `authbridge-proxy` binaries for linux and macOS (amd64/arm64).'
+          add ''
+          add '`authbridge-proxy` ships in variants matching the container images:'
+          add 'unqualified (default plugin set, matches the `authbridge` image),'
+          add '`-lite` (auth-only, matches `authbridge-lite`), plus one variant per'
+          add 'opt-in plugin currently offered for try-out (today: `-sessionbudget`).'
+          add 'Variants track opt-in plugins one-for-one; arbitrary combinations are not published.'
+          add ''
+          add 'Verify downloads with `sha256sum -c checksums.txt`. On macOS, clear the'
+          add 'Gatekeeper quarantine after extracting: `xattr -dr com.apple.quarantine ./abctl`.'
           if gh release view "${TAG}" >/dev/null 2>&1; then
             gh release upload "${TAG}" dist/*.tar.gz dist/checksums.txt --clobber
           else

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -103,9 +103,9 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          # Build release notes as printf lines so no single string exceeds
-          # yamllint's 150-char cap. Single-quoted %s formats keep backticks
-          # literal (no shell expansion).
+          # Build release notes one line at a time so no single string
+          # exceeds yamllint's 150-char cap. Single-quoted arguments keep
+          # backticks literal (no shell expansion).
           notes=""
           add() { notes="${notes}${1}"$'\n'; }
           add 'Prebuilt `abctl` and `authbridge-proxy` binaries for linux and macOS (amd64/arm64).'

--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -34,6 +34,23 @@ binaries with shared auth logic in `authlib/`:
 Each binary is hardcoded to its deployment shape; mode is no longer selected
 at runtime. The YAML `mode:` field must match the binary or boot fails.
 
+### Release binaries
+
+`v*` tag pushes trigger `.github/workflows/release-binaries.yaml`, which
+cross-compiles `authbridge-proxy` and `abctl` for linux/darwin ×
+amd64/arm64 and attaches tarballs to the GitHub Release. `authbridge-proxy`
+ships in variants that mirror the container images:
+
+| Variant | Tarball name shape | Matches |
+|---|---|---|
+| unqualified (default plugins) | `authbridge-proxy_<ver>_<os>_<arch>.tar.gz` | `authbridge` image |
+| `-lite` (jwt-validation + token-exchange only) | `authbridge-proxy-lite_<ver>_<os>_<arch>.tar.gz` | `authbridge-lite` image |
+| `-sessionbudget` (default + opt-in session-budget) | `authbridge-proxy-sessionbudget_<ver>_<os>_<arch>.tar.gz` | no image today |
+
+One variant per opt-in plugin — never enumerate combos. To add one,
+append to the `proxy_variants` array in the workflow. `authbridge-cpex`
+stays image-only (needs cgo).
+
 See [`authlib/README.md`](authlib/README.md) for the library reference.
 
 ## What AuthBridge Does

--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -44,12 +44,13 @@ ships in variants that mirror the container images:
 | Variant | Tarball name shape | Matches |
 |---|---|---|
 | unqualified (default plugins) | `authbridge-proxy_<ver>_<os>_<arch>.tar.gz` | `authbridge` image |
-| `-lite` (jwt-validation + token-exchange only) | `authbridge-proxy-lite_<ver>_<os>_<arch>.tar.gz` | `authbridge-lite` image |
+| `-lite` (drops the OPA SDK and the protocol parsers) | `authbridge-proxy-lite_<ver>_<os>_<arch>.tar.gz` | `authbridge-lite` image |
 | `-sessionbudget` (default + opt-in session-budget) | `authbridge-proxy-sessionbudget_<ver>_<os>_<arch>.tar.gz` | no image today |
 
-One variant per opt-in plugin — never enumerate combos. To add one,
-append to the `proxy_variants` array in the workflow. `authbridge-cpex`
-stays image-only (needs cgo).
+One variant per opt-in plugin currently offered for try-out (today:
+`-sessionbudget`) — never enumerate combos. To add one, append to the
+`proxy_variants` array in the workflow. `authbridge-cpex` stays image-only
+(needs cgo); `context-guru` is opt-in but not yet offered as a variant.
 
 See [`authlib/README.md`](authlib/README.md) for the library reference.
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Adds `-lite` [auth-only] and `-sessionbudget` variants to the existing `authbridge-proxy` release-binary workflow. Tarball names mirror image tag names so the vocabulary stays consistent across artifacts. This lets users try opt-in plugins (starting with session-budget) via curl | tar | run instead of a source build, and sets a repeatable one-variant-per-opt-in pattern (no combinatorial combos) for future plugins.

This could allow for future additions to the byo cortex skill (https://github.com/rossoctl/agent-skills/tree/main/skills/byo-rossoctl-cortex) to point to a release binary and reduce dependence on a local build.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

## Related issue(s)

## (Optional) Testing Instructions

Tested end-to-end against a fork workflow_dispatch run (https://github.com/evaline-ju/cortex/actions/runs/33658689950)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the release workflow, supported binaries, platform targets, package variants, and corresponding container images.
  * Documented the capabilities included in standard, lightweight, and session-budget proxy variants.
  * Clarified how future release variants are configured and noted currently unavailable variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->