### PR TITLE
Docs: Clarify litellm-budget-track pipeline (inbound vs outbound)

### DIFF
--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -1,6 +1,6 @@
 # litellm-budget-track Plugin
 
-Design document for the `litellm-budget-track` AuthBridge inbound pipeline plugin.
+Design document for the `litellm-budget-track` AuthBridge pipeline plugin.
 
 **Issue:** https://github.com/rossoctl/rossoctl/issues/2177
 
@@ -16,8 +16,9 @@ with HTTP 429 when the configured daily budget is exceeded.
 When running AI agents through Cortex (local budget proxy), each agent needs
 a spending cap. LiteLLM returns the cost of each completion in the
 `x-litellm-response-cost` response header. This plugin reads that header in the
-AuthBridge inbound pipeline, tracks cumulative daily spend in a JSON ledger file,
-and blocks further requests once the budget is exhausted.
+AuthBridge pipeline that carries the LLM traffic (see [Pipeline placement](#pipeline-placement)),
+tracks cumulative daily spend in a JSON ledger file, and blocks further requests
+once the budget is exhausted.
 
 ## Architecture
 
@@ -90,6 +91,15 @@ pipeline:
           spend_file: /etc/cortex/spend-authbridge.json
           max_budget: 5.00
 ```
+
+### Pipeline placement
+
+The plugin is direction-agnostic — place it in whichever pipeline carries the LLM
+traffic: **`inbound`** when fronting the LLM endpoint (a reverse proxy the LLM requests
+arrive at, as shown above), **`outbound`** when hosting the agent via
+`rossoctl authbridge exec -- <agent>`, whose forward proxy runs the outbound pipeline on
+the agent's own egress to LiteLLM. In an `authbridge exec` setup nothing reaches the
+inbound pipeline, so a plugin left under `inbound:` there records `$0` — use `outbound:`.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|


### PR DESCRIPTION
The doc described litellm-budget-track as an inbound-pipeline plugin and its example config placed it under pipeline.inbound. The plugin is actually direction-agnostic (it implements the generic OnRequest/OnResponse/OnResponseFrame hooks and declares no fixed direction), and the correct pipeline depends on topology: inbound when AuthBridge fronts the LLM endpoint as a reverse proxy, outbound when hosting the agent via 'rossoctl authbridge exec', whose forward proxy runs the outbound pipeline on the agent's egress.

In an 'authbridge exec' setup nothing reaches the inbound pipeline, so a plugin left under inbound: records $0 — a common 'it ran but tracked nothing' trap.

Add a 'Pipeline placement' subsection at the config example and soften the two 'inbound pipeline' assertions in the title and Use Case to be direction-agnostic.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

## Related issue(s)

## (Optional) Testing Instructions

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the LiteLLM budget tracking plugin can run in either inbound or outbound pipeline placement.
  * Documented that `authbridge exec` deployments must configure the plugin under the outbound pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->