### PR TITLE
Feat: Add the lineage attach kit for any running Deployment

### DIFF
--- a/authbridge/lineage-attach/DESIGN.md
+++ b/authbridge/lineage-attach/DESIGN.md
@@ -1,0 +1,246 @@
+# Design — why the attachment works, and where it stops
+
+The [README](README.md) says what to do. This is why it is built this way, what
+it depends on, and the cases that look fine and are not. Nothing here is needed
+to attach; all of it is needed to trust the result.
+
+## Two halves, one insight
+
+Every HTTP exchange a workload takes part in crosses its pod's network
+boundary, and a sidecar at that boundary sees all of it: the request as it
+arrives or leaves, the response as it ends, the protocol, the peer, the
+outcome. Those are facts, and they can be recorded without the application
+knowing. That is the first half — **capture** — and it is pure configuration:
+a plugin entry in the sidecar's pipeline.
+
+What the boundary cannot see is *causality inside the pod*: which inbound
+request made the app issue which outbound call. The sidecar lives outside the
+app's execution context and has no way to know which coroutine did what. To
+attribute an outbound hop to the inbound that caused it, something must carry
+a token **with the execution scope through the app** — which is exactly what
+the W3C `traceparent` header is for, and only code running *inside* the
+request's context can copy it from the inbound request onto the outbound
+ones. That is the second half — **propagation** — and it is the only thing the
+app must do.
+
+The shim does it for the app: stock OpenTelemetry auto-instrumentation,
+exporting nothing, baked as an inert layer. Nothing about what the app *does*
+enters into it — the same layer serves an agent, a tool, a relay — and its
+activation is one environment variable. Everything else the sidecar records
+from the outside.
+
+## How a hop finds its parent
+
+Each sidecar stamps the id of the span it just emitted into the request's
+`tracestate` header before forwarding; the next sidecar parents on that stamp
+(`lineage.parent.source=tracestate`) and re-stamps its own. When no stamp is
+present the hop is parented on the `traceparent` the wire carried and records
+`lineage.parent.source=wire`; when the wire carried nothing at all it roots a
+trace of its own and records `none`. The forwarded `traceparent` itself is
+never modified — when none arrived the sidecar forwards one naming its own
+request span, so the next hop has a context to extract and the stamp has a
+header to ride on — and nothing guesses: a hop without context is *visibly*
+unparented rather than attached to a plausible caller.
+
+So there is exactly one unstamped hop (`wire`, or `none` for a caller that
+sent no `traceparent`) per well-propagated trace, at the entry, where
+the caller supplied the first `traceparent`. Every other unstamped hop marks a
+pod that did not carry the context through — `none` when its app sent no
+`traceparent` at all, `wire` when it forwarded one without the stamp. The
+subtree beneath it fragments out of its caller's
+trace — *visibly absent* lineage rather than wrong lineage — and attribution is
+lost for everything downstream of that pod.
+
+> In-process `traceparent` propagation is mandatory, and the sidecar cannot do
+> it from outside the app.
+
+## Why the shim is needed, and what it installs
+
+The shim supplies propagation with stock OpenTelemetry auto-instrumentation and
+**exports nothing**:
+
+- **server side** (`starlette` / `asgi` / `fastapi`) — extract the inbound
+  `traceparent`, make it the active context.
+- **client side** (`httpx` / `requests` / `aiohttp-client` / `urllib3`) — inject
+  `traceparent` on outbound calls. `urllib3` is what covers `boto3`/`botocore`:
+  an S3 read from a tool otherwise escapes into a trace of its own (seen live).
+- **`threading`** — carry the active context across `Thread.start` /
+  `ThreadPoolExecutor.submit`. **Load-bearing**: frameworks that run the LLM
+  call in a worker thread (anything using `loop.run_in_executor`) otherwise
+  lose the context at the thread boundary and those legs silently fragment.
+- **exporters pinned to `none`, and no `OTEL_EXPORTER_OTLP_ENDPOINT`** — the
+  activation hook sets all three signal exporters to `none` as environment
+  defaults the moment it wakes, so the shim's instrumentation generates spans
+  that go nowhere. Your telemetry backend sees only what the sidecar emits.
+
+### The activation hook
+
+Activation is a baked, env-gated site hook (`lineage-propagate-hook.py`,
+installed into site-packages as a `.pth` + module pair): every Python process
+of the image checks one variable at startup and either initializes stock
+auto-instrumentation (`LINEAGE_PROPAGATE=1`) or does nothing at all. The
+image's ENTRYPOINT/CMD is never rewritten, there is no launcher process, and
+an unactivated `-otel` image runs the app exactly as its base does, with no
+OpenTelemetry module loaded —
+`build-otel-shim.sh` attests both halves of that claim on every bake, before
+the image is ever loaded. It is the same attach shape as the Java agent
+(`JAVA_TOOL_OPTIONS`) and Node (`NODE_OPTIONS`): the switch lives in the
+Deployment, next to the image reference, and nowhere in the app.
+
+A hook failure cannot take the app down: the module catches everything and
+logs; propagation is then off and the trace shows it (`none` on the pod's
+outbound hops), which is the
+honest failure mode. Read the hook's docstring for the full contract.
+
+### An app that already configures OpenTelemetry itself
+
+That app is outside the shim's envelope, and the bake interlock cannot see it
+(it probes for instrumentors, not for SDK use). The hook's `initialize()`
+installs the global `TracerProvider` first, so a provider the app sets in code
+is rejected (`Overriding of current TracerProvider is not allowed`) and the
+app's own exporter goes silent. An `OTEL_*_EXPORTER` the app sets in its
+environment wins over the hook's `none` (`setdefault`), so the shim's own
+server and client spans then flow to the app's backend — and `otlp` needs an
+exporter package the shim does not install, in which case the hook fails at
+startup and propagation stays off. For such an app attach capture only (no
+`APP_CONTAINER`) and let its own instrumentation carry `traceparent`.
+
+## The envelope
+
+The shim is generic across the mainstream Python stack, not universal:
+
+- **Python**, in any of the common layouts — a venv (declared via
+  `$VIRTUAL_ENV` or at the usual paths) or a plain pip/system python;
+  `build-otel-shim.sh` probes the image for the interpreter the app runs and
+  refuses when it finds none (an explicit argument overrides the probe).
+- Server is **ASGI / Starlette / FastAPI**; HTTP client is **httpx**,
+  **requests**, **aiohttp** or **urllib3** (which is how `boto3` talks).
+- A caller that sends no `traceparent` gets one minted by the entry sidecar
+  (`parent.source=none` on that hop, contract v1.6); the shim itself seeds
+  nothing.
+- **Not covered:** work handed to a `multiprocessing` child or a `subprocess`,
+  threads started at app boot rather than inside a request, and an app that
+  configures the OpenTelemetry SDK itself — in code or through `OTEL_*`
+  environment variables (above).
+- The base image has a shell and coreutils (`Dockerfile.otel-shim` runs one
+  `RUN` step to place the hook); a distroless base fails that step.
+
+Outside the envelope, attach capture only (no `APP_CONTAINER`): every hop is
+still recorded. Whether those hops are *correctly attributed* depends entirely
+on the app carrying the trace context (`traceparent`, and the stamp in
+`tracestate`) from its inbound to its outbound calls itself — and that is a
+stronger condition than it sounds.
+
+### Half-instrumented apps: the case that looks fine and is not
+
+Propagation needs **two** halves: something that extracts the inbound
+`traceparent` into an active context (`starlette` / `asgi` / `fastapi`), and
+something that injects it on the way out (`httpx` / `requests` / `aiohttp` /
+`urllib3`). An app carrying only the client half can inject, but has nothing
+to inject *from*.
+
+That app is in a corner this kit cannot get you out of:
+
+- **The shim refuses it**, correctly — its client instrumentor is one this shim
+  installs, so wrapping would stack a second one on the same library.
+- **Capture-only does not save it** — with no server-side extraction, every
+  outbound call starts a *fresh* trace.
+
+Measured on exactly such an app: it served requests, called its LLM
+successfully, and produced 26 outbound exchanges — **every one of them alone
+in its own trace, none sharing a trace with the inbound that caused it.** No
+correlation survives at all, and every per-trace consistency check stays green
+while it happens.
+
+**Check the shape, not just the count.** A concurrency check that only asks "is
+each trace internally consistent?" will pass this app perfectly: a trace holding
+one lonely inbound is clean by every structural measure. What exposes it is
+expecting a *number of hops* per trace and finding one. If your app should make
+three outbound calls per request, assert that three appear in the same trace —
+otherwise a total attribution failure reads as a clean run. The same test
+caught the shim's own gap once: a tool reading S3 through `boto3` escaped into
+its own trace on a run whose every functional check passed, because the
+recipe lacked the `urllib3` instrumentor. One unstamped hop in the wrong place
+is the whole signal.
+
+If you own the image, the fix is to add the missing server-side instrumentor
+(or activate stock auto-instrumentation, which brings both halves — that is
+what the shim's hook does). If you do not, the image reference is the only
+lever left (`SELF_ACTIVATE=1`, README "The propagation half") — and only if
+the shim's interlock lets the image through.
+
+### Baking is not purely additive
+
+The shim installs one pinned OpenTelemetry contrib release
+(`OTEL_CONTRIB_VERSION` in `Dockerfile.otel-shim`), and the resolver brings
+the SDK that release requires — on an image that already carries an older SDK,
+the bake *upgrades* it (observed: `opentelemetry-sdk 1.42.1 → 1.44.0`, semconv
+`0.63b1 → 0.65b0`). Harmless for an app that does not pin, but an app pinning
+an older SDK can be affected by being wrapped. Check the build output if your
+app is sensitive to those versions.
+
+### Refuse rather than guess
+
+`build-otel-shim.sh` probes the image and stops if it finds no runnable Python,
+or if any of the eight instrumentors the shim installs is already present
+(wrapping would stack a second instrumentor on the same library), or if the
+image already carries the shim's own hook. It does **not** refuse on the mere
+presence of the `opentelemetry.instrumentation` namespace or of a dormant SDK
+— an image can carry those as transitive dependencies and still need the shim.
+`FORCE_BAKE=1` overrides, which makes the human judgment explicit and
+greppable.
+
+## What the sidecar can and cannot see
+
+- **Plaintext HTTP only.** An HTTPS destination is TLS passthrough — no hop is
+  recorded for it. Inside a cluster that is usually every hop that matters;
+  an external HTTPS LLM is the notable exception, and it is invisible.
+- **Non-HTTP protocols cannot pass through the outbound listener at all.**
+  `proxy-init` redirects every outbound TCP connection to the sidecar, whose
+  outbound listener hands each non-TLS connection to its HTTP codec. A
+  Postgres or SMTP connection is closed on arrival (seen live as `psycopg`
+  "server terminated abnormally"). `OUTBOUND_PORTS_EXCLUDE` keeps such ports
+  out of the redirect; those hops carry no HTTP facts and are invisible to
+  lineage either way. S3 is HTTP and stays in. The redirect is symmetric:
+  every inbound TCP port of the pod is sent to the inbound listener too, and
+  this kit exposes no inbound exclusion (`proxy-init` supports
+  `INBOUND_PORTS_EXCLUDE`; the generator does not offer it). An app that
+  *serves* a plaintext non-HTTP protocol cannot be adopted as is.
+- **Content is captured through parsers, not off the wire.** With
+  `capture_io: true` the A2A, MCP and inference parsers attach the parsed
+  message as `input.value` / `output.value`; a plain HTTP exchange has no
+  parser and is recorded bodyless — who called whom, with what outcome, but
+  not what was said. Payloads are capped (`max_payload_bytes`, 4096 by
+  default) with a visible truncation marker.
+
+## Where you see the spans, on the rossoctl platform
+
+The platform's `rossoctl-deps` chart
+([`charts/rossoctl-deps/values.yaml`](https://github.com/rossoctl/rossoctl/blob/main/charts/rossoctl-deps/values.yaml),
+`otel.collector`) runs an OTel collector (`deploy/otel-collector` in
+`rossoctl-system`) whose base `traces` pipeline exports to `debug` at
+`verbosity: detailed` — span attributes included — and does **not** install
+Phoenix (`components.phoenix.enabled` defaults to `false`). Spans arriving at
+the default endpoint are printed to the collector's log and stored nowhere
+queryable:
+
+```sh
+kubectl logs -n rossoctl-system deploy/otel-collector | grep lineage.exchange.id
+```
+
+That is enough to prove the plugin works. For a store, add an exporter and a
+pipeline to the collector's ConfigMap (Phoenix with
+`--set components.phoenix.enabled=true`, Jaeger, any OTLP store of your own), or point
+`OTEL_ENDPOINT` straight at a sink of your own. Nothing in this kit depends
+on which you choose.
+
+## Limits, in one place
+
+- **The sidecar sees plaintext HTTP only.**
+- **Trace-context propagation is the app's job** — the shim does it for the
+  in-envelope stack, and nothing else can do it from outside the process.
+- **The patch path is not durable**: the owner still owns the Deployment, and
+  a platform-side rewrite (an operator reconcile, a chart upgrade, a UI
+  redeploy) silently drops the sidecar. Keep the attachment in the manifests
+  when you own them (README "Bring your own manifests").
+- **A workload whose image *and* env you cannot influence stays capture-only.**

--- a/authbridge/lineage-attach/DESIGN.md
+++ b/authbridge/lineage-attach/DESIGN.md
@@ -81,11 +81,24 @@ of the image checks one variable at startup and either initializes stock
 auto-instrumentation (`LINEAGE_PROPAGATE=1`) or does nothing at all. The
 image's ENTRYPOINT/CMD is never rewritten, there is no launcher process, and
 an unactivated `-otel` image runs the app exactly as its base does, with no
-OpenTelemetry module loaded —
-`build-otel-shim.sh` attests both halves of that claim on every bake, before
-the image is ever loaded. It is the same attach shape as the Java agent
+OpenTelemetry module loaded. `build-otel-shim.sh` attests this on every bake,
+before the image is ever loaded: `verify_inert` starts a bare interpreter with
+the gate off and asserts no `opentelemetry` module loads, and
+`verify_propagates` starts one with the gate on and asserts the hook ran and a
+`traceparent` is injected. (Both run the interpreter directly, not the image's
+ENTRYPOINT/CMD — they prove the hook's behaviour, not that the app's own
+command is unchanged; that half rests on the Dockerfile never touching
+ENTRYPOINT/CMD.) It is the same attach shape as the Java agent
 (`JAVA_TOOL_OPTIONS`) and Node (`NODE_OPTIONS`): the switch lives in the
 Deployment, next to the image reference, and nowhere in the app.
+
+One thing the bake *does* rewrite is `USER`: the final stage resets it to
+`${APP_UID}:${APP_GID}` (the detected values), so a base image that named its
+user — `USER app` — comes out numeric, which drops that user's supplementary
+groups. The primary uid/gid are preserved; only supplementary group
+memberships are lost. Detected automatically by `build-otel-shim.sh`; a direct
+Dockerfile build must pass both build-args (they have no default) or the build
+fails rather than silently running as `1001:0`.
 
 A hook failure cannot take the app down: the module catches everything and
 logs; propagation is then off and the trace shows it (`none` on the pod's

--- a/authbridge/lineage-attach/DESIGN.md
+++ b/authbridge/lineage-attach/DESIGN.md
@@ -231,15 +231,16 @@ container therefore *cannot* start before its proxy is accepting, with no
 cooperation from the app.
 
 This needs **Kubernetes ≥ 1.29** (native sidecars are on by default from 1.29,
-GA in 1.33), and an older cluster fails loud before any write: with the
-SidecarContainers gate off, the apiserver drops `restartPolicy: Always` and
-then rejects the now-orphaned `startupProbe` on the init container
-(`startupProbe: Forbidden: may not be set for init containers without
-restartPolicy=Always`) — verified on a real 1.28 cluster. So there is no
-version parsing and no silent wedge: the adopt route hits that rejection at
-`sidecar-patch.sh`'s server-side dry-run (which recognises the native-sidecar
-error and adds a needs-1.29 hint), and the bring-your-own-manifests route hits
-it at the operator's own `kubectl apply` — both before anything is persisted.
+GA in 1.33), and an older cluster fails loud: with the SidecarContainers gate
+off, the apiserver drops `restartPolicy: Always` and then rejects the
+now-orphaned `startupProbe` on the init container (`startupProbe: Forbidden:
+may not be set for init containers without restartPolicy=Always`) — verified
+on a real 1.28 cluster. So there is no version parsing and no silent wedge:
+the adopt route hits that rejection at `sidecar-patch.sh`'s server-side
+dry-run (which recognises the native-sidecar error and adds a needs-1.29
+hint), before anything is persisted; the bring-your-own-manifests route hits
+it at the operator's own `kubectl apply` of the Deployment — the ConfigMap
+from that same apply does persist, inert on its own (no pod references it).
 
 ## What the sidecar can and cannot see
 

--- a/authbridge/lineage-attach/DESIGN.md
+++ b/authbridge/lineage-attach/DESIGN.md
@@ -192,6 +192,11 @@ the bake *upgrades* it (observed: `opentelemetry-sdk 1.42.1 → 1.44.0`, semconv
 an older SDK can be affected by being wrapped. Check the build output if your
 app is sensitive to those versions.
 
+The static `uv` used to install the shim is copied into the image and left
+there — a `rm` in a later layer would not reclaim the copy layer's space, so
+removing it cleanly would need a build-stage split the kit does not do. It is a
+small self-contained binary and inert at runtime; noted here rather than hidden.
+
 ### Refuse rather than guess
 
 `build-otel-shim.sh` probes the image and stops if it finds no runnable Python,
@@ -200,8 +205,41 @@ or if any of the eight instrumentors the shim installs is already present
 image already carries the shim's own hook. It does **not** refuse on the mere
 presence of the `opentelemetry.instrumentation` namespace or of a dormant SDK
 — an image can carry those as transitive dependencies and still need the shim.
-`FORCE_BAKE=1` overrides, which makes the human judgment explicit and
-greppable.
+`FORCE_BAKE=1` overrides the **instrumentation interlock only** — the
+already-instrumented and already-has-hook refusals — and makes that human
+judgment explicit and greppable. The no-runnable-Python refusal is not
+overridable by it: pass the interpreter explicitly (arg 3) instead.
+
+## Why the sidecar is a native sidecar
+
+`proxy-init` programs the pod's iptables and exits; from that instant every
+non-1337 outbound TCP connection is redirected to the envoy outbound listener.
+If `envoy-proxy` were a plain container, the kubelet would start it and the app
+container together and wait for neither — and an app that makes its first
+outbound call *at process start* (peer discovery, a config fetch, a license
+ping) would reach the redirect before envoy is listening: connection refused,
+surfaced as an app error, the pod "running" and the failure silent. Observed
+live on an agent mesh resolving its A2A peers at boot — every agent came up
+with `0 peers` and delegations quietly no-oped.
+
+So `envoy-proxy` is emitted as a **native sidecar**: an `initContainers` entry
+with `restartPolicy: Always` and a `startupProbe` on the outbound listener. The
+merge prepends it (with `proxy-init`) ahead of the owner's own init containers,
+and the kubelet holds every later container — the owner's inits included — until
+its startupProbe passes, keeping it running for the pod's life. The app
+container therefore *cannot* start before its proxy is accepting, with no
+cooperation from the app.
+
+This needs **Kubernetes ≥ 1.29** (native sidecars are on by default from 1.29,
+GA in 1.33), and an older cluster fails loud before any write: with the
+SidecarContainers gate off, the apiserver drops `restartPolicy: Always` and
+then rejects the now-orphaned `startupProbe` on the init container
+(`startupProbe: Forbidden: may not be set for init containers without
+restartPolicy=Always`) — verified on a real 1.28 cluster. So there is no
+version parsing and no silent wedge: the adopt route hits that rejection at
+`sidecar-patch.sh`'s server-side dry-run (which recognises the native-sidecar
+error and adds a needs-1.29 hint), and the bring-your-own-manifests route hits
+it at the operator's own `kubectl apply` — both before anything is persisted.
 
 ## What the sidecar can and cannot see
 

--- a/authbridge/lineage-attach/DESIGN.md
+++ b/authbridge/lineage-attach/DESIGN.md
@@ -223,12 +223,22 @@ live on an agent mesh resolving its A2A peers at boot — every agent came up
 with `0 peers` and delegations quietly no-oped.
 
 So `envoy-proxy` is emitted as a **native sidecar**: an `initContainers` entry
-with `restartPolicy: Always` and a `startupProbe` on the outbound listener. The
-merge prepends it (with `proxy-init`) ahead of the owner's own init containers,
-and the kubelet holds every later container — the owner's inits included — until
-its startupProbe passes, keeping it running for the pod's life. The app
-container therefore *cannot* start before its proxy is accepting, with no
-cooperation from the app.
+with `restartPolicy: Always` and a `startupProbe` on the outbound listener,
+and the kubelet holds every container that starts after it until that probe
+passes, keeping it running for the pod's life. The app container therefore
+*cannot* start before its proxy is accepting, with no cooperation from the app.
+
+Where the pair lands among the owner's own init containers is strategic-merge
+placement behaviour the patch does not pin (no `$setElementOrder`), and the
+safety of the owner's inits deliberately does not rest on it. What the kit
+does control is that **`proxy-init` and `envoy-proxy` travel adjacent in one
+patch**, and both possible placements are safe: prepended (what the apiserver
+does today), the owner's inits run after the proxy is up, against a working
+redirect; appended, they run before any redirect exists, on ordinary pod
+networking. The only arrangement that breaks — an owner init container landing
+*between* the two — cannot arise from a merge, because getting there would
+need the target to already own one of those two names, which the
+`refuse_name_collision` precondition refuses outright.
 
 This needs **Kubernetes ≥ 1.29** (native sidecars are on by default from 1.29,
 GA in 1.33), and an older cluster fails loud: with the SidecarContainers gate

--- a/authbridge/lineage-attach/Dockerfile.otel-shim
+++ b/authbridge/lineage-attach/Dockerfile.otel-shim
@@ -1,0 +1,68 @@
+# Propagate-only OpenTelemetry shim for an uninstrumented Python app image.
+#
+# Auto-instrumentation is layered ON TOP of the app image so the app carries
+# the W3C traceparent through itself: extract on the inbound ASGI/Starlette/
+# FastAPI request, inject on the outbound httpx/requests/aiohttp call. Nothing
+# is exported (the hook pins every exporter to `none`); the sidecar does the
+# capture. Neither the app's source nor its command is touched.
+#
+# Activation is environment, not command: a site-packages hook (`.pth` +
+# `_lineage_propagate.py`, see lineage-propagate-hook.py) runs stock
+# auto-instrumentation at interpreter start ONLY when LINEAGE_PROPAGATE=1 is
+# set — the same attach shape as JAVA_TOOL_OPTIONS / NODE_OPTIONS. Without it
+# the app runs exactly as on its base: no OpenTelemetry module loads.
+#
+# One recipe for every app: instrumentors target libraries, and only the ones
+# the app imports activate.
+#
+# Build with build-otel-shim.sh (detects the build-args, refuses images it
+# cannot safely wrap, attests the result, kind-loads it). Direct:
+#   podman build -f Dockerfile.otel-shim --build-arg BASE_IMAGE=<app> -t <app>-otel:latest .
+#
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# The python the app runs in, and the uid:gid it runs as — detected from the
+# image by build-otel-shim.sh; the defaults match the common uv-built layout.
+ARG VENV_PYTHON=/app/.venv/bin/python
+ARG APP_UID=1001
+ARG APP_GID=0
+
+USER root
+# Our own static uv, pinned by digest: a builder-stage image may have neither
+# uv nor pip in its runtime layer.
+COPY --from=ghcr.io/astral-sh/uv:0.9.24@sha256:816fdce3387ed2142e37d2e56e1b1b97ccc1ea87731ba199dc8a25c04e4997c5 /uv /usr/local/bin/uv
+# One contrib release for everything, so a bake never silently upgrades the
+# OTel set under an app. -distro is the SDK; the eight others — server
+# (starlette/asgi/fastapi), client (httpx/requests/aiohttp/urllib3) and
+# -threading — are the instrumentors build-otel-shim.sh's interlock probes
+# for; keep the two lists in sync.
+# `-urllib3` covers clients that bypass `requests`: boto3/botocore (S3 and
+# every AWS-style store) drive urllib3 directly. Without it an object read
+# lands in a trace of its own (seen live: a MinIO GetObject escaping into a
+# trace of its own). Inside a `requests` call urllib3 is suppressed, so
+# the two never stack.
+# `-threading` is load-bearing: OTel context is contextvars-based and does not
+# cross run_in_executor / ThreadPoolExecutor on its own; without it the LLM or
+# tool call made from a worker thread fragments out of its caller's trace.
+# `--system --break-system-packages` lets the install land in a non-venv
+# python too; both flags are inert when --python is a venv.
+ARG OTEL_CONTRIB_VERSION=0.65b0
+RUN uv pip install --no-cache --python ${VENV_PYTHON} --system --break-system-packages \
+      "opentelemetry-distro==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-starlette==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-asgi==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-fastapi==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-httpx==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-requests==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-aiohttp-client==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-urllib3==${OTEL_CONTRIB_VERSION}" \
+      "opentelemetry-instrumentation-threading==${OTEL_CONTRIB_VERSION}"
+# The hook, into the same environment: `site` imports every .pth at
+# interpreter start; the module no-ops unless LINEAGE_PROPAGATE=1.
+COPY lineage-propagate-hook.py /tmp/lineage-propagate-hook.py
+RUN sp="$(${VENV_PYTHON} -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" \
+ && install -m 0644 /tmp/lineage-propagate-hook.py "${sp}/_lineage_propagate.py" \
+ && printf 'import _lineage_propagate\n' > "${sp}/zz-lineage-propagate.pth" \
+ && rm /tmp/lineage-propagate-hook.py
+USER ${APP_UID}:${APP_GID}

--- a/authbridge/lineage-attach/Dockerfile.otel-shim
+++ b/authbridge/lineage-attach/Dockerfile.otel-shim
@@ -68,6 +68,13 @@ RUN uv pip install --no-cache --python "${VENV_PYTHON}" --system --break-system-
       "opentelemetry-instrumentation-aiohttp-client==${OTEL_CONTRIB_VERSION}" \
       "opentelemetry-instrumentation-urllib3==${OTEL_CONTRIB_VERSION}" \
       "opentelemetry-instrumentation-threading==${OTEL_CONTRIB_VERSION}"
+# The install resolves into the app's OWN environment, so it may move a package
+# an app dependency pins (wrapt, deprecated, typing-extensions are the usual
+# suspects) — and the attestations import only OpenTelemetry, never the app.
+# Verify the resolved environment is still consistent, so a conflict the bake
+# introduced fails the BUILD instead of surfacing as an ImportError in the
+# cluster after the attach, where it would look like the sidecar's fault.
+RUN uv pip check --python "${VENV_PYTHON}" --system
 # The hook, into the same environment: `site` imports every .pth at
 # interpreter start; the module no-ops unless LINEAGE_PROPAGATE=1.
 COPY lineage-propagate-hook.py /tmp/lineage-propagate-hook.py

--- a/authbridge/lineage-attach/Dockerfile.otel-shim
+++ b/authbridge/lineage-attach/Dockerfile.otel-shim
@@ -16,17 +16,27 @@
 # the app imports activate.
 #
 # Build with build-otel-shim.sh (detects the build-args, refuses images it
-# cannot safely wrap, attests the result, kind-loads it). Direct:
-#   podman build -f Dockerfile.otel-shim --build-arg BASE_IMAGE=<app> -t <app>-otel:latest .
+# cannot safely wrap, attests the result, kind-loads it). A direct build must
+# pass the uid:gid too — they have no default on purpose (see APP_UID below):
+#   podman build -f Dockerfile.otel-shim --build-arg BASE_IMAGE=<app> \
+#     --build-arg APP_UID=<uid> --build-arg APP_GID=<gid> -t <app>-otel:latest .
 #
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 # The python the app runs in, and the uid:gid it runs as — detected from the
-# image by build-otel-shim.sh; the defaults match the common uv-built layout.
+# image by build-otel-shim.sh. VENV_PYTHON keeps the common uv-built layout as
+# a default (a wrong one fails LOUDLY: the install RUN errors when the path is
+# absent). APP_UID/APP_GID have NO default, so a direct build that omits them
+# is refused rather than silently running the app as 1001:0 — the guard below
+# enforces it, because an empty `USER :` does not itself fail the build (it
+# resolves to root at runtime).
 ARG VENV_PYTHON=/app/.venv/bin/python
-ARG APP_UID=1001
-ARG APP_GID=0
+ARG APP_UID
+ARG APP_GID
+RUN [ -n "${APP_UID}" ] && [ -n "${APP_GID}" ] || { \
+      echo "APP_UID and APP_GID are required build-args (build via build-otel-shim.sh, which detects them)" >&2; \
+      exit 1; }
 
 USER root
 # Our own static uv, pinned by digest: a builder-stage image may have neither
@@ -48,7 +58,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.24@sha256:816fdce3387ed2142e37d2e56e1b1b97c
 # `--system --break-system-packages` lets the install land in a non-venv
 # python too; both flags are inert when --python is a venv.
 ARG OTEL_CONTRIB_VERSION=0.65b0
-RUN uv pip install --no-cache --python ${VENV_PYTHON} --system --break-system-packages \
+RUN uv pip install --no-cache --python "${VENV_PYTHON}" --system --break-system-packages \
       "opentelemetry-distro==${OTEL_CONTRIB_VERSION}" \
       "opentelemetry-instrumentation-starlette==${OTEL_CONTRIB_VERSION}" \
       "opentelemetry-instrumentation-asgi==${OTEL_CONTRIB_VERSION}" \
@@ -61,7 +71,7 @@ RUN uv pip install --no-cache --python ${VENV_PYTHON} --system --break-system-pa
 # The hook, into the same environment: `site` imports every .pth at
 # interpreter start; the module no-ops unless LINEAGE_PROPAGATE=1.
 COPY lineage-propagate-hook.py /tmp/lineage-propagate-hook.py
-RUN sp="$(${VENV_PYTHON} -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" \
+RUN sp="$("${VENV_PYTHON}" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')" \
  && install -m 0644 /tmp/lineage-propagate-hook.py "${sp}/_lineage_propagate.py" \
  && printf 'import _lineage_propagate\n' > "${sp}/zz-lineage-propagate.pth" \
  && rm /tmp/lineage-propagate-hook.py

--- a/authbridge/lineage-attach/README.md
+++ b/authbridge/lineage-attach/README.md
@@ -1,0 +1,251 @@
+# Lineage — per-request data lineage from the AuthBridge sidecar
+
+Every HTTP exchange a workload takes part in crosses its pod's network
+boundary. A sidecar at that boundary sees all of it — who called whom, over
+which protocol, with what outcome, and — if you switch it on — what was said.
+Attach the AuthBridge sidecar to a Deployment that is **already running**,
+switch on the `lineage-telemetry` plugin, and each exchange becomes **two
+OTLP spans**, request and response, sent to any OTLP consumer. The application
+is not asked to do anything, and nothing about what it does enters into it.
+
+One thing the boundary cannot see is which inbound request caused which
+outbound call. Only code running inside the request can carry that, and it
+does so by forwarding two headers, `traceparent` and `tracestate`. So the app image gets one
+inert layer — stock OpenTelemetry auto-instrumentation with every exporter
+off — that wakes on a single environment variable and forwards the header.
+The app's source, command and manifests stay as its owner wrote them.
+
+That is the whole attachment: a ConfigMap and a strategic-merge patch on the
+cluster side, an image reference and one variable on the app side. It is
+additive, it is reversible with one `rollout undo`, and it is the same for
+every workload in the fleet — an agent, a tool, a relay, a service nobody
+remembers writing.
+
+> **Until a release carries the plugin, build the sidecar yourself.** The
+> published `ghcr.io/rossoctl/cortex/authbridge-envoy` image boots without
+> `lineage-telemetry` and logs `unknown plugin`. The plugin is cortex #761;
+> [RECIPE.md](RECIPE.md) step 1 builds and loads `authbridge-envoy` + `proxy-init`
+> from a tree that carries it.
+
+**Start here:** [RECIPE.md](RECIPE.md) — six steps, expected output, back
+out. **Why it works and where it stops:** [DESIGN.md](DESIGN.md).
+
+---
+
+## What you get
+
+Per HTTP exchange, two spans. The request span is named
+`{self_id} {protocol} {operation}`, the response span appends ` response`; the
+pair is joined by `lineage.exchange.id` (the request span's own id):
+
+| attribute | what it records |
+|---|---|
+| `lineage.exchange.id` · `lineage.role` | pairs the two spans of one exchange; `request` / `response` |
+| `lineage.direction` · `lineage.self.id` · `lineage.peer.host` | `inbound` / `outbound`; this workload's stable id; the other end |
+| `lineage.protocol` | `a2a` / `mcp` / `inference` / `http` |
+| `lineage.outcome`, `lineage.denied_by` | how the exchange ended |
+| `lineage.principal.sub`, `lineage.principal.client` | the caller's identity when a validated token carried one (the generated pipeline runs no `jwt-validation`, so not with the generated ConfigMap) |
+| `lineage.parent.source` | `tracestate` — parented on the previous sidecar's stamp; `wire` — on a `traceparent` that arrived without a stamp; `none` — nothing valid arrived, so this hop roots a trace and a `traceparent` is minted for the next |
+| `input.value` / `output.value` | with `capture_io: true`: the parsed A2A message, MCP arguments or LLM prompt, cut at `max_payload_bytes` (4096 unless `MAX_PAYLOAD_BYTES` says otherwise) with a visible marker |
+
+The attributes are the plugin's: [`plugin-catalog.md`](../docs/plugin-catalog.md#lineage-telemetry)
+lists its knobs, [`lineage-wire-contract.md`](../docs/lineage-wire-contract.md) the wire format.
+
+A well-propagated trace has exactly one unstamped hop, at the entry: `wire`
+when the caller sent a `traceparent`, `none` when it sent nothing. Every other
+unstamped hop marks a pod that did not carry the context through — `none` when
+its app sent no `traceparent` at all, `wire` when it forwarded one without the
+stamp — and the subtree beneath it is visibly its own trace rather than
+silently misattributed. The spans say
+what happened on the wire; whatever consumes them decides what it means.
+
+---
+
+## How to attach
+
+The target is a Deployment that already exists. `attach-lineage.sh` generates
+exactly two things — the per-app plugin ConfigMap (`EMIT=cm`) and a
+strategic-merge patch with the sidecar pieces (`EMIT=patch`, the default) —
+and there are two ways to consume them.
+
+### Adopt a live Deployment
+
+```sh
+DEPLOY=<deployment> [APP_CONTAINER=<container> APP_IMAGE=docker.io/library/<app>-otel:latest] ./sidecar-patch.sh
+```
+
+`sidecar-patch.sh` checks the preconditions (the Deployment exists, the
+platform-rendered `envoy-config` ConfigMap is in the namespace, no container
+already named `envoy-proxy`/`proxy-init`, no port collision, `APP_CONTAINER`
+names a real container), applies the ConfigMap,
+patches the Deployment, and waits for the rollout. The patch only *adds*:
+lists merge by name, so everything the owner wrote stays as written. To back
+out, `kubectl rollout undo deploy/<name> --to-revision=<n>` with the revision
+the script printed (the patch is one revision), then delete
+`authbridge-lineage-config-<name>`.
+
+Two limits. **The target must not already carry an AuthBridge sidecar** — a
+platform-enrolled workload (an `AgentRuntime` CR) has an injected one, also
+named `envoy-proxy`, so the script refuses rather than merge into it; see the
+namespace route below. **A patch is not durable** — the owner still owns the
+Deployment, and a platform-side rewrite (operator reconcile, chart upgrade, UI
+redeploy) silently drops the sidecar. Re-run after such a change, or keep the
+attachment in the manifests.
+
+### Bring your own manifests
+
+If you own the app's manifests, make lineage part of them instead — the
+attachment then survives every re-deploy:
+
+```sh
+NAME=my-agent EMIT=cm    ./attach-lineage.sh > lineage-cm.yaml
+NAME=my-agent EMIT=patch APP_CONTAINER=agent APP_IMAGE=docker.io/library/my-agent-otel:latest \
+  ./attach-lineage.sh > lineage-patch.yaml
+```
+
+```yaml
+# kustomization.yaml
+resources: [deployment.yaml, service.yaml, lineage-cm.yaml]   # yours untouched, plus the generated cm
+patches:
+  - path: lineage-patch.yaml
+    target: { kind: Deployment, name: my-agent }
+```
+
+### The propagation half
+
+Both routes attach **capture**. For *attribution* — outbound hops landing in
+the trace of the inbound that caused them — the app must forward
+`traceparent`: its own instrumentation, or the shim:
+
+```sh
+./build-otel-shim.sh <your-app>:latest    # -> <your-app>-otel:latest, attested, kind-loaded
+```
+
+then hand the patch the container to switch on: `APP_CONTAINER=<name>` adds
+`LINEAGE_PROPAGATE=1` to that container's env (merged by name — nothing else
+in the container changes) and `APP_IMAGE=…-otel:latest` points it at the baked
+image. Without `APP_CONTAINER` the app container is not touched at all.
+
+The `-otel` image must be resolvable the way the base is: the patch swaps
+`image` and leaves `imagePullPolicy` alone, so a kind-loaded image needs
+`IfNotPresent` and a registry-pulled base needs the `-otel` tag pushed beside
+it. A Deployment whose env you cannot touch at all has one lever left, the
+image reference: `SELF_ACTIVATE=1 ./build-otel-shim.sh` bakes the switch in.
+
+### Enrolled workloads: the namespace-ConfigMap route
+
+When the platform injects its own AuthBridge sidecar (an `AgentRuntime` CR),
+lineage is enabled for the whole namespace by adding the three parsers +
+`lineage-telemetry` to both directions of the operator-rendered
+`authbridge-runtime-config` ConfigMap. Leave `self_id` unset — each pod
+resolves its identity from the operator-mounted credential. The propagation
+half is unchanged, and a platform upgrade re-renders the ConfigMap; re-apply
+after one. This route is described here, not exercised: nothing in this kit
+generates that edit.
+
+---
+
+## What it costs, per workload
+
+Deploying the app is your work and stays your work. Attaching lineage adds
+two commands and no YAML:
+
+| step | command | per | done for you |
+|---|---|---|---|
+| bake | `./build-otel-shim.sh <image>` | image | interpreter and uid detection, the interlock, the attestation, the kind load |
+| attach | `DEPLOY=<name> APP_CONTAINER=<c> APP_IMAGE=…-otel:latest ./sidecar-patch.sh` | Deployment | the ConfigMap, the patch, five preconditions, the rollout wait |
+
+Capture only is one command, the attach without `APP_CONTAINER`. A fleet is
+two loops (RECIPE "A fleet"). Then read the *shape* of one trace: one root per
+turn, unstamped only at the entry.
+
+---
+
+## Prerequisites and configuration
+
+- A cluster with the platform installed and the platform-rendered
+  **`envoy-config` ConfigMap** in the target namespace (the sidecar mounts it).
+- Sidecar images resolvable from the cluster: `SIDECAR_IMAGE` /
+  `PROXY_INIT_IMAGE`, defaulting to the published
+  `ghcr.io/rossoctl/cortex/{authbridge-envoy,proxy-init}:latest` — see the
+  caveat at the top.
+- An **OTLP/gRPC endpoint**, `OTEL_ENDPOINT`, default
+  `otel-collector.rossoctl-system.svc.cluster.local:4317`. Nothing downstream
+  is assumed; DESIGN "Where you see the spans" covers the platform collector.
+- **Know what leaves the pod.** Content capture is off by default, as in the
+  plugin. `CAPTURE_IO=true` makes the spans carry parsed content: LLM prompts,
+  MCP arguments, A2A messages, cut at 4,096 bytes (`MAX_PAYLOAD_BYTES`;
+  `-1` keeps them whole). That content is
+  PII-bearing. It travels to `OTEL_ENDPOINT` as plain gRPC unless the endpoint
+  starts with `https://`, and on the stock platform the collector prints every
+  attribute into its own pod log.
+
+The generated ConfigMap's plugin entry:
+
+```yaml
+- name: lineage-telemetry
+  config:
+    otel_endpoint: "otel-collector.rossoctl-system.svc.cluster.local:4317"   # host:port; https:// prefix turns on TLS
+    capture_io: false     # the plugin's default; CAPTURE_IO=true attaches the parsed content — PII lives in it
+    self_id: "<deploy>"   # falls back to self_id_file (the operator-mounted credential)
+    # max_payload_bytes: 4096 — the plugin's default cap on a captured value (MAX_PAYLOAD_BYTES); bypass_paths / bypass_hosts as below
+```
+
+`bypass_paths` / `bypass_hosts` keep infrastructure noise out (agent-card
+discovery, health probes, telemetry backends). `OUTBOUND_PORTS_EXCLUDE` keeps
+a port out of the iptables redirect: an app's own telemetry export port, or a
+**plaintext non-HTTP store** it talks to (Postgres 5432, SMTP 1025, Redis 6379
+— the outbound listener's HTTP codec would close them; DESIGN "What the
+sidecar can and cannot see"). Never exclude LLM, tool, peer or S3 ports.
+`NO_EMIT=1` keeps the sidecar as a pure proxy — a clean A/B baseline.
+Script knobs: `NAME`/`DEPLOY`, `NAMESPACE`, `SELF_ID`, `OTEL_ENDPOINT`,
+`CAPTURE_IO`, `MAX_PAYLOAD_BYTES`, `APP_CONTAINER`, `APP_IMAGE`, `OUTBOUND_PORTS_EXCLUDE`, `SIDECAR_IMAGE`,
+`PROXY_INIT_IMAGE`, `NO_EMIT`, `EMIT`; each script's header documents its own.
+
+---
+
+## Files
+
+Two moments, eight files. The bake happens once per image, on a laptop; the
+attach once per Deployment, against the cluster. The only thing that crosses
+between them is an image reference.
+
+```
+BAKE — once per app image                 ATTACH — once per Deployment
+  build-otel-shim.sh <app>:latest           sidecar-patch.sh DEPLOY=<name> [APP_CONTAINER= APP_IMAGE=]
+    ├─ container-runtime.sh   podman/docker, kind load     ├─ checks    Deployment · envoy-config · names · ports · container
+    ├─ Dockerfile.otel-shim   + lineage-propagate-hook.py  ├─ attach-lineage.sh EMIT=cm    → kubectl apply
+    └─ <app>-otel:latest      inert until LINEAGE_PROPAGATE=1 ├─ attach-lineage.sh EMIT=patch → kubectl patch
+                                                            └─ kubectl rollout status
+```
+
+| file | what it is |
+|---|---|
+| `RECIPE.md` · `DESIGN.md` | the step-by-step; the reasoning, envelope and limits |
+| `attach-lineage.sh` | **the one generator** — every YAML byte of the attachment, `EMIT=patch` / `EMIT=cm`, env-driven, stdout only, every input validated or refused |
+| `sidecar-patch.sh` | the live applier: preconditions, then ConfigMap + patch + rollout wait; owns no YAML |
+| `Dockerfile.otel-shim` | the propagate-only layer, one recipe for every in-envelope app, instrumentors pinned to one contrib release |
+| `build-otel-shim.sh` | bakes, attests (gate off: nothing OTel-shaped loads; gate on: a `traceparent` is injected), kind-loads; refuses images it cannot safely wrap |
+| `lineage-propagate-hook.py` | the env-gated site hook the Dockerfile installs (`.pth` + module); read its docstring for the contract |
+| `container-runtime.sh` | sourced helper: docker vs podman, kind load either way |
+
+---
+
+## Troubleshooting
+
+| symptom | cause |
+|---|---|
+| No spans at all | Wrong `OTEL_ENDPOINT`, or the sidecar image predates the plugin — read the `envoy-proxy` container's log. |
+| `envoy-proxy` restarts with `unknown plugin "lineage-telemetry"` | The published image, until a release carries the plugin. Build from this repo (RECIPE step 1); `rollout undo` meanwhile. The patch pulls `IfNotPresent`, so a node that cached an older `:latest` keeps it. |
+| Only inbound hops, never outbound | `proxy-init` did not install its iptables rules — its log. |
+| Outbound hops fragment (`lineage.parent.source=none` on the pod's outbound hops) | `traceparent` not propagating: the app container lacks `LINEAGE_PROPAGATE=1` (the patch sets it with `APP_CONTAINER`; an operator-owned Deployment needs `SELF_ACTIVATE=1`), or the call runs in a worker thread (the `threading` instrumentor is bundled), or the client library is outside the envelope. Only the entry hop dangling is expected. |
+| The app cannot reach its database / mail server after the patch | A plaintext non-HTTP port went through the outbound HTTP codec — `OUTBOUND_PORTS_EXCLUDE` it. |
+| A non-HTTP port the app *serves* stops answering after the patch | Inbound is redirected too, and there is no inbound exclusion knob; the app cannot be adopted as is (DESIGN "What the sidecar can and cannot see"). `rollout undo`. |
+| Nothing captured when testing | `kubectl port-forward` reaches the app on loopback and bypasses the sidecar. Drive from inside the cluster. |
+| `kind load` fails under podman | `container-runtime.sh` saves + loads an archive for podman v5; `CONTAINER_TOOL` forces a runtime, `KIND_CLUSTER_NAME` the cluster. |
+| Sidecar `ImagePullBackOff` | `SIDECAR_IMAGE` / `PROXY_INIT_IMAGE` unresolvable from the cluster. |
+| App container `ErrImagePull` after the patch | `APP_IMAGE` unresolvable under the container's own `imagePullPolicy` ("The propagation half"). `rollout undo`. |
+| Pod stuck `ContainerCreating`, `configmap "envoy-config" not found` | Not a platform-set-up namespace (`sidecar-patch.sh` checks; the manifests route cannot). |
+| `sidecar-patch.sh` refuses: "already has a container named …" | The target carries an `envoy-proxy` container or a `proxy-init` init container — enrolled workload, another mesh, or an earlier attach. Namespace route for the first; `rollout undo` the last. |
+| `sidecar-patch.sh` refuses: "already declares containerPort …" | An undeclared sidecar, or the app itself listens on 9090/15123/15124; the latter cannot be adopted. |
+| `sidecar-patch.sh` refuses: "has no container named …" | `APP_CONTAINER` matches nothing; a strategic merge would otherwise *add* a stub container by that name. |

--- a/authbridge/lineage-attach/README.md
+++ b/authbridge/lineage-attach/README.md
@@ -17,8 +17,8 @@ The app's source, command and manifests stay as its owner wrote them.
 
 That is the whole attachment: a ConfigMap and a strategic-merge patch on the
 cluster side, an image reference and one variable on the app side. It is
-additive, it is reversible with one `rollout undo`, and it is the same for
-every workload in the fleet — an agent, a tool, a relay, a service nobody
+additive, it is reversible with one printed reverse patch, and it is the same
+for every workload in the fleet — an agent, a tool, a relay, a service nobody
 remembers writing.
 
 > **Until a release carries the plugin, build the sidecar yourself.** The
@@ -76,13 +76,21 @@ DEPLOY=<deployment> [APP_CONTAINER=<container> APP_IMAGE=docker.io/library/<app>
 
 `sidecar-patch.sh` checks the preconditions (the Deployment exists, the
 platform-rendered `envoy-config` ConfigMap is in the namespace, no container
-already named `envoy-proxy`/`proxy-init`, no port collision, `APP_CONTAINER`
-names a real container), applies the ConfigMap,
+already named `envoy-proxy`/`proxy-init`, no port collision, no volume
+already named `envoy-config`/`authbridge-runtime` — volumes merge by name
+too, so an existing one would have its source silently repointed —
+`APP_CONTAINER` names a real container), applies the ConfigMap,
 patches the Deployment, and waits for the rollout. The patch only *adds*:
 lists merge by name, so everything the owner wrote stays as written. To back
-out, `kubectl rollout undo deploy/<name> --to-revision=<n>` with the revision
-the script printed (the patch is one revision), then delete
-`authbridge-lineage-config-<name>`.
+out, run the reverse-patch line the script printed — a strategic merge that
+`$patch: delete`s exactly what the attach added and restores the app image it
+replaced, leaving every later change of the owner's in place — then delete
+`authbridge-lineage-config-<name>`. (A `rollout undo` is not a back-out: it
+restores a whole earlier pod template, silently taking with it anything the
+owner changed since the attach.) The line is reconstructible without
+scrollback: `EMIT=undo` with the attach's `NAME`/`NAMESPACE`/`APP_CONTAINER`
+plus `RESTORE_IMAGE=<pre-attach ref>` regenerates the patch — not `APP_IMAGE`,
+which is the ref to *install* and is refused in undo mode (RECIPE step 5).
 
 Two limits. **The target must not already carry an AuthBridge sidecar** — a
 platform-enrolled workload (an `AgentRuntime` CR) has an injected one, also
@@ -153,7 +161,7 @@ two commands and no YAML:
 | step | command | per | done for you |
 |---|---|---|---|
 | bake | `./build-otel-shim.sh <image>` | image | interpreter and uid detection, the interlock, the attestation, the kind load |
-| attach | `DEPLOY=<name> APP_CONTAINER=<c> APP_IMAGE=…-otel:latest ./sidecar-patch.sh` | Deployment | the ConfigMap, the patch, five preconditions, the rollout wait |
+| attach | `DEPLOY=<name> APP_CONTAINER=<c> APP_IMAGE=…-otel:latest ./sidecar-patch.sh` | Deployment | the ConfigMap, the patch, six preconditions, the rollout wait |
 
 Capture only is one command, the attach without `APP_CONTAINER`. A fleet is
 two loops (RECIPE "A fleet"). Then read the *shape* of one trace: one root per
@@ -236,16 +244,17 @@ BAKE — once per app image                 ATTACH — once per Deployment
 | symptom | cause |
 |---|---|
 | No spans at all | Wrong `OTEL_ENDPOINT`, or the sidecar image predates the plugin — read the `envoy-proxy` container's log. |
-| `envoy-proxy` restarts with `unknown plugin "lineage-telemetry"` | The published image, until a release carries the plugin. Build from this repo (RECIPE step 1); `rollout undo` meanwhile. The patch pulls `IfNotPresent`, so a node that cached an older `:latest` keeps it. |
+| `envoy-proxy` restarts with `unknown plugin "lineage-telemetry"` | The published image, until a release carries the plugin. Build from this repo (RECIPE step 1); the printed back-out line meanwhile. The patch pulls `IfNotPresent`, so a node that cached an older `:latest` keeps it. |
 | Only inbound hops, never outbound | `proxy-init` did not install its iptables rules — its log. |
 | Outbound hops fragment (`lineage.parent.source=none` on the pod's outbound hops) | `traceparent` not propagating: the app container lacks `LINEAGE_PROPAGATE=1` (the patch sets it with `APP_CONTAINER`; an operator-owned Deployment needs `SELF_ACTIVATE=1`), or the call runs in a worker thread (the `threading` instrumentor is bundled), or the client library is outside the envelope. Only the entry hop dangling is expected. |
 | The app cannot reach its database / mail server after the patch | A plaintext non-HTTP port went through the outbound HTTP codec — `OUTBOUND_PORTS_EXCLUDE` it. |
-| A non-HTTP port the app *serves* stops answering after the patch | Inbound is redirected too, and there is no inbound exclusion knob; the app cannot be adopted as is (DESIGN "What the sidecar can and cannot see"). `rollout undo`. |
+| A non-HTTP port the app *serves* stops answering after the patch | Inbound is redirected too, and there is no inbound exclusion knob; the app cannot be adopted as is (DESIGN "What the sidecar can and cannot see"). Run the printed back-out line. |
 | Nothing captured when testing | `kubectl port-forward` reaches the app on loopback and bypasses the sidecar. Drive from inside the cluster. |
 | `kind load` fails under podman | `container-runtime.sh` saves + loads an archive for podman v5; `CONTAINER_TOOL` forces a runtime, `KIND_CLUSTER_NAME` the cluster. |
 | Sidecar `ImagePullBackOff` | `SIDECAR_IMAGE` / `PROXY_INIT_IMAGE` unresolvable from the cluster. |
-| App container `ErrImagePull` after the patch | `APP_IMAGE` unresolvable under the container's own `imagePullPolicy` ("The propagation half"). `rollout undo`. |
+| App container `ErrImagePull` after the patch | `APP_IMAGE` unresolvable under the container's own `imagePullPolicy` ("The propagation half"). Run the printed back-out line. |
 | Pod stuck `ContainerCreating`, `configmap "envoy-config" not found` | Not a platform-set-up namespace (`sidecar-patch.sh` checks; the manifests route cannot). |
-| `sidecar-patch.sh` refuses: "already has a container named …" | The target carries an `envoy-proxy` container or a `proxy-init` init container — enrolled workload, another mesh, or an earlier attach. Namespace route for the first; `rollout undo` the last. |
+| `sidecar-patch.sh` refuses: "already has a container named …" | The target carries an `envoy-proxy` container or a `proxy-init` init container — enrolled workload, another mesh, or an earlier attach. Namespace route for the first; the printed back-out line for the last. |
 | `sidecar-patch.sh` refuses: "already declares containerPort …" | An undeclared sidecar, or the app itself listens on 9090/15123/15124; the latter cannot be adopted. |
+| `sidecar-patch.sh` refuses: "already has a volume named …" | The target owns a volume named `envoy-config` or `authbridge-runtime`. Volumes merge by name, so the patch would silently repoint that volume's source under the owner's own mounts; the target cannot be adopted until the owner renames their volume. |
 | `sidecar-patch.sh` refuses: "has no container named …" | `APP_CONTAINER` matches nothing; a strategic merge would otherwise *add* a stub container by that name. |

--- a/authbridge/lineage-attach/README.md
+++ b/authbridge/lineage-attach/README.md
@@ -211,9 +211,11 @@ In the cluster:
   `initContainers` entry with `restartPolicy: Always`), on by default since 1.29
   (GA in 1.33). On an older cluster the apiserver rejects the native-sidecar
   fields (`startupProbe: Forbidden: may not be set for init containers without
-  restartPolicy=Always`) — loud, before any write, on **both** routes: the adopt
-  path hits it at `sidecar-patch.sh`'s server-side dry-run (which adds a
-  needs-1.29 hint), the manifests route at your own `kubectl apply`.
+  restartPolicy=Always`) — loud, on **both** routes: the adopt path at
+  `sidecar-patch.sh`'s server-side dry-run, before any write (with a needs-1.29
+  hint); the manifests route at your own `kubectl apply` of the Deployment —
+  the ConfigMap from that same apply does persist, inert on its own (no pod
+  references it), so delete it if you back off.
 - Sidecar images resolvable from the cluster: `SIDECAR_IMAGE` /
   `PROXY_INIT_IMAGE`, defaulting to the published
   `ghcr.io/rossoctl/cortex/{authbridge-envoy,proxy-init}:latest` — see the

--- a/authbridge/lineage-attach/README.md
+++ b/authbridge/lineage-attach/README.md
@@ -22,10 +22,14 @@ for every workload in the fleet — an agent, a tool, a relay, a service nobody
 remembers writing.
 
 > **Until a release carries the plugin, build the sidecar yourself.** The
-> published `ghcr.io/rossoctl/cortex/authbridge-envoy` image boots without
-> `lineage-telemetry` and logs `unknown plugin`. The plugin is cortex #761;
+> published `ghcr.io/rossoctl/cortex/authbridge-envoy` image does not carry
+> `lineage-telemetry`, and the sidecar *crashloops* on the unknown plugin name
+> (`plugins.Build` fails closed) — and because `proxy-init` has already
+> redirected the pod's egress, the workload is **down**, not merely
+> un-instrumented, until you back out. The plugin is cortex #761;
 > [RECIPE.md](RECIPE.md) step 1 builds and loads `authbridge-envoy` + `proxy-init`
-> from a tree that carries it.
+> from a tree that carries it. To run on a stock image meanwhile, `NO_EMIT=1`
+> gives a graceful parsers-only sidecar (the parsers predate the plugin).
 
 **Start here:** [RECIPE.md](RECIPE.md) — six steps, expected output, back
 out. **Why it works and where it stops:** [DESIGN.md](DESIGN.md).
@@ -50,6 +54,8 @@ pair is joined by `lineage.exchange.id` (the request span's own id):
 
 The attributes are the plugin's: [`plugin-catalog.md`](../docs/plugin-catalog.md#lineage-telemetry)
 lists its knobs, [`lineage-wire-contract.md`](../docs/lineage-wire-contract.md) the wire format.
+(Both docs arrive with the `lineage-telemetry` plugin in cortex #761; the links
+resolve once it lands.)
 
 A well-propagated trace has exactly one unstamped hop, at the entry: `wire`
 when the caller sent a `traceparent`, `none` when it sent nothing. Every other
@@ -78,10 +84,12 @@ DEPLOY=<deployment> [APP_CONTAINER=<container> APP_IMAGE=docker.io/library/<app>
 platform-rendered `envoy-config` ConfigMap is in the namespace, no container
 already named `envoy-proxy`/`proxy-init`, no port collision, no volume
 already named `envoy-config`/`authbridge-runtime` — volumes merge by name
-too, so an existing one would have its source silently repointed —
+too, so an existing one would have its source silently repointed — and
 `APP_CONTAINER` names a real container), applies the ConfigMap,
-patches the Deployment, and waits for the rollout. The patch only *adds*:
-lists merge by name, so everything the owner wrote stays as written. To back
+patches the Deployment, and waits for the rollout. The patch only *adds* —
+lists merge by name, so everything the owner wrote stays as written — except
+the app container's `image`, which it replaces when `APP_IMAGE` is given (the
+back-out restores the original). To back
 out, run the reverse-patch line the script printed — a strategic merge that
 `$patch: delete`s exactly what the attach added and restores the app image it
 replaced, leaving every later change of the owner's in place — then delete
@@ -106,10 +114,16 @@ If you own the app's manifests, make lineage part of them instead — the
 attachment then survives every re-deploy:
 
 ```sh
-NAME=my-agent EMIT=cm    ./attach-lineage.sh > lineage-cm.yaml
-NAME=my-agent EMIT=patch APP_CONTAINER=agent APP_IMAGE=docker.io/library/my-agent-otel:latest \
+NAME=my-agent NAMESPACE=my-ns EMIT=cm    ./attach-lineage.sh > lineage-cm.yaml
+NAME=my-agent NAMESPACE=my-ns EMIT=patch APP_CONTAINER=agent APP_IMAGE=docker.io/library/my-agent-otel:latest \
   ./attach-lineage.sh > lineage-patch.yaml
 ```
+
+`NAMESPACE` defaults to `team1` and is written into the generated ConfigMap —
+set it to your app's namespace. Omit it and the ConfigMap is stamped
+`namespace: team1` while kustomize still places the Deployment in its own
+namespace: the patched pod then mounts a ConfigMap that is not there and hangs
+in `ContainerCreating`.
 
 ```yaml
 # kustomization.yaml
@@ -132,13 +146,17 @@ the trace of the inbound that caused them — the app must forward
 then hand the patch the container to switch on: `APP_CONTAINER=<name>` adds
 `LINEAGE_PROPAGATE=1` to that container's env (merged by name — nothing else
 in the container changes) and `APP_IMAGE=…-otel:latest` points it at the baked
-image. Without `APP_CONTAINER` the app container is not touched at all.
+image. Without `APP_CONTAINER` the app container is not touched at all. The
+sidecar is a native initContainer, not a regular one, so the app stays the
+pod's sole regular container — `kubectl logs`/`exec` without `-c` keep hitting
+it, unchanged.
 
 The `-otel` image must be resolvable the way the base is: the patch swaps
 `image` and leaves `imagePullPolicy` alone, so a kind-loaded image needs
 `IfNotPresent` and a registry-pulled base needs the `-otel` tag pushed beside
 it. A Deployment whose env you cannot touch at all has one lever left, the
-image reference: `SELF_ACTIVATE=1 ./build-otel-shim.sh` bakes the switch in.
+image reference: `SELF_ACTIVATE=1 ./build-otel-shim.sh <your-app>:latest` bakes
+the switch in (the image argument is required).
 
 ### Enrolled workloads: the namespace-ConfigMap route
 
@@ -171,8 +189,31 @@ turn, unstamped only at the entry.
 
 ## Prerequisites and configuration
 
+On the host running the scripts:
+
+- **`kubectl`** (the attach path) and **`kind`** (the bake's image load) on
+  `PATH`; a container engine, **podman** or **docker** (`CONTAINER_TOOL`
+  selects, nothing else is supported); **`python3`** for the verify step.
+- **Network egress at bake time** to `ghcr.io/astral-sh/uv` and PyPI — the
+  shim build pulls `uv` and the OpenTelemetry packages. `NO_KIND_LOAD=1` skips
+  only the cluster load, not the build, so the bake is not offline-capable;
+  the image *probes* run `--network=none`, the build does not.
+- **RBAC** in the target namespace: get/patch/watch `deployments` (the rollout
+  wait watches) and get/create/patch/delete `configmaps` (a re-attach `apply`s —
+  i.e. patches — over an existing ConfigMap); the verify step also needs `create pods` in
+  the namespace and `get deployments` + `get pods/log` in `rossoctl-system`.
+
+In the cluster:
+
 - A cluster with the platform installed and the platform-rendered
   **`envoy-config` ConfigMap** in the target namespace (the sidecar mounts it).
+- **Kubernetes ≥ 1.29** — the sidecar is attached as a *native sidecar* (an
+  `initContainers` entry with `restartPolicy: Always`), on by default since 1.29
+  (GA in 1.33). On an older cluster the apiserver rejects the native-sidecar
+  fields (`startupProbe: Forbidden: may not be set for init containers without
+  restartPolicy=Always`) — loud, before any write, on **both** routes: the adopt
+  path hits it at `sidecar-patch.sh`'s server-side dry-run (which adds a
+  needs-1.29 hint), the manifests route at your own `kubectl apply`.
 - Sidecar images resolvable from the cluster: `SIDECAR_IMAGE` /
   `PROXY_INIT_IMAGE`, defaulting to the published
   `ghcr.io/rossoctl/cortex/{authbridge-envoy,proxy-init}:latest` — see the
@@ -206,7 +247,7 @@ a port out of the iptables redirect: an app's own telemetry export port, or a
 — the outbound listener's HTTP codec would close them; DESIGN "What the
 sidecar can and cannot see"). Never exclude LLM, tool, peer or S3 ports.
 `NO_EMIT=1` keeps the sidecar as a pure proxy — a clean A/B baseline.
-Script knobs: `NAME`/`DEPLOY`, `NAMESPACE`, `SELF_ID`, `OTEL_ENDPOINT`,
+Script knobs: `NAME`/`DEPLOY`, `NAMESPACE` (default `team1`), `SELF_ID`, `OTEL_ENDPOINT`,
 `CAPTURE_IO`, `MAX_PAYLOAD_BYTES`, `APP_CONTAINER`, `APP_IMAGE`, `OUTBOUND_PORTS_EXCLUDE`, `SIDECAR_IMAGE`,
 `PROXY_INIT_IMAGE`, `NO_EMIT`, `EMIT`; each script's header documents its own.
 
@@ -214,7 +255,7 @@ Script knobs: `NAME`/`DEPLOY`, `NAMESPACE`, `SELF_ID`, `OTEL_ENDPOINT`,
 
 ## Files
 
-Two moments, eight files. The bake happens once per image, on a laptop; the
+Two moments, nine files. The bake happens once per image, on a laptop; the
 attach once per Deployment, against the cluster. The only thing that crosses
 between them is an image reference.
 

--- a/authbridge/lineage-attach/README.md
+++ b/authbridge/lineage-attach/README.md
@@ -23,10 +23,13 @@ remembers writing.
 
 > **Until a release carries the plugin, build the sidecar yourself.** The
 > published `ghcr.io/rossoctl/cortex/authbridge-envoy` image does not carry
-> `lineage-telemetry`, and the sidecar *crashloops* on the unknown plugin name
-> (`plugins.Build` fails closed) — and because `proxy-init` has already
-> redirected the pod's egress, the workload is **down**, not merely
-> un-instrumented, until you back out. The plugin is cortex #761;
+> `lineage-telemetry`, so the generator **refuses** to emit a patch that pins
+> it (set `SIDECAR_IMAGE`, or `NO_EMIT=1`). What the refusal prevents: the
+> sidecar crashloops on the unknown plugin name (`plugins.Build` fails
+> closed), its startupProbe never passes, the app container never starts, and
+> a rolling update stalls with the **old pods still serving** — contained,
+> but nothing attaches. (Under `strategy: Recreate` the old pods are deleted
+> first, so there the workload would be down.) The plugin is cortex #761;
 > [RECIPE.md](RECIPE.md) step 1 builds and loads `authbridge-envoy` + `proxy-init`
 > from a tree that carries it. To run on a stock image meanwhile, `NO_EMIT=1`
 > gives a graceful parsers-only sidecar (the parsers predate the plugin).
@@ -238,12 +241,19 @@ The generated ConfigMap's plugin entry:
   config:
     otel_endpoint: "otel-collector.rossoctl-system.svc.cluster.local:4317"   # host:port; https:// prefix turns on TLS
     capture_io: false     # the plugin's default; CAPTURE_IO=true attaches the parsed content — PII lives in it
-    self_id: "<deploy>"   # falls back to self_id_file (the operator-mounted credential)
-    # max_payload_bytes: 4096 — the plugin's default cap on a captured value (MAX_PAYLOAD_BYTES); bypass_paths / bypass_hosts as below
+    self_id: "<deploy>"   # ALWAYS set (SELF_ID, default: the Deployment name) — see below
+    # max_payload_bytes: 4096 — the plugin's default cap on a captured value (MAX_PAYLOAD_BYTES)
 ```
 
-`bypass_paths` / `bypass_hosts` keep infrastructure noise out (agent-card
-discovery, health probes, telemetry backends). `OUTBOUND_PORTS_EXCLUDE` keeps
+`self_id` is always emitted: the plugin's `self_id_file` fallback (the
+operator-mounted credential, which can race its own Secret and fail the
+sidecar's boot) is deliberately never used on a ConfigMap this kit generates.
+The plugin's `bypass_paths` / `bypass_hosts` keep infrastructure noise out
+(agent-card discovery, health probes, telemetry backends) at their **plugin
+defaults** — they are not adjustable from this kit: setting either key
+*replaces* the default list rather than extending it, and a hand-edit of the
+generated ConfigMap only lasts until the next attach or back-out rewrites it.
+`OUTBOUND_PORTS_EXCLUDE` keeps
 a port out of the iptables redirect: an app's own telemetry export port, or a
 **plaintext non-HTTP store** it talks to (Postgres 5432, SMTP 1025, Redis 6379
 — the outbound listener's HTTP codec would close them; DESIGN "What the

--- a/authbridge/lineage-attach/RECIPE.md
+++ b/authbridge/lineage-attach/RECIPE.md
@@ -1,0 +1,118 @@
+# Recipe — attach lineage to a running Deployment
+
+A step-by-step for an operator or a coding agent. Every step is one command,
+the one line of output that means it worked, and what to do when it did not.
+Run from this directory. The explanations are in [README.md](README.md); the
+reasons behind them in [DESIGN.md](DESIGN.md).
+
+**Inputs.** `NS` — the namespace · `DEPLOY` — the Deployment · `CONTAINER` —
+the name of its app container (`kubectl -n $NS get deploy/$DEPLOY -o jsonpath='{.spec.template.spec.containers[*].name}'`)
+· `IMAGE` — that container's image, present locally under the name the engine knows it by (a podman build of
+`my-agent:latest` is `localhost/my-agent:latest`; a bare name is asked of the engine first, then taken as `docker.io/library/<name>`).
+
+## 0. Preconditions (read-only)
+
+| check | command | pass |
+|---|---|---|
+| the Deployment exists and is not platform-enrolled | `kubectl -n $NS get deploy $DEPLOY -o jsonpath='{.spec.template.spec.initContainers[*].name} {.spec.template.spec.containers[*].name}'` | prints the app container(s) only — no `proxy-init`, no `envoy-proxy` |
+| the platform rendered the sidecar's config here | `kubectl -n $NS get cm envoy-config` | found |
+| the app's image is local (for the bake) | `podman image exists $IMAGE` (docker: `docker image inspect $IMAGE >/dev/null`) | exit 0 |
+| an OTLP/gRPC collector is reachable in-cluster | `kubectl -n rossoctl-system get deploy otel-collector` | found (else set `OTEL_ENDPOINT` in step 3) |
+
+Enrolled workloads (an `AgentRuntime` CR) already carry a sidecar: this recipe
+refuses them by design; see README "Enrolled workloads".
+
+## 1. A sidecar image that carries the plugin (once per cluster, until a release does)
+
+The plugin is cortex #761: build from a tree that carries `authbridge/authlib/plugins/lineage/`
+(`main` once #761 has merged; the #761 branch until then).
+
+```sh
+( cd .. && podman build -f cmd/authbridge-envoy/Dockerfile -t docker.io/library/authbridge-envoy:latest . \
+            && podman build -f proxy-init/Dockerfile.init -t docker.io/library/proxy-init:latest proxy-init/ )
+for ref in authbridge-envoy proxy-init; do podman save docker.io/library/$ref:latest -o /tmp/$ref.tar \
+  && KIND_EXPERIMENTAL_PROVIDER=podman kind load image-archive /tmp/$ref.tar --name rossoctl; rm -f /tmp/$ref.tar; done
+export SIDECAR_IMAGE=docker.io/library/authbridge-envoy:latest PROXY_INIT_IMAGE=docker.io/library/proxy-init:latest
+```
+
+Pass: `podman exec <kind-node> crictl images | grep -E 'library/(authbridge-envoy|proxy-init)'` lists both.
+Docker hosts: `docker build` with the same `-f`/`-t`, then `kind load docker-image <ref> --name rossoctl`.
+Skip this step once the published `ghcr.io/rossoctl/cortex/authbridge-envoy` carries `lineage-telemetry`;
+the symptom of skipping it too early is the sidecar crash-looping with `unknown plugin "lineage-telemetry"`.
+
+## 2. Bake the propagation shim onto the app image (once per image)
+
+```sh
+KIND_CLUSTER_NAME=rossoctl ./build-otel-shim.sh $IMAGE
+```
+
+Pass: last line `>> loaded docker.io/library/<name>-otel:latest into kind cluster rossoctl`
+(exit 0; the attestation runs before the load and prints nothing when it passes).
+Fail `REFUSING to bake … already instruments …` (exit 3): the app instruments itself — go to step 3 **without** `APP_CONTAINER`/`APP_IMAGE` (capture only).
+Fail `REFUSING to bake … no runnable Python found` (exit 3): outside the shim's envelope (DESIGN "The envelope") — same, capture only; or pass the interpreter as arg 3 if you know it.
+Fail `REFUSING to bake … is not present locally` (exit 3): wrong `IMAGE` — see Inputs; nothing was built.
+Fail `ATTESTATION FAILED` (exit 4): the bake itself is broken (the image was not loaded) — read the assertion it prints; not an app property.
+
+## 3. Attach (once per Deployment)
+
+```sh
+NAMESPACE=$NS DEPLOY=$DEPLOY APP_CONTAINER=$CONTAINER APP_IMAGE=docker.io/library/<name>-otel:latest ./sidecar-patch.sh
+```
+
+Add `OUTBOUND_PORTS_EXCLUDE=5432,1025` (comma-separated) if the app speaks a plaintext **non-HTTP**
+protocol to a store — Postgres, SMTP, Redis. Never exclude LLM, tool, peer or S3 ports.
+Set `OTEL_ENDPOINT=host:port` for a collector other than the platform's.
+
+Pass — the output ends with:
+```
+>> back out: kubectl -n <ns> rollout undo deploy/<deploy> --to-revision=<n> && kubectl -n <ns> delete cm authbridge-lineage-config-<deploy>
+deployment "<deploy>" successfully rolled out
+>> lineage sidecar attached to deploy/<deploy> (self_id=<deploy>, ns=<ns>)
+```
+(preceded by `configmap/authbridge-lineage-config-<deploy> created` and `deployment.apps/<deploy> patched`;
+the back-out line is printed before the rollout wait so it is there even when the wait fails).
+Add `CAPTURE_IO=true` to attach the parsed content — prompts, tool arguments, messages — to the spans (off by default; PII).
+Fail `already has a container named` / `already declares containerPort` → enrolled or colliding workload (README "How to attach").
+Fail `has no container named` → wrong `APP_CONTAINER`; nothing was applied.
+Rollout stuck → run the back-out line printed above, then read the sidecar log (step 4).
+
+## 4. Verify
+
+```sh
+kubectl -n $NS logs deploy/$DEPLOY -c envoy-proxy | grep 'lineage-telemetry: initialized'
+```
+Pass: `… endpoint=<otel_endpoint> self_id=<deploy>`.
+
+Then one request **from inside the cluster** (a port-forward bypasses the sidecar) with a trace id you choose:
+```sh
+T=$(python3 -c 'import secrets;print(secrets.token_hex(16))')
+kubectl -n $NS run drive --rm -i --restart=Never --image=curlimages/curl:8.11.1 -- \
+  curl -s -H "traceparent: 00-$T-0000000000000001-01" http://<service>:<port>/<path>    # any request the app answers
+kubectl -n rossoctl-system logs deploy/otel-collector | grep -c "$T"
+```
+Pass: a count ≥ 2 (one request span + one response span per exchange the app took part in).
+Attribution check, when the app calls out: every hop after the entry must show
+`lineage.parent.source: tracestate`; a `none` (or `wire`) on a non-entry hop is an un-propagated call
+(DESIGN "Why the shim is needed").
+
+## 5. Back out
+
+```sh
+kubectl -n $NS rollout undo deploy/$DEPLOY --to-revision=<n> && kubectl -n $NS delete cm authbridge-lineage-config-$DEPLOY
+```
+`<n>` is the revision step 3 printed in its last line — the spec as it was before the attach. A bare
+`rollout undo` goes one step back, which is that spec only if nothing rolled the Deployment since;
+`kubectl -n $NS rollout history deploy/$DEPLOY` lists the revisions if the line is gone. Delete the
+ConfigMap after the undo, not before: a revision that still mounts it cannot start without it.
+
+## A fleet
+
+Bake once per image, attach once per Deployment; two loops. Then check the **shape** of one trace
+(one root, unstamped only at the entry), not just that spans arrived.
+
+```sh
+for img in agent-a agent-b tool-x; do KIND_CLUSTER_NAME=rossoctl ./build-otel-shim.sh docker.io/library/$img:latest; done
+for d in agent-a agent-b tool-x; do
+  NAMESPACE=$NS DEPLOY=$d APP_CONTAINER=app APP_IMAGE=docker.io/library/$d-otel:latest ./sidecar-patch.sh
+done
+```

--- a/authbridge/lineage-attach/RECIPE.md
+++ b/authbridge/lineage-attach/RECIPE.md
@@ -14,7 +14,7 @@ the name of its app container (`kubectl -n $NS get deploy/$DEPLOY -o jsonpath='{
 
 | check | command | pass |
 |---|---|---|
-| the Deployment exists and is not platform-enrolled | `kubectl -n $NS get deploy $DEPLOY -o jsonpath='{.spec.template.spec.initContainers[*].name} {.spec.template.spec.containers[*].name}'` | prints the app container(s) only — no `proxy-init`, no `envoy-proxy` |
+| the Deployment exists and is not platform-enrolled | `kubectl -n $NS get deploy $DEPLOY -o jsonpath='{.spec.template.spec.initContainers[*].name} {.spec.template.spec.containers[*].name}'` | no `proxy-init`, no `envoy-proxy` (the target's own app/init containers are fine — the sidecar attaches as a native initContainer ahead of them) |
 | no volume-name collision (volumes merge by name too) | `kubectl -n $NS get deploy $DEPLOY -o jsonpath='{.spec.template.spec.volumes[*].name}'` | no `envoy-config`, no `authbridge-runtime` |
 | the platform rendered the sidecar's config here | `kubectl -n $NS get cm envoy-config` | found |
 | the app's image is local (for the bake) | `podman image exists $IMAGE` (docker: `docker image inspect $IMAGE >/dev/null`) | exit 0 |
@@ -74,7 +74,7 @@ deployment "<deploy>" successfully rolled out
 (preceded by `configmap/authbridge-lineage-config-<deploy> created` and `deployment.apps/<deploy> patched`;
 the back-out line is printed before the rollout wait so it is there even when the wait fails).
 Add `CAPTURE_IO=true` to attach the parsed content — prompts, tool arguments, messages — to the spans (off by default; PII).
-Fail `already has a container named` / `already declares containerPort` → enrolled or colliding workload (README "How to attach").
+Fail `already has a container named` / `already declares containerPort` / `already has a volume named` → enrolled or colliding workload (README "How to attach").
 Fail `has no container named` → wrong `APP_CONTAINER`; nothing was applied.
 Rollout stuck → the Deployment is left patched on purpose (Kubernetes keeps the old pod serving);
 run the back-out line printed above, then read the sidecar log (step 4).

--- a/authbridge/lineage-attach/RECIPE.md
+++ b/authbridge/lineage-attach/RECIPE.md
@@ -15,6 +15,7 @@ the name of its app container (`kubectl -n $NS get deploy/$DEPLOY -o jsonpath='{
 | check | command | pass |
 |---|---|---|
 | the Deployment exists and is not platform-enrolled | `kubectl -n $NS get deploy $DEPLOY -o jsonpath='{.spec.template.spec.initContainers[*].name} {.spec.template.spec.containers[*].name}'` | prints the app container(s) only — no `proxy-init`, no `envoy-proxy` |
+| no volume-name collision (volumes merge by name too) | `kubectl -n $NS get deploy $DEPLOY -o jsonpath='{.spec.template.spec.volumes[*].name}'` | no `envoy-config`, no `authbridge-runtime` |
 | the platform rendered the sidecar's config here | `kubectl -n $NS get cm envoy-config` | found |
 | the app's image is local (for the bake) | `podman image exists $IMAGE` (docker: `docker image inspect $IMAGE >/dev/null`) | exit 0 |
 | an OTLP/gRPC collector is reachable in-cluster | `kubectl -n rossoctl-system get deploy otel-collector` | found (else set `OTEL_ENDPOINT` in step 3) |
@@ -65,7 +66,8 @@ Set `OTEL_ENDPOINT=host:port` for a collector other than the platform's.
 
 Pass — the output ends with:
 ```
->> back out: kubectl -n <ns> rollout undo deploy/<deploy> --to-revision=<n> && kubectl -n <ns> delete cm authbridge-lineage-config-<deploy>
+>> back out: kubectl -n <ns> patch deploy/<deploy> --type strategic -p '<the reverse patch>' && kubectl -n <ns> delete cm authbridge-lineage-config-<deploy>
+>>   (the patch restores image <pre-attach ref> — drop its "image" field if the app is re-imaged after this attach)
 deployment "<deploy>" successfully rolled out
 >> lineage sidecar attached to deploy/<deploy> (self_id=<deploy>, ns=<ns>)
 ```
@@ -74,7 +76,8 @@ the back-out line is printed before the rollout wait so it is there even when th
 Add `CAPTURE_IO=true` to attach the parsed content — prompts, tool arguments, messages — to the spans (off by default; PII).
 Fail `already has a container named` / `already declares containerPort` → enrolled or colliding workload (README "How to attach").
 Fail `has no container named` → wrong `APP_CONTAINER`; nothing was applied.
-Rollout stuck → run the back-out line printed above, then read the sidecar log (step 4).
+Rollout stuck → the Deployment is left patched on purpose (Kubernetes keeps the old pod serving);
+run the back-out line printed above, then read the sidecar log (step 4).
 
 ## 4. Verify
 
@@ -97,13 +100,23 @@ Attribution check, when the app calls out: every hop after the entry must show
 
 ## 5. Back out
 
+Run the line step 3 printed: a strategic-merge **reverse patch** that deletes, by name, exactly
+what the attach added — and restores the app image it replaced — then deletes the ConfigMap:
+
 ```sh
-kubectl -n $NS rollout undo deploy/$DEPLOY --to-revision=<n> && kubectl -n $NS delete cm authbridge-lineage-config-$DEPLOY
+kubectl -n $NS patch deploy/$DEPLOY --type strategic -p '<the printed reverse patch>' \
+  && kubectl -n $NS delete cm authbridge-lineage-config-$DEPLOY
 ```
-`<n>` is the revision step 3 printed in its last line — the spec as it was before the attach. A bare
-`rollout undo` goes one step back, which is that spec only if nothing rolled the Deployment since;
-`kubectl -n $NS rollout history deploy/$DEPLOY` lists the revisions if the line is gone. Delete the
-ConfigMap after the undo, not before: a revision that still mounts it cannot start without it.
+
+It is right at any later time: whatever the owner rolled since the attach stays in place. (A
+`rollout undo` is not a back-out — it restores a whole earlier pod template, taking the owner's
+later changes with it.) Two caveats. The patch restores the pre-attach image ref — drop its
+`"image"` field if the app was re-imaged after the attach. And if the printed line is gone,
+regenerate the patch with the attach's own knobs:
+`EMIT=undo NAME=$DEPLOY NAMESPACE=$NS APP_CONTAINER=$CONTAINER RESTORE_IMAGE=<pre-attach ref> ./attach-lineage.sh`
+(leave `APP_CONTAINER`/`RESTORE_IMAGE` off for a capture-only attach; `APP_IMAGE` is the ref to
+INSTALL and `EMIT=undo` refuses it — reusing the attach line verbatim would "restore" the -otel image). Delete the ConfigMap after the
+patch, not before: pods of a revision that still mounts it cannot start without it.
 
 ## A fleet
 

--- a/authbridge/lineage-attach/RECIPE.md
+++ b/authbridge/lineage-attach/RECIPE.md
@@ -45,10 +45,13 @@ the symptom of skipping it too early is the sidecar crash-looping with `unknown 
 
 ```sh
 KIND_CLUSTER_NAME=rossoctl ./build-otel-shim.sh $IMAGE
+# positional: ./build-otel-shim.sh <base> [wrapper-tag] [venv-python] [app-uid[:gid]]
+# NO_KIND_LOAD=1 builds and attests only (skips the cluster load)
 ```
 
-Pass: last line `>> loaded docker.io/library/<name>-otel:latest into kind cluster rossoctl`
-(exit 0; the attestation runs before the load and prints nothing when it passes).
+Pass (exit 0): `>> loaded docker.io/library/<name>-otel:latest into kind cluster rossoctl`
+(a `>> NOTE:` block follows it, so this is not the literal last line; the
+attestation runs before the load and prints nothing when it passes).
 Fail `REFUSING to bake … already instruments …` (exit 3): the app instruments itself — go to step 3 **without** `APP_CONTAINER`/`APP_IMAGE` (capture only).
 Fail `REFUSING to bake … no runnable Python found` (exit 3): outside the shim's envelope (DESIGN "The envelope") — same, capture only; or pass the interpreter as arg 3 if you know it.
 Fail `REFUSING to bake … is not present locally` (exit 3): wrong `IMAGE` — see Inputs; nothing was built.
@@ -110,8 +113,13 @@ kubectl -n $NS patch deploy/$DEPLOY --type strategic -p '<the printed reverse pa
 
 It is right at any later time: whatever the owner rolled since the attach stays in place. (A
 `rollout undo` is not a back-out — it restores a whole earlier pod template, taking the owner's
-later changes with it.) Two caveats. The patch restores the pre-attach image ref — drop its
-`"image"` field if the app was re-imaged after the attach. And if the printed line is gone,
+later changes with it.) A few caveats. The patch restores the pre-attach image ref — drop its
+`"image"` field if the app was re-imaged after the attach. The `$patch: delete` on
+`LINEAGE_PROPAGATE` *removes* that env var — if the app owner set it themselves before the attach
+(unusual — it is the shim's activation), edit the line to restore their value instead. And unlike
+the attach, the printed line is raw `kubectl patch` with no precondition check, so if the app
+container was **renamed** after the attach, the `containers` entry would add a stub by the old
+name — regenerate with the current name. If the printed line is gone,
 regenerate the patch with the attach's own knobs:
 `EMIT=undo NAME=$DEPLOY NAMESPACE=$NS APP_CONTAINER=$CONTAINER RESTORE_IMAGE=<pre-attach ref> ./attach-lineage.sh`
 (leave `APP_CONTAINER`/`RESTORE_IMAGE` off for a capture-only attach; `APP_IMAGE` is the ref to

--- a/authbridge/lineage-attach/attach-lineage.sh
+++ b/authbridge/lineage-attach/attach-lineage.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# attach-lineage.sh — the one generator. Given a Deployment's NAME (and,
+# optionally, which of its containers to switch propagation on and with which
+# image), print ONE of the two objects that attach lineage to it:
+#
+#   EMIT=patch (default)  strategic-merge patch adding the sidecar pieces —
+#                         proxy-init initContainer, envoy-proxy container, two
+#                         config volumes — and, with APP_CONTAINER, the
+#                         propagation switch on the app's own container.
+#   EMIT=cm               the per-app plugin ConfigMap the sidecar mounts
+#                         (parser chain + lineage-telemetry entry).
+#
+# Apply both and the app's traffic flows through the lineage plugin. The app
+# itself is never described: no Deployment, no Service, no app config — lists
+# merge by name, so nothing the owner wrote changes. Stdout only; this script
+# never touches the cluster.
+#
+# Consumed by sidecar-patch.sh (live: checks, applies both, waits) or by your
+# own kustomization (the cm under resources:, the patch under patches: with
+# target kind Deployment / name NAME) — see README.md "How to attach".
+#
+# Propagation: capture alone cannot attribute an app's outbound calls to the
+# inbound that caused them. The sidecar forwards the trace context (a
+# traceparent when none arrived, plus its own tracestate stamp), but only code
+# running inside the request can carry it from the inbound to the outbound
+# calls it causes — the app must do that itself. For an
+# uninstrumented Python app, bake the shim first (build-otel-shim.sh), then
+# pass APP_CONTAINER (+ APP_IMAGE): the patch sets LINEAGE_PROPAGATE=1 on that
+# container, which wakes the baked hook. Without APP_CONTAINER the patch is
+# capture-only and the app container is not touched.
+#
+# Usage:
+#   NAME=echo-upstream ./attach-lineage.sh                     # the patch
+#   NAME=echo-upstream EMIT=cm ./attach-lineage.sh             # the ConfigMap
+#   NAME=my-agent APP_CONTAINER=agent \
+#     APP_IMAGE=docker.io/library/my-agent-otel:latest ./attach-lineage.sh
+#
+# Variables:
+#   NAME            (required) the target Deployment; also names the ConfigMap
+#                   (authbridge-lineage-config-NAME) and defaults SELF_ID
+#   NAMESPACE       default team1
+#   SELF_ID         lineage identity on every span (default NAME)
+#   APP_CONTAINER   the app container to set LINEAGE_PROPAGATE=1 on. MUST name
+#                   an existing container: a strategic merge ADDS a stub for an
+#                   unknown name. Checked by sidecar-patch.sh, not here.
+#   APP_IMAGE       needs APP_CONTAINER: the -otel image to set on it
+#   OTEL_ENDPOINT   OTLP/gRPC target for the plugin's spans (default: the
+#                   platform collector). Any OTLP consumer works. Plain gRPC
+#                   unless it starts with https://.
+#   CAPTURE_IO      false (default, the plugin's own) | true — whether the spans
+#                   carry the parsed content (input.value / output.value:
+#                   prompts, tool arguments, messages). PII-bearing: opt in.
+#   MAX_PAYLOAD_BYTES  cap on a captured value (plugin default 4096 when unset;
+#                   -1 = attach whole). Only meaningful with CAPTURE_IO=true.
+#   OUTBOUND_PORTS_EXCLUDE  ports proxy-init must not intercept — an app's OWN
+#                   telemetry export port (e.g. 4317), or a plaintext non-HTTP
+#                   store (Postgres 5432, SMTP 1025: the outbound HTTP codec
+#                   would close them). Never LLM/tool/S3 ports.
+#   SIDECAR_IMAGE   default ghcr.io/rossoctl/cortex/authbridge-envoy:latest —
+#                   UNTIL A RELEASE CARRIES lineage-telemetry (cortex #761) it
+#                   boots without the plugin; build from a tree that has it and
+#                   point this at your tag (RECIPE.md step 1)
+#   PROXY_INIT_IMAGE  default ghcr.io/rossoctl/cortex/proxy-init:latest
+#   NO_EMIT=1       omit the plugin entry: the sidecar proxies, emits nothing
+#                   (parsers alone are legal). The A/B baseline.
+#   EMIT            patch (default) | cm
+#
+# Structure: parse_inputs validates EVERY knob (all refusals live there);
+# build_* each assemble one optional YAML fragment into a global; the three
+# fragment functions are the single source of the sidecar YAML; emit()
+# dispatches to the two emitters.
+set -euo pipefail
+
+# Every free-form value lands in a double-quoted YAML scalar, where only '"'
+# and '\' are special — refusing those two is exactly sufficient. Whitespace
+# and control characters are refused as well: never part of an endpoint or
+# image ref, and a control character is illegal in YAML even inside quotes.
+yaml_safe() {  # $1 = what it is (for the error), $2 = the value
+  local unsafe=$'"\\'
+  case "$2" in
+    *["$unsafe"]*|*[[:space:][:cntrl:]]*)
+      printf "error: %s '%s' contains whitespace, a control character or one of %s, which this script cannot quote safely\n" "$1" "$2" "$unsafe" >&2
+      exit 2 ;;
+  esac
+}
+
+parse_inputs() {
+  # Knobs of the removed app-deployment mode (EMIT=manifest): a caller passing
+  # one is running a stale recipe — refuse loudly rather than ignore.
+  local stale
+  for stale in APP_PORT SVC_PORT ENV_VARS APP_COMMAND APP_RESOURCES \
+               PVC_NAME PVC_MOUNT WORKLOAD_TYPE WORKLOAD_PROTOCOL LABEL_PREFIX \
+               NO_PROPAGATE APP_ENTRYPOINT; do
+    if [ -n "${!stale:-}" ]; then
+      echo "error: $stale is not a knob — it was removed with the app-deployment (EMIT=manifest) mode." >&2
+      echo "       This script only attaches lineage to an EXISTING Deployment; the app itself" >&2
+      echo "       is deployed by its owner. See the header and README.md." >&2
+      exit 2
+    fi
+  done
+
+  EMIT="${EMIT:-patch}"
+  NAME="${NAME:?set NAME}"
+  NAMESPACE="${NAMESPACE:-team1}"
+  # NAME (RFC 1123 subdomain) and NAMESPACE (DNS label) are interpolated bare.
+  # 227 = 253 minus the ConfigMap name's prefix (authbridge-lineage-config-).
+  if [ "${#NAME}" -gt 227 ] \
+     || ! [[ "$NAME" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ ]]; then
+    echo "error: NAME='$NAME' must be a lowercase RFC 1123 subdomain of at most 227 chars (253 minus the ConfigMap prefix)" >&2; exit 2
+  fi
+  if ! [[ "$NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$ ]]; then
+    echo "error: NAMESPACE='$NAMESPACE' is not a DNS label (lowercase alphanumerics and '-', max 63)" >&2; exit 2
+  fi
+  case "$EMIT" in
+    patch|cm) ;;
+    *) echo "error: EMIT must be patch|cm (got '$EMIT')" >&2; exit 2 ;;
+  esac
+  SELF_ID="${SELF_ID:-$NAME}"
+  APP_CONTAINER="${APP_CONTAINER:-}"
+  APP_IMAGE="${APP_IMAGE:-}"
+  OUTBOUND_PORTS_EXCLUDE="${OUTBOUND_PORTS_EXCLUDE:-}"
+  OTEL_ENDPOINT="${OTEL_ENDPOINT:-otel-collector.rossoctl-system.svc.cluster.local:4317}"
+  CAPTURE_IO="${CAPTURE_IO:-false}"
+  case "$CAPTURE_IO" in
+    true|false) ;;
+    *) echo "error: CAPTURE_IO must be true|false (got '$CAPTURE_IO')" >&2; exit 2 ;;
+  esac
+  MAX_PAYLOAD_BYTES="${MAX_PAYLOAD_BYTES:-}"
+  [[ "$MAX_PAYLOAD_BYTES" =~ ^(-1|[1-9][0-9]*)?$ ]] \
+    || { echo "error: MAX_PAYLOAD_BYTES must be a positive integer or -1 (got '$MAX_PAYLOAD_BYTES')" >&2; exit 2; }
+  # Published images by default; point at local tags when building from source.
+  SIDECAR_IMAGE="${SIDECAR_IMAGE:-ghcr.io/rossoctl/cortex/authbridge-envoy:latest}"
+  PROXY_INIT_IMAGE="${PROXY_INIT_IMAGE:-ghcr.io/rossoctl/cortex/proxy-init:latest}"
+  NO_EMIT="${NO_EMIT:-0}"
+  case "$NO_EMIT" in
+    0|1) ;;
+    *) echo "error: NO_EMIT must be 0|1 (got '$NO_EMIT')" >&2; exit 2 ;;
+  esac
+
+  local v
+  for v in SELF_ID OTEL_ENDPOINT APP_IMAGE SIDECAR_IMAGE PROXY_INIT_IMAGE; do
+    yaml_safe "$v" "${!v}"
+  done
+  # A container name is a DNS label; it is interpolated bare.
+  if [ -n "$APP_CONTAINER" ] && ! [[ "$APP_CONTAINER" =~ ^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$ ]]; then
+    echo "error: APP_CONTAINER='$APP_CONTAINER' is not a valid container name (DNS label)" >&2; exit 2
+  fi
+  if [ -n "$APP_IMAGE" ] && [ -z "$APP_CONTAINER" ]; then
+    echo "error: APP_IMAGE needs APP_CONTAINER — the image lands on a container the patch must name" >&2; exit 2
+  fi
+  # Ports exactly as proxy-init hands them to iptables: no leading zero (iptables
+  # reads `010` as octal and refuses `0080`), at most five digits (a longer
+  # number overflows the `-gt` test below), then the range.
+  [[ "$OUTBOUND_PORTS_EXCLUDE" =~ ^([1-9][0-9]{0,4}(,[1-9][0-9]{0,4})*)?$ ]] \
+    || { echo "error: OUTBOUND_PORTS_EXCLUDE='$OUTBOUND_PORTS_EXCLUDE' is not a comma-separated list of ports (1-65535, no leading zeros)" >&2; exit 2; }
+  local port
+  for port in ${OUTBOUND_PORTS_EXCLUDE//,/ }; do
+    if [ "$port" -gt 65535 ]; then
+      echo "error: OUTBOUND_PORTS_EXCLUDE has '$port', which is not a port (1-65535)" >&2; exit 2
+    fi
+  done
+}
+
+build_proxy_env() {
+  # proxy-init OUTBOUND_PORTS_EXCLUDE env (only if set)
+  exclude_env=""
+  if [ -n "$OUTBOUND_PORTS_EXCLUDE" ]; then
+    exclude_env="
+            - name: OUTBOUND_PORTS_EXCLUDE
+              value: \"${OUTBOUND_PORTS_EXCLUDE}\""
+  fi
+}
+
+build_plugin_entry() {
+  # The plugin entry, one variable so NO_EMIT is a single point. Empty → the
+  # parsers stay and the sidecar is a pure proxy that emits nothing.
+  lineage_plugin=""
+  if [ "$NO_EMIT" != "1" ]; then
+    lineage_plugin='
+          - name: lineage-telemetry
+            config:
+              otel_endpoint: "'"${OTEL_ENDPOINT}"'"
+              capture_io: '"${CAPTURE_IO}"'
+              self_id: "'"${SELF_ID}"'"'
+    # The plugin's own default applies when unset; an explicit value is emitted.
+    [ -z "$MAX_PAYLOAD_BYTES" ] || lineage_plugin="${lineage_plugin}
+              max_payload_bytes: ${MAX_PAYLOAD_BYTES}"
+  fi
+}
+
+build_app_patch() {
+  # The propagation switch. `containers` and `env` both merge by name, so this
+  # sets exactly LINEAGE_PROPAGATE (and the image, if given) on the owner's
+  # container and nothing else. One env var is enough: it wakes the baked hook,
+  # which sets the propagate-only posture itself as env defaults.
+  app_patch=""
+  if [ -n "$APP_CONTAINER" ]; then
+    app_patch="
+        - name: ${APP_CONTAINER}"
+    if [ -n "$APP_IMAGE" ]; then
+      app_patch="${app_patch}
+          image: \"${APP_IMAGE}\""
+    fi
+    app_patch="${app_patch}
+          env:
+            - { name: LINEAGE_PROPAGATE, value: \"1\" }"
+  fi
+}
+
+# ---- the sidecar fragments (the single source of every sidecar YAML byte) ----
+
+sidecar_container() {  # the envoy-proxy container (8-space list-item indent)
+  cat <<EOF
+        # Envoy + authbridge-envoy (ext_proc + the lineage plugin). MUST run as
+        # UID 1337: proxy-init exempts that uid from the outbound redirect.
+        # Readiness = the inbound listener accepting (without it a Service endpoint
+        # goes Ready before the sidecar can take the redirect); admin binds loopback.
+        - name: envoy-proxy
+          image: "${SIDECAR_IMAGE}"
+          imagePullPolicy: IfNotPresent
+          args: ["--config", "/etc/authbridge/config.yaml"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1337
+            runAsGroup: 1337
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - { containerPort: 15123, name: envoy-out }
+            - { containerPort: 15124, name: envoy-in }
+            - { containerPort: 9090,  name: ext-proc }
+          readinessProbe:
+            tcpSocket: { port: 15124 }
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 512Mi }
+          volumeMounts:
+            - { name: envoy-config,       mountPath: /etc/envoy,      readOnly: true }
+            - { name: authbridge-runtime, mountPath: /etc/authbridge, readOnly: true }
+EOF
+}
+
+proxy_init_container() {  # the iptables init container
+  cat <<EOF
+        # Programs the pod's iptables once and exits. Root + exactly
+        # NET_ADMIN/NET_RAW, nothing else.
+        - name: proxy-init
+          image: "${PROXY_INIT_IMAGE}"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["NET_ADMIN", "NET_RAW"]
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { cpu: 100m, memory: 64Mi }
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP${exclude_env}
+EOF
+}
+
+sidecar_volumes() {  # envoy-config + the per-app runtime ConfigMap
+  cat <<EOF
+        - name: envoy-config
+          configMap:
+            name: envoy-config
+        - name: authbridge-runtime
+          configMap:
+            name: authbridge-lineage-config-${NAME}
+            items:
+              - { key: config.yaml, path: config.yaml }
+EOF
+}
+
+# ---- the two emittable objects ----
+
+emit_configmap() {
+  cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authbridge-lineage-config-${NAME}
+  namespace: ${NAMESPACE}
+data:
+  config.yaml: |
+    mode: envoy-sidecar
+    # The same parser chain in both directions: an app's entry protocol is
+    # not knowable from the attach side, and a direction-specific chain would
+    # silently mislabel what it was not given as plain http. Uniform is safe —
+    # parsers are content-gated and not mutually exclusive (mcp-parser attaches
+    # to any JSON-RPC body), and the plugin reads payloads only through the
+    # protocol fact it stamped (precedence a2a > mcp > inference).
+    pipeline:
+      inbound:
+        plugins:
+          - name: a2a-parser
+          - name: mcp-parser
+          - name: inference-parser${lineage_plugin}
+      outbound:
+        plugins:
+          - name: a2a-parser
+          - name: mcp-parser
+          - name: inference-parser${lineage_plugin}
+EOF
+}
+
+emit_patch() {  # strategic merge: lists merge by name — the owner's spec is untouched
+  # apiVersion/kind/metadata make it a complete resource, which kustomize
+  # requires of a patch file; kubectl patch merges them harmlessly.
+  cat <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template:
+    spec:
+      initContainers:
+$(proxy_init_container)
+      containers:
+$(sidecar_container)${app_patch}
+      volumes:
+$(sidecar_volumes)
+EOF
+}
+
+emit() {
+  case "$EMIT" in
+    cm)    emit_configmap ;;
+    patch) emit_patch ;;
+  esac
+}
+
+main() {
+  [ $# -eq 0 ] || { echo "error: attach-lineage.sh takes no arguments — every input is an environment variable (see the header)" >&2; exit 2; }
+  parse_inputs        # every knob: read, default, validate — all refusals live here
+  build_proxy_env     # optional OUTBOUND_PORTS_EXCLUDE env for proxy-init
+  build_plugin_entry  # the lineage-telemetry pipeline entry (empty under NO_EMIT=1)
+  build_app_patch     # optional propagation switch on the app's own container
+  emit                # dispatch: patch | cm
+}
+main "$@"

--- a/authbridge/lineage-attach/attach-lineage.sh
+++ b/authbridge/lineage-attach/attach-lineage.sh
@@ -72,14 +72,17 @@
 #                   store (Postgres 5432, SMTP 1025: the outbound HTTP codec
 #                   would close them). Never LLM/tool/S3 ports.
 #   SIDECAR_IMAGE   default ghcr.io/rossoctl/cortex/authbridge-envoy:latest —
-#                   UNTIL A RELEASE CARRIES lineage-telemetry (cortex #761) the
-#                   sidecar CRASHLOOPS on this default: plugins.Build fails
-#                   closed on the unknown name, and because proxy-init has
-#                   already redirected the pod's egress, the workload is down,
-#                   not merely un-instrumented. Build from a tree that has the
-#                   plugin and point this at your tag (RECIPE.md step 1); or
-#                   NO_EMIT=1 for a graceful parsers-only sidecar on a stock
-#                   image (the parsers predate the plugin)
+#                   UNTIL A RELEASE CARRIES lineage-telemetry (cortex #761),
+#                   EMIT=patch REFUSES this default: the sidecar crashloops on
+#                   the unknown plugin name (plugins.Build fails closed), the
+#                   startupProbe never passes, the app container never starts,
+#                   and a rolling update stalls with the OLD pods still serving
+#                   — contained, but nothing attaches. (Under strategy:
+#                   Recreate the old pods are deleted first, so there the
+#                   workload IS down.) Build from a tree that has the plugin
+#                   and point this at your tag (RECIPE.md step 1); or NO_EMIT=1
+#                   for a graceful parsers-only sidecar on a stock image (the
+#                   parsers predate the plugin)
 #   PROXY_INIT_IMAGE  default ghcr.io/rossoctl/cortex/proxy-init:latest
 #   NO_EMIT=1       omit the plugin entry: the sidecar proxies, emits nothing
 #                   (parsers alone are legal). The A/B baseline.
@@ -184,6 +187,20 @@ parse_inputs() {
     0|1) ;;
     *) echo "error: NO_EMIT must be 0|1 (got '$NO_EMIT')" >&2; exit 2 ;;
   esac
+  # The published default image predates the plugin (cortex #761): plugins.Build
+  # fails closed on the unknown name and the sidecar crashloops (see the
+  # SIDECAR_IMAGE note above). Emitting a patch that pins it is a foreseeable
+  # misuse like any other — refuse it. EMIT=patch only: the ConfigMap and the
+  # reverse patch carry no image, and a back-out must never be blocked. Delete
+  # this guard when a release image carries lineage-telemetry.
+  if [ "$EMIT" = "patch" ] && [ "$NO_EMIT" != "1" ] \
+     && [ "$SIDECAR_IMAGE" = "ghcr.io/rossoctl/cortex/authbridge-envoy:latest" ]; then
+    echo "error: SIDECAR_IMAGE is the published default, which does not carry lineage-telemetry" >&2
+    echo "  yet (cortex #761) — the sidecar would crashloop on it. Build one from a tree that has" >&2
+    echo "  the plugin and set SIDECAR_IMAGE (RECIPE.md step 1), or NO_EMIT=1 for a parsers-only" >&2
+    echo "  sidecar on the stock image." >&2
+    exit 2
+  fi
 
   local v
   for v in SELF_ID OTEL_ENDPOINT APP_IMAGE RESTORE_IMAGE SIDECAR_IMAGE PROXY_INIT_IMAGE; do

--- a/authbridge/lineage-attach/attach-lineage.sh
+++ b/authbridge/lineage-attach/attach-lineage.sh
@@ -9,6 +9,15 @@
 #                         propagation switch on the app's own container.
 #   EMIT=cm               the per-app plugin ConfigMap the sidecar mounts
 #                         (parser chain + lineage-telemetry entry).
+#   EMIT=undo             the reverse of the patch: one line of strategic-merge
+#                         JSON (JSON is YAML) deleting, by name, exactly what
+#                         the patch adds — `$patch: delete` on the merge-by-name
+#                         lists, null on the default-container annotation key.
+#                         The image is restored via RESTORE_IMAGE (a replaced
+#                         image has no delete directive, only another value);
+#                         APP_IMAGE is refused in this mode — it is the ref to
+#                         INSTALL, and reusing the attach line verbatim would
+#                         otherwise "restore" the -otel image.
 #
 # Apply both and the app's traffic flows through the lineage plugin. The app
 # itself is never described: no Deployment, no Service, no app config — lists
@@ -44,6 +53,9 @@
 #                   an existing container: a strategic merge ADDS a stub for an
 #                   unknown name. Checked by sidecar-patch.sh, not here.
 #   APP_IMAGE       needs APP_CONTAINER: the -otel image to set on it
+#                   (EMIT=patch only; EMIT=undo refuses it — see RESTORE_IMAGE)
+#   RESTORE_IMAGE   EMIT=undo only, needs APP_CONTAINER: the pre-attach image
+#                   ref the reverse patch sets back on the app container
 #   OTEL_ENDPOINT   OTLP/gRPC target for the plugin's spans (default: the
 #                   platform collector). Any OTLP consumer works. Plain gRPC
 #                   unless it starts with https://.
@@ -63,20 +75,22 @@
 #   PROXY_INIT_IMAGE  default ghcr.io/rossoctl/cortex/proxy-init:latest
 #   NO_EMIT=1       omit the plugin entry: the sidecar proxies, emits nothing
 #                   (parsers alone are legal). The A/B baseline.
-#   EMIT            patch (default) | cm
+#   EMIT            patch (default) | cm | undo
 #
 # Structure: parse_inputs validates EVERY knob (all refusals live there);
 # build_* each assemble one optional YAML fragment into a global; the three
 # fragment functions are the single source of the sidecar YAML; emit()
-# dispatches to the two emitters.
+# dispatches to the emitters.
 set -euo pipefail
 
-# Every free-form value lands in a double-quoted YAML scalar, where only '"'
-# and '\' are special — refusing those two is exactly sufficient. Whitespace
-# and control characters are refused as well: never part of an endpoint or
-# image ref, and a control character is illegal in YAML even inside quotes.
+# Every free-form value lands in a double-quoted YAML or JSON scalar, where
+# only '"' and '\' are special, and — via EMIT=undo — inside the single-quoted
+# shell line sidecar-patch.sh prints, where "'" is. Refusing those three is
+# exactly sufficient. Whitespace and control characters are refused as well:
+# never part of an endpoint or image ref, and a control character is illegal
+# in YAML even inside quotes.
 yaml_safe() {  # $1 = what it is (for the error), $2 = the value
-  local unsafe=$'"\\'
+  local unsafe=$'"\'\\'
   case "$2" in
     *["$unsafe"]*|*[[:space:][:cntrl:]]*)
       printf "error: %s '%s' contains whitespace, a control character or one of %s, which this script cannot quote safely\n" "$1" "$2" "$unsafe" >&2
@@ -112,12 +126,25 @@ parse_inputs() {
     echo "error: NAMESPACE='$NAMESPACE' is not a DNS label (lowercase alphanumerics and '-', max 63)" >&2; exit 2
   fi
   case "$EMIT" in
-    patch|cm) ;;
-    *) echo "error: EMIT must be patch|cm (got '$EMIT')" >&2; exit 2 ;;
+    patch|cm|undo) ;;
+    *) echo "error: EMIT must be patch|cm|undo (got '$EMIT')" >&2; exit 2 ;;
   esac
   SELF_ID="${SELF_ID:-$NAME}"
   APP_CONTAINER="${APP_CONTAINER:-}"
   APP_IMAGE="${APP_IMAGE:-}"
+  RESTORE_IMAGE="${RESTORE_IMAGE:-}"
+  # The two image knobs are mode-bound, and confusing them is destructive:
+  # regenerating an undo with the attach line's APP_IMAGE would "restore" the
+  # -otel image. Refuse the wrong knob loudly rather than reinterpret it.
+  if [ "$EMIT" = "undo" ] && [ -n "$APP_IMAGE" ]; then
+    echo "error: APP_IMAGE is the image to INSTALL (EMIT=patch) — under EMIT=undo pass the" >&2
+    echo "       pre-attach ref to restore as RESTORE_IMAGE instead" >&2
+    exit 2
+  fi
+  if [ "$EMIT" != "undo" ] && [ -n "$RESTORE_IMAGE" ]; then
+    echo "error: RESTORE_IMAGE is an EMIT=undo knob (the pre-attach ref the reverse patch restores)" >&2
+    exit 2
+  fi
   OUTBOUND_PORTS_EXCLUDE="${OUTBOUND_PORTS_EXCLUDE:-}"
   OTEL_ENDPOINT="${OTEL_ENDPOINT:-otel-collector.rossoctl-system.svc.cluster.local:4317}"
   CAPTURE_IO="${CAPTURE_IO:-false}"
@@ -125,6 +152,17 @@ parse_inputs() {
     true|false) ;;
     *) echo "error: CAPTURE_IO must be true|false (got '$CAPTURE_IO')" >&2; exit 2 ;;
   esac
+  # Capture carries PII (prompts, tool arguments, messages). The plugin sends
+  # it plain gRPC unless OTEL_ENDPOINT starts with https://. In-cluster to the
+  # platform collector that is the norm, so this warns rather than refuses —
+  # but say it, once, on stderr (the YAML on stdout is unaffected).
+  if [ "$CAPTURE_IO" = "true" ]; then
+    case "$OTEL_ENDPOINT" in
+      https://*) ;;
+      *) echo "NOTE: CAPTURE_IO=true sends parsed content (PII) to ${OTEL_ENDPOINT} over plain gRPC." >&2
+         echo "      Use an https:// OTEL_ENDPOINT for TLS if that endpoint leaves the cluster." >&2 ;;
+    esac
+  fi
   MAX_PAYLOAD_BYTES="${MAX_PAYLOAD_BYTES:-}"
   [[ "$MAX_PAYLOAD_BYTES" =~ ^(-1|[1-9][0-9]*)?$ ]] \
     || { echo "error: MAX_PAYLOAD_BYTES must be a positive integer or -1 (got '$MAX_PAYLOAD_BYTES')" >&2; exit 2; }
@@ -138,7 +176,7 @@ parse_inputs() {
   esac
 
   local v
-  for v in SELF_ID OTEL_ENDPOINT APP_IMAGE SIDECAR_IMAGE PROXY_INIT_IMAGE; do
+  for v in SELF_ID OTEL_ENDPOINT APP_IMAGE RESTORE_IMAGE SIDECAR_IMAGE PROXY_INIT_IMAGE; do
     yaml_safe "$v" "${!v}"
   done
   # A container name is a DNS label; it is interpolated bare.
@@ -147,6 +185,9 @@ parse_inputs() {
   fi
   if [ -n "$APP_IMAGE" ] && [ -z "$APP_CONTAINER" ]; then
     echo "error: APP_IMAGE needs APP_CONTAINER — the image lands on a container the patch must name" >&2; exit 2
+  fi
+  if [ -n "$RESTORE_IMAGE" ] && [ -z "$APP_CONTAINER" ]; then
+    echo "error: RESTORE_IMAGE needs APP_CONTAINER — the ref lands on a container the patch must name" >&2; exit 2
   fi
   # Ports exactly as proxy-init hands them to iptables: no leading zero (iptables
   # reads `010` as octal and refuses `0080`), at most five digits (a longer
@@ -224,6 +265,7 @@ sidecar_container() {  # the envoy-proxy container (8-space list-item indent)
             runAsUser: 1337
             runAsGroup: 1337
             allowPrivilegeEscalation: false
+            seccompProfile: { type: RuntimeDefault }
             capabilities:
               drop: ["ALL"]
           ports:
@@ -254,6 +296,7 @@ proxy_init_container() {  # the iptables init container
             runAsNonRoot: false
             runAsUser: 0
             allowPrivilegeEscalation: false
+            seccompProfile: { type: RuntimeDefault }
             capabilities:
               drop: ["ALL"]
               add: ["NET_ADMIN", "NET_RAW"]
@@ -334,10 +377,35 @@ $(sidecar_volumes)
 EOF
 }
 
+emit_undo() {
+  # The exact inverse of emit_patch, in one line of compact JSON so it can ride
+  # inside the single-quoted back-out line sidecar-patch.sh prints. Lists that
+  # merge by name un-merge by name: `$patch: delete` removes exactly the items
+  # the patch added and touches nothing else, at ANY later time — unlike a
+  # `rollout undo`, which restores a whole earlier pod template and silently
+  # takes with it whatever the owner changed since the attach. The
+  # default-container annotation deletes via null (strategic merge on maps);
+  # an owner value of that key the attach overwrote is deleted, not restored —
+  # the same one-key limitation the attach documents. The image is the one
+  # non-additive field — a replaced value has no delete, only another value —
+  # so RESTORE_IMAGE is the pre-attach ref to restore, captured by the caller
+  # (APP_IMAGE is refused in this mode; see parse_inputs).
+  local meta="" app=""
+  if [ -n "$APP_CONTAINER" ]; then
+    meta='"metadata":{"annotations":{"kubectl.kubernetes.io/default-container":null}},'
+    app=',{"name":"'"${APP_CONTAINER}"'"'
+    [ -z "$RESTORE_IMAGE" ] || app="${app},\"image\":\"${RESTORE_IMAGE}\""
+    app="${app},\"env\":[{\"name\":\"LINEAGE_PROPAGATE\",\"\$patch\":\"delete\"}]}"
+  fi
+  printf '{"spec":{"template":{%s"spec":{"initContainers":[{"name":"proxy-init","$patch":"delete"}],"containers":[{"name":"envoy-proxy","$patch":"delete"}%s],"volumes":[{"name":"envoy-config","$patch":"delete"},{"name":"authbridge-runtime","$patch":"delete"}]}}}}\n' \
+    "$meta" "$app"
+}
+
 emit() {
   case "$EMIT" in
     cm)    emit_configmap ;;
     patch) emit_patch ;;
+    undo)  emit_undo ;;
   esac
 }
 

--- a/authbridge/lineage-attach/attach-lineage.sh
+++ b/authbridge/lineage-attach/attach-lineage.sh
@@ -72,9 +72,14 @@
 #                   store (Postgres 5432, SMTP 1025: the outbound HTTP codec
 #                   would close them). Never LLM/tool/S3 ports.
 #   SIDECAR_IMAGE   default ghcr.io/rossoctl/cortex/authbridge-envoy:latest —
-#                   UNTIL A RELEASE CARRIES lineage-telemetry (cortex #761) it
-#                   boots without the plugin; build from a tree that has it and
-#                   point this at your tag (RECIPE.md step 1)
+#                   UNTIL A RELEASE CARRIES lineage-telemetry (cortex #761) the
+#                   sidecar CRASHLOOPS on this default: plugins.Build fails
+#                   closed on the unknown name, and because proxy-init has
+#                   already redirected the pod's egress, the workload is down,
+#                   not merely un-instrumented. Build from a tree that has the
+#                   plugin and point this at your tag (RECIPE.md step 1); or
+#                   NO_EMIT=1 for a graceful parsers-only sidecar on a stock
+#                   image (the parsers predate the plugin)
 #   PROXY_INIT_IMAGE  default ghcr.io/rossoctl/cortex/proxy-init:latest
 #   NO_EMIT=1       omit the plugin entry: the sidecar proxies, emits nothing
 #                   (parsers alone are legal). The A/B baseline.
@@ -157,9 +162,11 @@ parse_inputs() {
   esac
   # Capture carries PII (prompts, tool arguments, messages). The plugin sends
   # it plain gRPC unless OTEL_ENDPOINT starts with https://. In-cluster to the
-  # platform collector that is the norm, so this warns rather than refuses —
-  # but say it, once, on stderr (the YAML on stdout is unaffected).
-  if [ "$CAPTURE_IO" = "true" ]; then
+  # platform collector that is the norm, so this warns rather than refuses — on
+  # stderr (the YAML on stdout is unaffected). Gated to EMIT=cm, where capture_io
+  # actually lives, so sidecar-patch.sh (which runs the generator once per
+  # object: cm, patch, undo) prints it once, not three times.
+  if [ "$EMIT" = "cm" ] && [ "$CAPTURE_IO" = "true" ]; then
     case "$OTEL_ENDPOINT" in
       https://*) ;;
       *) echo "NOTE: CAPTURE_IO=true sends parsed content (PII) to ${OTEL_ENDPOINT} over plain gRPC." >&2
@@ -443,6 +450,6 @@ main() {
   build_proxy_env     # optional OUTBOUND_PORTS_EXCLUDE env for proxy-init
   build_plugin_entry  # the lineage-telemetry pipeline entry (empty under NO_EMIT=1)
   build_app_patch     # optional propagation switch on the app's own container
-  emit                # dispatch: patch | cm
+  emit                # dispatch: patch | cm | undo
 }
 main "$@"

--- a/authbridge/lineage-attach/attach-lineage.sh
+++ b/authbridge/lineage-attach/attach-lineage.sh
@@ -4,15 +4,18 @@
 # image), print ONE of the two objects that attach lineage to it:
 #
 #   EMIT=patch (default)  strategic-merge patch adding the sidecar pieces —
-#                         proxy-init initContainer, envoy-proxy container, two
-#                         config volumes — and, with APP_CONTAINER, the
+#                         proxy-init + envoy-proxy as initContainers (envoy a
+#                         NATIVE sidecar: restartPolicy Always, so it is up
+#                         before the app container starts — needs k8s >= 1.29),
+#                         two config volumes — and, with APP_CONTAINER, the
 #                         propagation switch on the app's own container.
 #   EMIT=cm               the per-app plugin ConfigMap the sidecar mounts
 #                         (parser chain + lineage-telemetry entry).
 #   EMIT=undo             the reverse of the patch: one line of strategic-merge
 #                         JSON (JSON is YAML) deleting, by name, exactly what
 #                         the patch adds — `$patch: delete` on the merge-by-name
-#                         lists, null on the default-container annotation key.
+#                         lists (proxy-init + envoy-proxy initContainers, the
+#                         volumes, the app's LINEAGE_PROPAGATE env).
 #                         The image is restored via RESTORE_IMAGE (a replaced
 #                         image has no delete directive, only another value);
 #                         APP_IMAGE is refused in this mode — it is the ref to
@@ -233,7 +236,10 @@ build_app_patch() {
   # The propagation switch. `containers` and `env` both merge by name, so this
   # sets exactly LINEAGE_PROPAGATE (and the image, if given) on the owner's
   # container and nothing else. One env var is enough: it wakes the baked hook,
-  # which sets the propagate-only posture itself as env defaults.
+  # which sets the propagate-only posture itself as env defaults. This is the
+  # ONLY thing the patch adds under `containers:` — the sidecar is a native
+  # initContainer now, so the app stays the pod's sole regular container (and
+  # its default for `kubectl logs/exec`); no default-container annotation.
   app_patch=""
   if [ -n "$APP_CONTAINER" ]; then
     app_patch="
@@ -250,15 +256,22 @@ build_app_patch() {
 
 # ---- the sidecar fragments (the single source of every sidecar YAML byte) ----
 
-sidecar_container() {  # the envoy-proxy container (8-space list-item indent)
+sidecar_container() {  # the envoy-proxy NATIVE sidecar (8-space list-item indent)
   cat <<EOF
         # Envoy + authbridge-envoy (ext_proc + the lineage plugin). MUST run as
         # UID 1337: proxy-init exempts that uid from the outbound redirect.
-        # Readiness = the inbound listener accepting (without it a Service endpoint
-        # goes Ready before the sidecar can take the redirect); admin binds loopback.
+        # A NATIVE sidecar: an initContainer with restartPolicy Always, so the
+        # kubelet holds the app container until this one's startupProbe passes —
+        # proxy-init has already redirected egress, and without this the app can
+        # boot and make its first outbound call before the proxy is listening
+        # (connection refused). The startupProbe watches the OUTBOUND listener
+        # (15123), which is the one an app's startup egress actually hits.
+        # readinessProbe stays on the inbound listener: it gates the pod into
+        # Service endpoints, a separate concern. Admin binds loopback.
         - name: envoy-proxy
           image: "${SIDECAR_IMAGE}"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
           args: ["--config", "/etc/authbridge/config.yaml"]
           securityContext:
             runAsNonRoot: true
@@ -272,9 +285,12 @@ sidecar_container() {  # the envoy-proxy container (8-space list-item indent)
             - { containerPort: 15123, name: envoy-out }
             - { containerPort: 15124, name: envoy-in }
             - { containerPort: 9090,  name: ext-proc }
+          startupProbe:
+            tcpSocket: { port: 15123 }
+            periodSeconds: 1
+            failureThreshold: 60
           readinessProbe:
             tcpSocket: { port: 15124 }
-            initialDelaySeconds: 2
             periodSeconds: 5
           resources:
             requests: { cpu: 50m, memory: 64Mi }
@@ -288,7 +304,9 @@ EOF
 proxy_init_container() {  # the iptables init container
   cat <<EOF
         # Programs the pod's iptables once and exits. Root + exactly
-        # NET_ADMIN/NET_RAW, nothing else.
+        # NET_ADMIN/NET_RAW, nothing else. POD_IP + POD_IPS (Downward API):
+        # proxy-init prefers the plural for full dual-stack redirect and falls
+        # back to the singular otherwise.
         - name: proxy-init
           image: "${PROXY_INIT_IMAGE}"
           imagePullPolicy: IfNotPresent
@@ -307,7 +325,11 @@ proxy_init_container() {  # the iptables init container
             - name: POD_IP
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP${exclude_env}
+                  fieldPath: status.podIP
+            - name: POD_IPS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIPs${exclude_env}
 EOF
 }
 
@@ -359,6 +381,14 @@ EOF
 emit_patch() {  # strategic merge: lists merge by name — the owner's spec is untouched
   # apiVersion/kind/metadata make it a complete resource, which kustomize
   # requires of a patch file; kubectl patch merges them harmlessly.
+  # proxy-init (to completion) then envoy-proxy (native sidecar) are both
+  # initContainers; the app container is touched only to switch propagation on.
+  # Emit `containers:` ONLY when there is an app fragment — a bare `containers:`
+  # key is `containers: null` in a strategic merge and would clobber the owner's
+  # container list.
+  local containers_block=""
+  [ -z "$app_patch" ] || containers_block="      containers:${app_patch}
+"
   cat <<EOF
 apiVersion: apps/v1
 kind: Deployment
@@ -370,9 +400,8 @@ spec:
     spec:
       initContainers:
 $(proxy_init_container)
-      containers:
-$(sidecar_container)${app_patch}
-      volumes:
+$(sidecar_container)
+${containers_block}      volumes:
 $(sidecar_volumes)
 EOF
 }
@@ -383,22 +412,21 @@ emit_undo() {
   # merge by name un-merge by name: `$patch: delete` removes exactly the items
   # the patch added and touches nothing else, at ANY later time — unlike a
   # `rollout undo`, which restores a whole earlier pod template and silently
-  # takes with it whatever the owner changed since the attach. The
-  # default-container annotation deletes via null (strategic merge on maps);
-  # an owner value of that key the attach overwrote is deleted, not restored —
-  # the same one-key limitation the attach documents. The image is the one
-  # non-additive field — a replaced value has no delete, only another value —
-  # so RESTORE_IMAGE is the pre-attach ref to restore, captured by the caller
-  # (APP_IMAGE is refused in this mode; see parse_inputs).
-  local meta="" app=""
+  # takes with it whatever the owner changed since the attach. proxy-init AND
+  # envoy-proxy are both initContainers now (the native sidecar), so both are
+  # deleted from that list. The image is the one non-additive field — a replaced
+  # value has no delete, only another value — so RESTORE_IMAGE is the pre-attach
+  # ref to restore, captured by the caller (APP_IMAGE is refused in this mode;
+  # see parse_inputs). `containers` appears only when the attach touched one.
+  local app_containers=""
   if [ -n "$APP_CONTAINER" ]; then
-    meta='"metadata":{"annotations":{"kubectl.kubernetes.io/default-container":null}},'
-    app=',{"name":"'"${APP_CONTAINER}"'"'
+    local app='{"name":"'"${APP_CONTAINER}"'"'
     [ -z "$RESTORE_IMAGE" ] || app="${app},\"image\":\"${RESTORE_IMAGE}\""
     app="${app},\"env\":[{\"name\":\"LINEAGE_PROPAGATE\",\"\$patch\":\"delete\"}]}"
+    app_containers=',"containers":['"${app}"']'
   fi
-  printf '{"spec":{"template":{%s"spec":{"initContainers":[{"name":"proxy-init","$patch":"delete"}],"containers":[{"name":"envoy-proxy","$patch":"delete"}%s],"volumes":[{"name":"envoy-config","$patch":"delete"},{"name":"authbridge-runtime","$patch":"delete"}]}}}}\n' \
-    "$meta" "$app"
+  printf '{"spec":{"template":{"spec":{"initContainers":[{"name":"proxy-init","$patch":"delete"},{"name":"envoy-proxy","$patch":"delete"}]%s,"volumes":[{"name":"envoy-config","$patch":"delete"},{"name":"authbridge-runtime","$patch":"delete"}]}}}}\n' \
+    "$app_containers"
 }
 
 emit() {

--- a/authbridge/lineage-attach/build-otel-shim.sh
+++ b/authbridge/lineage-attach/build-otel-shim.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# build-otel-shim.sh — bake the propagate-only OTel shim onto a Python app
+# image and load it into kind. Only the base image changes per app: the
+# interpreter and uid:gid are DETECTED from the image, and the app's command is
+# never touched — the shim activates through the environment
+# (LINEAGE_PROPAGATE=1, see Dockerfile.otel-shim).
+#
+# Usage:
+#   ./build-otel-shim.sh <base-image> [wrapper-tag] [venv-python] [app-uid[:gid]]
+#   venv-python / app-uid are escape hatches for when detection picks wrong;
+#   an explicit value is used as-is. Give app-uid as uid:gid — a bare uid
+#   still takes the gid the base image's own user resolves to.
+#
+# Env:
+#   FORCE_BAKE=1     override the refuse-to-bake interlock
+#   SELF_ACTIVATE=1  bake LINEAGE_PROPAGATE=1 INTO the image — for workloads
+#                    whose Deployment you cannot edit. Default images stay
+#                    inert and are activated by the Deployment env.
+#   NO_KIND_LOAD=1   build + attest only (CI / offline)
+#
+# Every probe runs the (unaudited) app image with --network=none.
+# container-runtime.sh picks podman or docker (override: CONTAINER_TOOL).
+#
+# Structure: main() at the bottom is the pipeline; each phase is a function
+# and a failed phase exits (3 = image refused, 4 = attestation failed).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "${SCRIPT_DIR}/container-runtime.sh"
+
+parse_args() {
+  BASE_IMAGE="${1:?usage: build-otel-shim.sh <base-image> [wrapper-tag] [venv-python] [app-uid[:gid]]}"
+  # default wrapper tag: <base name>-otel:latest (tag or digest stripped)
+  local base_short base_name
+  base_short="${BASE_IMAGE##*/}"; base_name="${base_short%%[:@]*}"
+  WRAPPER_TAG="${2:-${base_name}-otel:latest}"
+  case "${WRAPPER_TAG##*/}" in *:*) ;; *) WRAPPER_TAG="${WRAPPER_TAG}:latest" ;; esac
+  VENV_PYTHON="${3:-}"
+  APP_UID="${4:-}"
+  APP_GID="${APP_UID#*:}"; [ "$APP_GID" = "$APP_UID" ] && APP_GID=""
+  APP_UID="${APP_UID%%:*}"
+  FORCE_BAKE="${FORCE_BAKE:-0}"
+  SELF_ACTIVATE="${SELF_ACTIVATE:-0}"
+  NO_KIND_LOAD="${NO_KIND_LOAD:-0}"
+
+  # A registry-qualified ref is used as is. A bare name is asked of the engine
+  # first — podman keeps a local build as localhost/<name>, docker as
+  # docker.io/library/<name> — and only a name the engine does not have is
+  # taken to mean docker.io/library/<name>.
+  case "$BASE_IMAGE" in
+    */*) base_ref="$BASE_IMAGE" ;;
+    *)   if "$CONTAINER_TOOL" image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
+           base_ref="$BASE_IMAGE"
+         else
+           base_ref="docker.io/library/${BASE_IMAGE}"
+         fi ;;
+  esac
+  # Every probe below inspects or runs the image; say so once instead of
+  # surfacing the engine's own "no such object".
+  if ! "$CONTAINER_TOOL" image inspect "$base_ref" >/dev/null 2>&1; then
+    echo "REFUSING to bake ${BASE_IMAGE}: ${base_ref} is not present locally (${CONTAINER_TOOL})." >&2
+    echo "  Pull or build it first, and give the ref the engine knows it by" >&2
+    echo "  (a podman build of my-agent:latest is localhost/my-agent:latest)." >&2
+    exit 3
+  fi
+}
+
+# The two per-image build inputs are IN the image — probe it, never transcribe.
+runs_python() {  # $1 = candidate interpreter path/name
+  "$CONTAINER_TOOL" run --rm --network=none --entrypoint "$1" "$base_ref" -c 'import sys' >/dev/null 2>&1
+}
+
+detect_python() {  # sets VENV_PYTHON (validates it when given explicitly)
+  if [ -z "$VENV_PYTHON" ]; then
+    # The env the image declares, then the common venv layouts, then PATH.
+    local candidates virtual_env c
+    candidates=()
+    virtual_env="$("$CONTAINER_TOOL" inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$base_ref" \
+      | sed -n 's/^VIRTUAL_ENV=//p' | head -1)"
+    [ -n "$virtual_env" ] && candidates+=("${virtual_env}/bin/python")
+    candidates+=(/app/.venv/bin/python /opt/venv/bin/python python3)
+    for c in "${candidates[@]}"; do
+      if runs_python "$c"; then VENV_PYTHON="$c"; break; fi
+    done
+    if [ -z "$VENV_PYTHON" ]; then
+      echo "REFUSING to bake ${base_ref}: no runnable Python found." >&2
+      echo "  Probed: ${candidates[*]}" >&2
+      echo "  The image is outside the shim envelope (non-Python, or an unusual layout)." >&2
+      echo "  -> pass the interpreter explicitly as arg 3, or attach the sidecar only:" >&2
+      echo "     DEPLOY=<deployment> ./sidecar-patch.sh   (still captures every HTTP hop," >&2
+      echo "     but pairing under concurrency needs the app to propagate on its own)" >&2
+      exit 3
+    fi
+    echo ">> detected app python: ${VENV_PYTHON}"
+  elif ! runs_python "$VENV_PYTHON"; then
+    echo "REFUSING to bake ${base_ref}: no runnable Python at ${VENV_PYTHON} (explicit arg)." >&2
+    exit 3
+  fi
+}
+
+detect_user() {  # sets APP_UID and APP_GID (either may be given explicitly)
+  local config_user_full=""
+  if [ -z "$APP_UID" ]; then
+    # Exactly the user the base declared (root when empty); a named user is
+    # resolved to its uid inside the image.
+    local config_user
+    config_user_full="$("$CONTAINER_TOOL" inspect --format '{{.Config.User}}' "$base_ref")"
+    config_user="${config_user_full%%:*}"
+    case "$config_user" in
+      "")       APP_UID=0 ;;
+      *[!0-9]*) APP_UID="$("$CONTAINER_TOOL" run --rm --network=none --entrypoint id "$base_ref" -u 2>/dev/null)" || {
+                  echo "REFUSING to bake ${base_ref}: cannot resolve user '${config_user}' to a uid" >&2
+                  echo "  (no 'id' binary in the image?) -> pass the uid explicitly as arg 4." >&2
+                  exit 3
+                } ;;
+      *)        APP_UID="$config_user" ;;
+    esac
+    echo ">> detected app user: uid=${APP_UID} (Config.User='${config_user_full:-<root>}')"
+  fi
+  if [ -z "$APP_GID" ]; then
+    # An explicit `USER uid:gid`, else the primary gid the runtime gives that
+    # user (0 without a passwd entry — which is what the base ran as).
+    case "$config_user_full" in
+      *:*) APP_GID="${config_user_full#*:}" ;;
+      *)   APP_GID="$("$CONTAINER_TOOL" run --rm --network=none --entrypoint id "$base_ref" -g 2>/dev/null)" || APP_GID=0 ;;
+    esac
+    echo ">> detected app group: gid=${APP_GID}"
+  fi
+}
+
+# The interlock asks exactly "would wrapping DOUBLE-instrument?": is any of the
+# eight instrumentors this shim installs already present? Not the
+# `opentelemetry.instrumentation` namespace (a transitive dep of anything
+# OTel-adjacent, no library instrumentation in it) and not a dormant SDK
+# (a2a-sdk ships one on every stock agent) — neither is a refusal signal. An
+# app that activates its SDK in code is not statically detectable.
+refuse_already_instrumented() {
+  [ "$FORCE_BAKE" = "1" ] && return 0
+  # keep in sync with Dockerfile.otel-shim's install RUN (all but -distro)
+  local already
+  if already=$("$CONTAINER_TOOL" run --rm --network=none --entrypoint "$VENV_PYTHON" "$base_ref" -c '
+import importlib.util as u
+mods = ["starlette", "asgi", "fastapi", "httpx", "requests", "aiohttp_client", "urllib3", "threading"]
+found = [m for m in mods if u.find_spec("opentelemetry.instrumentation." + m)]
+print(",".join(found))
+raise SystemExit(0 if found else 1)' 2>/dev/null); then
+    echo "REFUSING to bake ${base_ref}: it already instruments ${already}" >&2
+    echo "  Those are instrumentors this shim installs, so wrapping would stack a" >&2
+    echo "  second one on the same library (an -otel image, or an app that bundles" >&2
+    echo "  its own instrumentation)." >&2
+    echo "  -> if this is a stock app image, point me at the un-shimmed base." >&2
+    echo "  -> FORCE_BAKE=1 overrides if you know the wrap is safe." >&2
+    exit 3
+  fi
+  # An already-baked -otel image carries the hook; refuse to bake it twice.
+  if "$CONTAINER_TOOL" run --rm --network=none --entrypoint "$VENV_PYTHON" "$base_ref" -c '
+import importlib.util as u
+raise SystemExit(0 if u.find_spec("_lineage_propagate") else 1)' >/dev/null 2>&1; then
+    echo "REFUSING to bake ${base_ref}: it already carries the lineage propagate hook" >&2
+    echo "  (an already-baked -otel image). -> point me at the un-shimmed base." >&2
+    echo "  -> FORCE_BAKE=1 overrides if you know the wrap is safe." >&2
+    exit 3
+  fi
+}
+
+build_image() {
+  echo ">> building shim ${WRAPPER_TAG} FROM ${base_ref} (${CONTAINER_TOOL}, python=${VENV_PYTHON}, uid=${APP_UID})"
+  "$CONTAINER_TOOL" build -f "${SCRIPT_DIR}/Dockerfile.otel-shim" \
+    --build-arg "BASE_IMAGE=${base_ref}" \
+    --build-arg "VENV_PYTHON=${VENV_PYTHON}" \
+    --build-arg "APP_UID=${APP_UID}" \
+    --build-arg "APP_GID=${APP_GID}" \
+    -t "${WRAPPER_TAG}" "${SCRIPT_DIR}"
+}
+
+# Attestation: the bake proves itself before anything is loaded. Gate off, not
+# one opentelemetry module may load; gate on, the hook ran, the exporter
+# selection is explicit, and the propagator injects a traceparent.
+verify_inert() {
+  if ! "$CONTAINER_TOOL" run --rm --network=none --entrypoint "$VENV_PYTHON" "$WRAPPER_TAG" -c '
+import sys
+loaded = sorted(m for m in sys.modules if m.startswith("opentelemetry"))
+raise SystemExit("gate off, yet otel loaded: %s" % loaded if loaded else 0)'; then
+    echo "ATTESTATION FAILED for ${WRAPPER_TAG}: image is not inert with the gate off." >&2
+    exit 4
+  fi
+}
+
+verify_propagates() {
+  if ! "$CONTAINER_TOOL" run --rm --network=none -e LINEAGE_PROPAGATE=1 --entrypoint "$VENV_PYTHON" "$WRAPPER_TAG" -c '
+import os, sys
+assert "opentelemetry.instrumentation.auto_instrumentation" in sys.modules, "hook did not run"
+assert os.environ.get("OTEL_TRACES_EXPORTER") is not None, "exporter selection not pinned"
+from opentelemetry import trace
+from opentelemetry.propagate import inject
+with trace.get_tracer("attest").start_as_current_span("attest"):
+    carrier = {}
+    inject(carrier)
+assert "traceparent" in carrier, "propagator injects nothing: %r" % carrier'; then
+    echo "ATTESTATION FAILED for ${WRAPPER_TAG}: gate on, but the hook did not come up." >&2
+    exit 4
+  fi
+}
+
+self_activate() {  # optional: bake the activation in
+  [ "$SELF_ACTIVATE" = "1" ] || return 0
+  echo ">> baking LINEAGE_PROPAGATE=1 into ${WRAPPER_TAG} (SELF_ACTIVATE=1)"
+  printf 'FROM %s\nENV LINEAGE_PROPAGATE=1\n' "$WRAPPER_TAG" \
+    | "$CONTAINER_TOOL" build -t "$WRAPPER_TAG" -
+}
+
+publish() {
+  # A bare tag is aliased under docker.io/library/ so kind resolves it;
+  # a registry-qualified one is used as is.
+  local alias_ref
+  case "$WRAPPER_TAG" in
+    */*) alias_ref="$WRAPPER_TAG" ;;
+    *)   alias_ref="docker.io/library/${WRAPPER_TAG}"
+         "$CONTAINER_TOOL" tag "${WRAPPER_TAG}" "${alias_ref}" ;;
+  esac
+
+  if [ "$NO_KIND_LOAD" = "1" ]; then
+    echo ">> built + attested ${alias_ref} (kind load skipped: NO_KIND_LOAD=1)"
+  else
+    kind_load "${alias_ref}"
+    echo ">> loaded ${alias_ref} into kind cluster ${KIND_CLUSTER_NAME}"
+  fi
+  if [ "$SELF_ACTIVATE" = "1" ]; then
+    echo ">> NOTE: this image is SELF-ACTIVATING (LINEAGE_PROPAGATE=1 baked in) — any"
+    echo ">>       deployment of it propagates. Meant for workloads whose Deployment you"
+    echo ">>       cannot edit; everywhere else prefer the inert default."
+  else
+    echo ">> NOTE: the -otel image is INERT — it runs exactly like its base until a"
+    echo ">>       Deployment sets LINEAGE_PROPAGATE=1 in the app container's env"
+    echo ">>       (attach-lineage.sh does this). Deploy it without that env and you"
+    echo ">>       simply get the base image's behavior: no propagation, and the trace"
+    echo ">>       fragments at this pod, visibly (lineage.parent.source=none on its outbound hops)."
+  fi
+}
+
+main() {
+  parse_args "$@"               # args + env → globals
+  detect_python                 # the app's interpreter, probed (or arg 3)
+  detect_user                   # uid:gid, probed (or arg 4)
+  refuse_already_instrumented   # would double-instrument, or already baked → exit 3
+  build_image                   # Dockerfile.otel-shim with the detected build-args
+  verify_inert                  # gate off: nothing OTel loads → else exit 4
+  verify_propagates             # gate on: hook up, traceparent injected → else exit 4
+  self_activate                 # SELF_ACTIVATE=1 only
+  publish                       # alias, kind-load, print the NOTE
+}
+main "$@"

--- a/authbridge/lineage-attach/build-otel-shim.sh
+++ b/authbridge/lineage-attach/build-otel-shim.sh
@@ -62,6 +62,28 @@ parse_args() {
     echo "  (a podman build of my-agent:latest is localhost/my-agent:latest)." >&2
     exit 3
   fi
+  # The wrapper tag must not be the base image: building FROM base_ref and then
+  # tagging the result onto the same ref leaves the un-shimmed original dangling
+  # and unrecoverable, and refuse_already_instrumented then blocks re-baking it.
+  # The same local image has three spellings — a bare `foo`, podman's
+  # `localhost/foo`, docker's `docker.io/library/foo` — so compare on a
+  # normalized `repo:tag` with those prefixes stripped and `:latest` implied.
+  if [ "$(norm_ref "$WRAPPER_TAG")" = "$(norm_ref "$base_ref")" ] \
+     || [ "$(norm_ref "$WRAPPER_TAG")" = "$(norm_ref "$BASE_IMAGE")" ]; then
+    echo "REFUSING to bake ${base_ref}: the wrapper tag (${WRAPPER_TAG}) is the base image itself." >&2
+    echo "  Baking FROM it and tagging onto it would leave the un-shimmed original dangling." >&2
+    echo "  -> give a distinct wrapper tag as arg 2 (default is <base name>-otel:latest)." >&2
+    exit 3
+  fi
+}
+
+# Normalize an image ref for identity comparison: strip the local-build registry
+# prefixes (podman's localhost/, docker's docker.io/library/) and imply :latest.
+norm_ref() {
+  local r="${1#localhost/}"
+  r="${r#docker.io/library/}"
+  case "${r##*/}" in *:*) ;; *) r="${r}:latest" ;; esac
+  printf '%s' "$r"
 }
 
 # The two per-image build inputs are IN the image — probe it, never transcribe.
@@ -69,16 +91,28 @@ runs_python() {  # $1 = candidate interpreter path/name
   "$CONTAINER_TOOL" run --rm --network=none --entrypoint "$1" "$base_ref" -c 'import sys' >/dev/null 2>&1
 }
 
+# VENV_PYTHON reaches two shell-form RUN lines in Dockerfile.otel-shim as an
+# unquoted ARG, and one of its sources — the image's own VIRTUAL_ENV — is
+# attacker-controlled. A Linux path may hold ';', '$( )', backticks and spaces,
+# so a hostile base could run commands inside the (networked) build. Refuse any
+# ref outside a safe character set here, before it is ever used; the Dockerfile
+# also quotes the ARG. The set keeps both an absolute path and the bare
+# `python3` PATH fallback while rejecting every shell metacharacter.
+safe_interpreter_ref() { [[ "$1" =~ ^[A-Za-z0-9._/-]+$ ]]; }
+
 detect_python() {  # sets VENV_PYTHON (validates it when given explicitly)
   if [ -z "$VENV_PYTHON" ]; then
     # The env the image declares, then the common venv layouts, then PATH.
     local candidates virtual_env c
     candidates=()
-    virtual_env="$("$CONTAINER_TOOL" inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$base_ref" \
+    virtual_env="$("$CONTAINER_TOOL" image inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$base_ref" \
       | sed -n 's/^VIRTUAL_ENV=//p' | head -1)"
     [ -n "$virtual_env" ] && candidates+=("${virtual_env}/bin/python")
     candidates+=(/app/.venv/bin/python /opt/venv/bin/python python3)
     for c in "${candidates[@]}"; do
+      # A candidate with shell metacharacters (only the image-derived one can
+      # carry them) is skipped, not run — the fallbacks below are all literal.
+      safe_interpreter_ref "$c" || continue
       if runs_python "$c"; then VENV_PYTHON="$c"; break; fi
     done
     if [ -z "$VENV_PYTHON" ]; then
@@ -91,9 +125,16 @@ detect_python() {  # sets VENV_PYTHON (validates it when given explicitly)
       exit 3
     fi
     echo ">> detected app python: ${VENV_PYTHON}"
-  elif ! runs_python "$VENV_PYTHON"; then
-    echo "REFUSING to bake ${base_ref}: no runnable Python at ${VENV_PYTHON} (explicit arg)." >&2
-    exit 3
+  else
+    if ! safe_interpreter_ref "$VENV_PYTHON"; then
+      echo "REFUSING to bake ${base_ref}: interpreter '${VENV_PYTHON}' has characters outside [A-Za-z0-9._/-]" >&2
+      echo "  (it reaches a shell-form RUN in the Dockerfile) — pass a plain path as arg 3." >&2
+      exit 3
+    fi
+    if ! runs_python "$VENV_PYTHON"; then
+      echo "REFUSING to bake ${base_ref}: no runnable Python at ${VENV_PYTHON} (explicit arg)." >&2
+      exit 3
+    fi
   fi
 }
 
@@ -103,7 +144,7 @@ detect_user() {  # sets APP_UID and APP_GID (either may be given explicitly)
     # Exactly the user the base declared (root when empty); a named user is
     # resolved to its uid inside the image.
     local config_user
-    config_user_full="$("$CONTAINER_TOOL" inspect --format '{{.Config.User}}' "$base_ref")"
+    config_user_full="$("$CONTAINER_TOOL" image inspect --format '{{.Config.User}}' "$base_ref")"
     config_user="${config_user_full%%:*}"
     case "$config_user" in
       "")       APP_UID=0 ;;
@@ -125,6 +166,15 @@ detect_user() {  # sets APP_UID and APP_GID (either may be given explicitly)
     esac
     echo ">> detected app group: gid=${APP_GID}"
   fi
+  # Both reach the Dockerfile's USER and a --build-arg; a non-numeric value —
+  # an odd Config.User, or a hostile image's `id` — has no place there. Validate
+  # detected and explicit alike, the same rigor VENV_PYTHON gets.
+  case "$APP_UID" in ''|*[!0-9]*)
+    echo "REFUSING to bake ${base_ref}: app uid '${APP_UID}' is not a number — pass it explicitly as arg 4." >&2; exit 3 ;;
+  esac
+  case "$APP_GID" in ''|*[!0-9]*)
+    echo "REFUSING to bake ${base_ref}: app gid '${APP_GID}' is not a number — pass it explicitly as arg 4 (uid:gid)." >&2; exit 3 ;;
+  esac
 }
 
 # The interlock asks exactly "would wrapping DOUBLE-instrument?": is any of the
@@ -133,33 +183,58 @@ detect_user() {  # sets APP_UID and APP_GID (either may be given explicitly)
 # OTel-adjacent, no library instrumentation in it) and not a dormant SDK
 # (a2a-sdk ships one on every stock agent) — neither is a refusal signal. An
 # app that activates its SDK in code is not statically detectable.
+# One probe, one verdict: "instrumented:<mods>" / "hook" / "clean", printed on
+# stdout, exit 0 whenever the probe actually RAN inside the image. find_spec is
+# wrapped per-module so a missing opentelemetry.instrumentation namespace reads
+# as "not found", not an abort — the clean answer is then deliberate, not the
+# accident of an uncaught ModuleNotFoundError. (Mods keep in sync with
+# Dockerfile.otel-shim's install RUN, all but -distro.)
+probe_instrumentation() {
+  "$CONTAINER_TOOL" run --rm --network=none --entrypoint "$VENV_PYTHON" "$base_ref" -c '
+import importlib.util as u
+def has(m):
+    try: return u.find_spec(m) is not None
+    except ModuleNotFoundError: return False
+mods = ["starlette", "asgi", "fastapi", "httpx", "requests", "aiohttp_client", "urllib3", "threading"]
+found = [m for m in mods if has("opentelemetry.instrumentation." + m)]
+if found: print("instrumented:" + ",".join(found))
+elif has("_lineage_propagate"): print("hook")
+else: print("clean")'
+}
+
+# The interlock asks exactly "would wrapping DOUBLE-instrument?". A guard whose
+# whole job is to refuse must tell "the probe says no" from "the probe did not
+# run": the probe above exits non-zero ONLY when it could not run at all (a bad
+# interpreter, OOM, a read-only rootfs), its error left on stderr — that is a
+# refusal, never a silent "safe to bake".
 refuse_already_instrumented() {
   [ "$FORCE_BAKE" = "1" ] && return 0
-  # keep in sync with Dockerfile.otel-shim's install RUN (all but -distro)
-  local already
-  if already=$("$CONTAINER_TOOL" run --rm --network=none --entrypoint "$VENV_PYTHON" "$base_ref" -c '
-import importlib.util as u
-mods = ["starlette", "asgi", "fastapi", "httpx", "requests", "aiohttp_client", "urllib3", "threading"]
-found = [m for m in mods if u.find_spec("opentelemetry.instrumentation." + m)]
-print(",".join(found))
-raise SystemExit(0 if found else 1)' 2>/dev/null); then
-    echo "REFUSING to bake ${base_ref}: it already instruments ${already}" >&2
-    echo "  Those are instrumentors this shim installs, so wrapping would stack a" >&2
-    echo "  second one on the same library (an -otel image, or an app that bundles" >&2
-    echo "  its own instrumentation)." >&2
-    echo "  -> if this is a stock app image, point me at the un-shimmed base." >&2
-    echo "  -> FORCE_BAKE=1 overrides if you know the wrap is safe." >&2
+  local verdict
+  if ! verdict="$(probe_instrumentation)"; then
+    echo "REFUSING to bake ${base_ref}: the instrumentation probe could not run (see the error above)." >&2
+    echo "  A probe that did not run is not evidence the image is clean." >&2
+    echo "  -> check the interpreter (arg 3); FORCE_BAKE=1 bakes without the check." >&2
     exit 3
   fi
-  # An already-baked -otel image carries the hook; refuse to bake it twice.
-  if "$CONTAINER_TOOL" run --rm --network=none --entrypoint "$VENV_PYTHON" "$base_ref" -c '
-import importlib.util as u
-raise SystemExit(0 if u.find_spec("_lineage_propagate") else 1)' >/dev/null 2>&1; then
-    echo "REFUSING to bake ${base_ref}: it already carries the lineage propagate hook" >&2
-    echo "  (an already-baked -otel image). -> point me at the un-shimmed base." >&2
-    echo "  -> FORCE_BAKE=1 overrides if you know the wrap is safe." >&2
-    exit 3
-  fi
+  case "$verdict" in
+    instrumented:*)
+      echo "REFUSING to bake ${base_ref}: it already instruments ${verdict#instrumented:}" >&2
+      echo "  Those are instrumentors this shim installs, so wrapping would stack a" >&2
+      echo "  second one on the same library (an -otel image, or an app that bundles" >&2
+      echo "  its own instrumentation)." >&2
+      echo "  -> if this is a stock app image, point me at the un-shimmed base." >&2
+      echo "  -> FORCE_BAKE=1 overrides if you know the wrap is safe." >&2
+      exit 3 ;;
+    hook)
+      echo "REFUSING to bake ${base_ref}: it already carries the lineage propagate hook" >&2
+      echo "  (an already-baked -otel image). -> point me at the un-shimmed base." >&2
+      echo "  -> FORCE_BAKE=1 overrides if you know the wrap is safe." >&2
+      exit 3 ;;
+    clean) ;;
+    *)
+      echo "REFUSING to bake ${base_ref}: unexpected probe output '${verdict}'" >&2
+      exit 3 ;;
+  esac
 }
 
 build_image() {

--- a/authbridge/lineage-attach/container-runtime.sh
+++ b/authbridge/lineage-attach/container-runtime.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+# container-runtime.sh — sourced by build-otel-shim.sh: picks the container
+# engine (CONTAINER_TOOL) and loads an image into kind the way that engine
+# needs (kind_load). Everything else uses $CONTAINER_TOOL directly.
+# KIND_CLUSTER_NAME: target cluster (default rossoctl).
+
+# Podman is checked FIRST: on podman hosts `docker` is often a compat client,
+# and `kind load docker-image` through it is exactly the breakage to avoid.
+container_tool() {
+  [ -n "${CONTAINER_TOOL:-}" ] && return 0
+  if command -v podman >/dev/null 2>&1; then CONTAINER_TOOL=podman
+  elif command -v docker >/dev/null 2>&1; then CONTAINER_TOOL=docker
+  else
+    echo "error: neither docker nor podman on PATH (set CONTAINER_TOOL)" >&2
+    return 1
+  fi
+}
+
+# `kind load docker-image` misbehaves under podman v5; save + image-archive.
+kind_load_podman() {
+  local ref="$1" tar rc=0
+  tar="$(mktemp "${TMPDIR:-/tmp}/kind-load.XXXXXX")"
+  podman save -o "$tar" "$ref" \
+    && KIND_EXPERIMENTAL_PROVIDER=podman kind load image-archive "$tar" --name "$KIND_CLUSTER_NAME" \
+    || rc=$?
+  rm -f "$tar"   # on success and failure alike
+  return "$rc"
+}
+
+kind_load_docker() {
+  kind load docker-image "$1" --name "$KIND_CLUSTER_NAME"
+}
+
+kind_load() { "kind_load_${CONTAINER_TOOL}" "$@"; }
+
+# `return`, not `exit`: sourced — the caller's `set -e` handles it.
+container_tool || return 1
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-rossoctl}"

--- a/authbridge/lineage-attach/container-runtime.sh
+++ b/authbridge/lineage-attach/container-runtime.sh
@@ -28,9 +28,9 @@ container_tool() {
 }
 
 # `kind load docker-image` misbehaves under podman v5; save + image-archive.
-# The archive is this file's only temp file; a trap removes it on normal exit
-# AND on Ctrl-C / SIGTERM during `podman save`, which for an app image is
-# easily multiple GB under TMPDIR.
+# The archive is this file's only temp file (an app image is easily multiple GB
+# under TMPDIR); it is removed explicitly on the normal and failed-save paths,
+# and by a signal trap on Ctrl-C / SIGTERM during `podman save`.
 kind_load_podman() {
   local ref="$1" tar rc=0
   tar="$(mktemp "${TMPDIR:-/tmp}/kind-load.XXXXXX")"
@@ -40,7 +40,8 @@ kind_load_podman() {
   # and fire again when the one-line kind_load() wrapper returns, where $tar
   # is out of scope and `set -u` would abort. The normal and failed-save paths
   # remove the archive explicitly below.
-  trap 'rm -f "${tar:-}"; trap - INT TERM; kill -s INT $$' INT TERM
+  trap 'rm -f "${tar:-}"; trap - INT; kill -s INT $$' INT
+  trap 'rm -f "${tar:-}"; trap - TERM; kill -s TERM $$' TERM
   podman save -o "$tar" "$ref" \
     && KIND_EXPERIMENTAL_PROVIDER=podman kind load image-archive "$tar" --name "$KIND_CLUSTER_NAME" \
     || rc=$?

--- a/authbridge/lineage-attach/container-runtime.sh
+++ b/authbridge/lineage-attach/container-runtime.sh
@@ -6,8 +6,19 @@
 
 # Podman is checked FIRST: on podman hosts `docker` is often a compat client,
 # and `kind load docker-image` through it is exactly the breakage to avoid.
+# An explicit CONTAINER_TOOL is validated against the engines kind_load knows:
+# the override is advertised generally, but kind_load_${CONTAINER_TOOL} only
+# resolves to podman/docker — anything else ran the whole bake and then died
+# with "command not found" AFTER both attestations. Fail it here instead.
 container_tool() {
-  [ -n "${CONTAINER_TOOL:-}" ] && return 0
+  if [ -n "${CONTAINER_TOOL:-}" ]; then
+    case "$CONTAINER_TOOL" in
+      podman|docker) return 0 ;;
+      *) echo "error: CONTAINER_TOOL='$CONTAINER_TOOL' is not supported — use podman or docker" >&2
+         echo "  (the kind-load step is engine-specific and only implements those two)" >&2
+         return 1 ;;
+    esac
+  fi
   if command -v podman >/dev/null 2>&1; then CONTAINER_TOOL=podman
   elif command -v docker >/dev/null 2>&1; then CONTAINER_TOOL=docker
   else
@@ -17,13 +28,24 @@ container_tool() {
 }
 
 # `kind load docker-image` misbehaves under podman v5; save + image-archive.
+# The archive is this file's only temp file; a trap removes it on normal exit
+# AND on Ctrl-C / SIGTERM during `podman save`, which for an app image is
+# easily multiple GB under TMPDIR.
 kind_load_podman() {
   local ref="$1" tar rc=0
   tar="$(mktemp "${TMPDIR:-/tmp}/kind-load.XXXXXX")"
+  # Clean up on Ctrl-C / SIGTERM during `podman save` (a multi-GB archive),
+  # then re-raise the default so the interrupt still aborts. The trap is on
+  # INT/TERM only and is cleared before return — a RETURN trap would linger
+  # and fire again when the one-line kind_load() wrapper returns, where $tar
+  # is out of scope and `set -u` would abort. The normal and failed-save paths
+  # remove the archive explicitly below.
+  trap 'rm -f "${tar:-}"; trap - INT TERM; kill -s INT $$' INT TERM
   podman save -o "$tar" "$ref" \
     && KIND_EXPERIMENTAL_PROVIDER=podman kind load image-archive "$tar" --name "$KIND_CLUSTER_NAME" \
     || rc=$?
-  rm -f "$tar"   # on success and failure alike
+  rm -f "$tar"
+  trap - INT TERM
   return "$rc"
 }
 

--- a/authbridge/lineage-attach/lineage-propagate-hook.py
+++ b/authbridge/lineage-attach/lineage-propagate-hook.py
@@ -1,0 +1,40 @@
+"""Env-gated activation hook for the propagate-only OTel shim.
+
+Dockerfile.otel-shim installs this as ``_lineage_propagate.py`` in the app
+environment's site-packages next to a one-line ``.pth``, so ``site`` imports
+it at every interpreter start, before any app code. The shim thus attaches
+through the environment (like ``JAVA_TOOL_OPTIONS`` / ``NODE_OPTIONS``); the
+container's command is never rewritten.
+
+Inert unless ``LINEAGE_PROPAGATE=1``. When active: pin the propagate-only
+posture as env *defaults* (every exporter ``none``, ``tracecontext,baggage``
+propagators — ``setdefault``, so a deliberate override still wins), then run
+stock auto-instrumentation via ``initialize()``; which instrumentors activate
+depends on what the app imports.
+
+Failure policy: never take the app down. ``initialize()`` swallows its own
+exceptions, the guard below covers the rest, and ``site`` itself survives a
+broken ``.pth`` line. A hook failure therefore means propagation is OFF and the
+trace fragments at this pod, visibly (``parent.source=none`` on its outbound
+hops) — absent lineage,
+never wrong lineage.
+"""
+
+import os
+
+if os.environ.get("LINEAGE_PROPAGATE") == "1":
+    os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
+    os.environ.setdefault("OTEL_METRICS_EXPORTER", "none")
+    os.environ.setdefault("OTEL_LOGS_EXPORTER", "none")
+    os.environ.setdefault("OTEL_PROPAGATORS", "tracecontext,baggage")
+    try:
+        from opentelemetry.instrumentation.auto_instrumentation import initialize
+
+        initialize()
+    # Deliberately broad: never break the app this hook rides in.
+    except Exception:  # noqa: BLE001
+        import logging
+
+        logging.getLogger(__name__).exception(
+            "lineage propagate hook failed to initialize; propagation is OFF for this process"
+        )

--- a/authbridge/lineage-attach/sidecar-patch.sh
+++ b/authbridge/lineage-attach/sidecar-patch.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# sidecar-patch.sh — attach the lineage sidecar to an EXISTING Deployment.
+#
+# The live applier. The Deployment is deployed and owned by someone else; this
+# script only ADDS the lineage pieces through a strategic-merge patch (lists
+# merge by name, so nothing the owner wrote changes; the app container is
+# touched only when APP_CONTAINER opts it in). Every YAML byte comes from
+# attach-lineage.sh: EMIT=cm (the plugin ConfigMap), EMIT=patch (the sidecar).
+# This script checks, applies both, and waits for the rollout.
+#
+# Not durable: the owner keeps owning the object, and a platform rewrite (an
+# operator reconcile, a UI redeploy) silently drops the patch — observed live
+# when an operator reconciled a patched Deployment. Re-run after any
+# platform-side change, or keep the attachment in your own manifests instead
+# (README.md "Bring your own manifests"). To back out: the `rollout undo
+# --to-revision` line this script prints last (a bare undo is right only
+# until the Deployment rolls again for another reason), then delete the CM.
+#
+# Refused: a target that already carries a container named `envoy-proxy` or an
+# init container named `proxy-init` (the operator's sidecar, another mesh's
+# init, a leftover of an earlier attach — the merge would silently take it
+# over rather than sit beside it), or one that declares 9090, 15123 or 15124
+# (an undeclared sidecar, or the app itself on a port the sidecar binds).
+#
+# Propagation: an uninstrumented app also needs the shim — bake it with
+# build-otel-shim.sh, then pass APP_CONTAINER (+ APP_IMAGE) so the patch
+# flips LINEAGE_PROPAGATE=1 on the app's own container. Without it this is
+# capture only (README.md "The propagation half").
+#
+# Usage:
+#   DEPLOY=echo-upstream ./sidecar-patch.sh
+#   DEPLOY=my-agent APP_CONTAINER=agent \
+#     APP_IMAGE=docker.io/library/my-agent-otel:latest ./sidecar-patch.sh
+#
+# Env — read here:
+#   DEPLOY         target Deployment (required)
+#   NAMESPACE      default team1
+#   SELF_ID        lineage identity (default: DEPLOY)
+#   APP_CONTAINER  the app container to switch propagation on (optional)
+# Env — inherited by attach-lineage.sh and validated there (see its header):
+#   APP_IMAGE, OTEL_ENDPOINT, CAPTURE_IO (content capture, off unless true),
+#   MAX_PAYLOAD_BYTES (cap on a captured value; plugin default 4096, -1 = whole),
+#   SIDECAR_IMAGE, PROXY_INIT_IMAGE, NO_EMIT,
+#   OUTBOUND_PORTS_EXCLUDE (an app's OWN telemetry port, or a plaintext non-HTTP store
+#                   port such as Postgres/SMTP — never LLM/tool/S3 ports).
+#
+# Requires in the namespace: the platform's `envoy-config` ConfigMap; the
+# sidecar + proxy-init images resolvable from the cluster (README "Prerequisites and configuration").
+#
+# Structure: read_inputs → preconditions (five, read-only; each returns or exits) →
+# note_capture_only → apply (the only cluster writes). gen() is the one bridge
+# to the generator.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+read_inputs() {
+  DEPLOY="${DEPLOY:?usage: DEPLOY=<deployment> [NAMESPACE=team1] [SELF_ID=<id>] [APP_CONTAINER=<name> [APP_IMAGE=<ref>]] [SIDECAR_IMAGE=<ref> PROXY_INIT_IMAGE=<ref>] [OUTBOUND_PORTS_EXCLUDE=ports] sidecar-patch.sh}"
+  NAMESPACE="${NAMESPACE:-team1}"
+  SELF_ID="${SELF_ID:-$DEPLOY}"
+  APP_CONTAINER="${APP_CONTAINER:-}"
+}
+
+require_deployment() {
+  kubectl get deploy -n "$NAMESPACE" "$DEPLOY" >/dev/null
+}
+
+require_envoy_config() {  # the patch mounts it; missing → the pod never starts
+  kubectl get cm -n "$NAMESPACE" envoy-config >/dev/null || {
+    echo "error: ConfigMap envoy-config missing in $NAMESPACE (rendered by the platform chart)" >&2
+    exit 1
+  }
+}
+
+refuse_name_collision() {
+  # Lists merge by NAME: a target already carrying either name is merged over,
+  # not added beside. Init containers included — that is where proxy-init
+  # lands. (A native sidecar, an initContainer with restartPolicy Always, is
+  # covered by name here but not by the port check below.)
+  local names n
+  names="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
+    -o jsonpath='{range .spec.template.spec.initContainers[*]}{.name}{" "}{end}{range .spec.template.spec.containers[*]}{.name}{" "}{end}')"
+  for n in envoy-proxy proxy-init; do
+    case " $names " in
+      *" $n "*)
+        echo "error: $DEPLOY already has a container named $n — the patch would merge over it, not add beside it" >&2
+        echo "  (an operator-injected sidecar, another mesh's init, or an earlier attach) — refusing" >&2
+        exit 1 ;;
+    esac
+  done
+}
+
+refuse_port_collision() {
+  # An existing sidecar or the app on a sidecar port — see the header. Ports are
+  # what a Deployment declares; an undeclared app port cannot be seen from here.
+  local declared_ports p
+  declared_ports="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
+    -o jsonpath='{range .spec.template.spec.containers[*].ports[*]}{.containerPort}{" "}{end}')"
+  for p in 15124 15123 9090; do
+    case " $declared_ports " in
+      *" $p "*)
+        echo "error: $DEPLOY already declares containerPort $p, which the lineage sidecar binds" >&2
+        echo "  (an operator-injected sidecar, or the app itself on that port) — refusing to patch over it" >&2
+        exit 1 ;;
+    esac
+  done
+}
+
+require_app_container() {
+  # A strategic merge ADDS a stub container for an unknown name instead of
+  # failing — so the name must exist. The generator cannot check this.
+  [ -n "$APP_CONTAINER" ] || return 0
+  local containers
+  containers="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
+    -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{" "}{end}')"
+  case " $containers " in
+    *" $APP_CONTAINER "*) ;;
+    *)
+      echo "error: deploy/$DEPLOY has no container named '$APP_CONTAINER' (it has: ${containers% })" >&2
+      echo "  — refusing: the patch would ADD a stub container by that name instead of failing" >&2
+      exit 1 ;;
+  esac
+}
+
+note_capture_only() {
+  # Whether the app propagates traceparent is a property of the app that
+  # nothing here can see — say so once instead of guessing from its env.
+  [ -z "$APP_CONTAINER" ] || return 0
+  echo "NOTE: the sidecar records every hop; whether $DEPLOY's outbound hops attribute to" >&2
+  echo "      their inbound depends on the app carrying the trace context (traceparent +" >&2
+  echo "      tracestate) from inbound to outbound itself (its own instrumentation, or the" >&2
+  echo "      baked shim + APP_CONTAINER=<name>). Verify pairing" >&2
+  echo "      under concurrency before relying on it (DESIGN.md, 'The envelope')." >&2
+}
+
+gen() {  # $1 = EMIT mode; the other knobs reach the generator through the environment
+  EMIT="$1" NAME="$DEPLOY" SELF_ID="$SELF_ID" NAMESPACE="$NAMESPACE" \
+    "${SCRIPT_DIR}/attach-lineage.sh"
+}
+
+apply() {
+  # Both objects are generated before the first write, so a generator refusal
+  # stops the script with nothing applied. ConfigMap first — the patch's
+  # volume names it.
+  local cm patch before
+  cm="$(gen cm)"
+  patch="$(gen patch)"
+  # The revision to return to. A bare `rollout undo` goes one step back, which
+  # is this one only until the Deployment rolls again for any other reason.
+  before="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
+    -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')"
+  kubectl apply -f - <<<"$cm"
+  kubectl patch deploy "$DEPLOY" -n "$NAMESPACE" --type strategic --patch "$patch" || {
+    kubectl delete cm -n "$NAMESPACE" "authbridge-lineage-config-$DEPLOY"   # nothing else was written
+    exit 1
+  }
+  # Said before the wait: a rollout that never completes still needs this line.
+  echo ">> back out: kubectl -n $NAMESPACE rollout undo deploy/$DEPLOY --to-revision=${before:-?} && kubectl -n $NAMESPACE delete cm authbridge-lineage-config-$DEPLOY"
+  kubectl rollout status -n "$NAMESPACE" "deploy/$DEPLOY" --timeout=180s
+  echo ">> lineage sidecar attached to deploy/$DEPLOY (self_id=$SELF_ID, ns=$NAMESPACE)"
+}
+
+preconditions() {  # read-only: each returns or exits — nothing is applied yet
+  require_deployment
+  require_envoy_config
+  refuse_name_collision
+  refuse_port_collision
+  require_app_container
+}
+
+main() {
+  read_inputs        # DEPLOY required; the rest defaulted or inherited
+  preconditions      # five checks that can only stop the script
+  note_capture_only  # no APP_CONTAINER → say what that means, once
+  apply              # generate both, then the only cluster writes: cm → patch → rollout
+}
+main "$@"

--- a/authbridge/lineage-attach/sidecar-patch.sh
+++ b/authbridge/lineage-attach/sidecar-patch.sh
@@ -13,7 +13,7 @@
 # when an operator reconciled a patched Deployment. Re-run after any
 # platform-side change, or keep the attachment in your own manifests instead
 # (README.md "Bring your own manifests"). To back out: the reverse-patch line
-# this script prints last — a strategic merge that deletes, by name, exactly
+# this script prints before the rollout wait — a strategic merge that deletes, by name, exactly
 # what the attach added and restores the app image it replaced, so it is right
 # at ANY later time, whatever else rolled the Deployment since — then delete
 # the CM. (A `rollout undo` is NOT the back-out: it restores a whole earlier
@@ -171,7 +171,7 @@ apply() {
   # All three objects — ConfigMap, patch, and its reverse — are generated
   # before the first write, so a generator refusal stops the script with
   # nothing applied. ConfigMap first — the patch's volume names it.
-  local cm patch undo restored_image cm_existed dryrun_err
+  local cm patch undo restored_image cm_existed
   cm="$(gen cm)"
   patch="$(gen patch)"
   # The image is the one piece the patch REPLACES rather than adds, so the
@@ -202,7 +202,7 @@ apply() {
     case "$dryrun_err" in
       *startupProbe*|*restartPolicy*|*"init container"*)
         echo "  hint: rejection of the native-sidecar fields (startupProbe / restartPolicy on an init" >&2
-        echo "        container) means the cluster is older than k8s 1.29, which the kit requires." >&2 ;;
+        echo "        container) likely means the cluster is older than k8s 1.29, which the kit requires." >&2 ;;
     esac
     exit 1
   fi

--- a/authbridge/lineage-attach/sidecar-patch.sh
+++ b/authbridge/lineage-attach/sidecar-patch.sh
@@ -82,7 +82,8 @@ refuse_name_collision() {
   # not added beside. Init containers included — that is where proxy-init
   # lands. (A native sidecar, an initContainer with restartPolicy Always, is
   # checked here only under these two names; the port check below ranges
-  # initContainers too, and refuse_own_init_containers refuses the rest.)
+  # initContainers too. envoy-proxy is itself emitted as a native-sidecar
+  # initContainer, so a re-attach is caught here by name.)
   local names n
   names="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
     -o jsonpath='{range .spec.template.spec.initContainers[*]}{.name}{" "}{end}{range .spec.template.spec.containers[*]}{.name}{" "}{end}')"
@@ -100,7 +101,8 @@ refuse_port_collision() {
   # An existing sidecar or the app on a sidecar port — see the header. Ports are
   # what a Deployment declares; an undeclared app port cannot be seen from here.
   # initContainers included: a native sidecar (restartPolicy Always) holds its
-  # ports at runtime, and ALLOW_INIT_CONTAINERS=1 can let one through.
+  # ports at runtime (envoy-proxy, the kit's own, is one — so a re-attach or a
+  # foreign native sidecar on these ports is caught here).
   local declared_ports p
   declared_ports="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
     -o jsonpath='{range .spec.template.spec.initContainers[*].ports[*]}{.containerPort}{" "}{end}{range .spec.template.spec.containers[*].ports[*]}{.containerPort}{" "}{end}')"
@@ -169,7 +171,7 @@ apply() {
   # All three objects — ConfigMap, patch, and its reverse — are generated
   # before the first write, so a generator refusal stops the script with
   # nothing applied. ConfigMap first — the patch's volume names it.
-  local cm patch undo restored_image cm_existed
+  local cm patch undo restored_image cm_existed dryrun_err
   cm="$(gen cm)"
   patch="$(gen patch)"
   # The image is the one piece the patch REPLACES rather than adds, so the
@@ -188,12 +190,22 @@ apply() {
           APP_IMAGE= RESTORE_IMAGE="$restored_image" "${SCRIPT_DIR}/attach-lineage.sh")"
   # The server validates the FULLY MERGED object without persisting it, so
   # every rejection class — an invalid merged field, an admission webhook,
-  # RBAC missing deployments/patch — fails here, before the first write.
-  kubectl patch deploy "$DEPLOY" -n "$NAMESPACE" --type strategic --patch "$patch" \
-      --dry-run=server -o name >/dev/null || {
-    echo "error: the server rejected the merged patch (above) — nothing was applied" >&2
+  # RBAC missing deployments/patch, and a cluster too old for native sidecars —
+  # fails here, before the first write. This is the version guard too: on k8s
+  # < 1.29 the server rejects the native-sidecar fields (startupProbe/
+  # restartPolicy on an init container), so no version parsing is needed.
+  local dryrun_err
+  if ! dryrun_err="$(kubectl patch deploy "$DEPLOY" -n "$NAMESPACE" --type strategic \
+        --patch "$patch" --dry-run=server -o name 2>&1)"; then
+    echo "error: the server rejected the merged patch — nothing was applied:" >&2
+    printf '%s\n' "$dryrun_err" >&2
+    case "$dryrun_err" in
+      *startupProbe*|*restartPolicy*|*"init container"*)
+        echo "  hint: rejection of the native-sidecar fields (startupProbe / restartPolicy on an init" >&2
+        echo "        container) means the cluster is older than k8s 1.29, which the kit requires." >&2 ;;
+    esac
     exit 1
-  }
+  fi
   # On a re-attach the ConfigMap already exists and running pods project it:
   # the failure compensation below may delete only what THIS run created.
   cm_existed=0

--- a/authbridge/lineage-attach/sidecar-patch.sh
+++ b/authbridge/lineage-attach/sidecar-patch.sh
@@ -12,15 +12,21 @@
 # operator reconcile, a UI redeploy) silently drops the patch — observed live
 # when an operator reconciled a patched Deployment. Re-run after any
 # platform-side change, or keep the attachment in your own manifests instead
-# (README.md "Bring your own manifests"). To back out: the `rollout undo
-# --to-revision` line this script prints last (a bare undo is right only
-# until the Deployment rolls again for another reason), then delete the CM.
+# (README.md "Bring your own manifests"). To back out: the reverse-patch line
+# this script prints last — a strategic merge that deletes, by name, exactly
+# what the attach added and restores the app image it replaced, so it is right
+# at ANY later time, whatever else rolled the Deployment since — then delete
+# the CM. (A `rollout undo` is NOT the back-out: it restores a whole earlier
+# pod template, silently taking the owner's later changes with it.)
 #
 # Refused: a target that already carries a container named `envoy-proxy` or an
 # init container named `proxy-init` (the operator's sidecar, another mesh's
 # init, a leftover of an earlier attach — the merge would silently take it
-# over rather than sit beside it), or one that declares 9090, 15123 or 15124
-# (an undeclared sidecar, or the app itself on a port the sidecar binds).
+# over rather than sit beside it), one that declares 9090, 15123 or 15124
+# (an undeclared sidecar, or the app itself on a port the sidecar binds), or
+# one that already has a volume named `envoy-config` or `authbridge-runtime`
+# (volumes merge by name too — the merge would repoint the volume's source
+# while the owner's volumeMounts keep serving it).
 #
 # Propagation: an uninstrumented app also needs the shim — bake it with
 # build-otel-shim.sh, then pass APP_CONTAINER (+ APP_IMAGE) so the patch
@@ -47,7 +53,7 @@
 # Requires in the namespace: the platform's `envoy-config` ConfigMap; the
 # sidecar + proxy-init images resolvable from the cluster (README "Prerequisites and configuration").
 #
-# Structure: read_inputs → preconditions (five, read-only; each returns or exits) →
+# Structure: read_inputs → preconditions (six, read-only; each returns or exits) →
 # note_capture_only → apply (the only cluster writes). gen() is the one bridge
 # to the generator.
 set -euo pipefail
@@ -75,7 +81,8 @@ refuse_name_collision() {
   # Lists merge by NAME: a target already carrying either name is merged over,
   # not added beside. Init containers included — that is where proxy-init
   # lands. (A native sidecar, an initContainer with restartPolicy Always, is
-  # covered by name here but not by the port check below.)
+  # checked here only under these two names; the port check below ranges
+  # initContainers too, and refuse_own_init_containers refuses the rest.)
   local names n
   names="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
     -o jsonpath='{range .spec.template.spec.initContainers[*]}{.name}{" "}{end}{range .spec.template.spec.containers[*]}{.name}{" "}{end}')"
@@ -92,14 +99,35 @@ refuse_name_collision() {
 refuse_port_collision() {
   # An existing sidecar or the app on a sidecar port — see the header. Ports are
   # what a Deployment declares; an undeclared app port cannot be seen from here.
+  # initContainers included: a native sidecar (restartPolicy Always) holds its
+  # ports at runtime, and ALLOW_INIT_CONTAINERS=1 can let one through.
   local declared_ports p
   declared_ports="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
-    -o jsonpath='{range .spec.template.spec.containers[*].ports[*]}{.containerPort}{" "}{end}')"
+    -o jsonpath='{range .spec.template.spec.initContainers[*].ports[*]}{.containerPort}{" "}{end}{range .spec.template.spec.containers[*].ports[*]}{.containerPort}{" "}{end}')"
   for p in 15124 15123 9090; do
     case " $declared_ports " in
       *" $p "*)
         echo "error: $DEPLOY already declares containerPort $p, which the lineage sidecar binds" >&2
         echo "  (an operator-injected sidecar, or the app itself on that port) — refusing to patch over it" >&2
+        exit 1 ;;
+    esac
+  done
+}
+
+refuse_volume_collision() {
+  # Volumes merge by NAME too: an existing volume by either name would have
+  # its source silently repointed at our ConfigMap (and a different-type
+  # volume would make the API server reject the merged object). The owner's
+  # volumeMounts keep referencing the name, so the damage would surface only
+  # at the next pod start, with nothing in a diff.
+  local volumes v
+  volumes="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
+    -o jsonpath='{range .spec.template.spec.volumes[*]}{.name}{" "}{end}')"
+  for v in envoy-config authbridge-runtime; do
+    case " $volumes " in
+      *" $v "*)
+        echo "error: $DEPLOY already has a volume named $v — the patch would repoint its source, not add beside it" >&2
+        echo "  (the owner mounts that volume somewhere; the merge would silently change what the mount serves) — refusing" >&2
         exit 1 ;;
     esac
   done
@@ -138,23 +166,60 @@ gen() {  # $1 = EMIT mode; the other knobs reach the generator through the envir
 }
 
 apply() {
-  # Both objects are generated before the first write, so a generator refusal
-  # stops the script with nothing applied. ConfigMap first — the patch's
-  # volume names it.
-  local cm patch before
+  # All three objects — ConfigMap, patch, and its reverse — are generated
+  # before the first write, so a generator refusal stops the script with
+  # nothing applied. ConfigMap first — the patch's volume names it.
+  local cm patch undo restored_image cm_existed
   cm="$(gen cm)"
   patch="$(gen patch)"
-  # The revision to return to. A bare `rollout undo` goes one step back, which
-  # is this one only until the Deployment rolls again for any other reason.
-  before="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
-    -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}')"
+  # The image is the one piece the patch REPLACES rather than adds, so the
+  # reverse patch needs a value, not a delete: capture the ref the owner runs
+  # now, before the patch swaps it. Every other added piece un-merges by name.
+  restored_image=""
+  if [ -n "${APP_IMAGE:-}" ]; then
+    restored_image="$(kubectl get deploy -n "$NAMESPACE" "$DEPLOY" \
+      -o jsonpath="{.spec.template.spec.containers[?(@.name=='$APP_CONTAINER')].image}")"
+    [ -n "$restored_image" ] || {
+      echo "error: could not read the current image of container '$APP_CONTAINER' — nothing was applied" >&2
+      exit 1
+    }
+  fi
+  undo="$(EMIT=undo NAME="$DEPLOY" NAMESPACE="$NAMESPACE" \
+          APP_IMAGE= RESTORE_IMAGE="$restored_image" "${SCRIPT_DIR}/attach-lineage.sh")"
+  # The server validates the FULLY MERGED object without persisting it, so
+  # every rejection class — an invalid merged field, an admission webhook,
+  # RBAC missing deployments/patch — fails here, before the first write.
+  kubectl patch deploy "$DEPLOY" -n "$NAMESPACE" --type strategic --patch "$patch" \
+      --dry-run=server -o name >/dev/null || {
+    echo "error: the server rejected the merged patch (above) — nothing was applied" >&2
+    exit 1
+  }
+  # On a re-attach the ConfigMap already exists and running pods project it:
+  # the failure compensation below may delete only what THIS run created.
+  cm_existed=0
+  if kubectl get cm -n "$NAMESPACE" "authbridge-lineage-config-$DEPLOY" >/dev/null 2>&1; then
+    cm_existed=1
+  fi
   kubectl apply -f - <<<"$cm"
   kubectl patch deploy "$DEPLOY" -n "$NAMESPACE" --type strategic --patch "$patch" || {
-    kubectl delete cm -n "$NAMESPACE" "authbridge-lineage-config-$DEPLOY"   # nothing else was written
+    # Only a failure the dry-run could not predict lands here (e.g. a 409
+    # from a concurrent write). Nothing else was written this run except,
+    # possibly, the ConfigMap — remove it only if this run created it.
+    [ "$cm_existed" = "1" ] || kubectl delete cm -n "$NAMESPACE" "authbridge-lineage-config-$DEPLOY"
     exit 1
   }
   # Said before the wait: a rollout that never completes still needs this line.
-  echo ">> back out: kubectl -n $NAMESPACE rollout undo deploy/$DEPLOY --to-revision=${before:-?} && kubectl -n $NAMESPACE delete cm authbridge-lineage-config-$DEPLOY"
+  # CM after the patch: pods of a revision that still mounts it cannot start.
+  echo ">> back out: kubectl -n $NAMESPACE patch deploy/$DEPLOY --type strategic -p '$undo' && kubectl -n $NAMESPACE delete cm authbridge-lineage-config-$DEPLOY"
+  [ -z "$restored_image" ] || \
+    echo ">>   (the patch restores image $restored_image — drop its \"image\" field if the app is re-imaged after this attach)"
+  # A rollout that times out is deliberately left patched (unlike the patch-
+  # apply failure above, which auto-cleans): Kubernetes holds the blast —
+  # maxUnavailable keeps the old pod serving — and the back-out line printed
+  # just above is the clean way out. Undoing here would fight a slow-but-
+  # healthy rollout, and the likely cause (an image absent from the node, an
+  # SCC/PodSecurity denial creating pods) wants the operator's eyes, not a
+  # silent revert.
   kubectl rollout status -n "$NAMESPACE" "deploy/$DEPLOY" --timeout=180s
   echo ">> lineage sidecar attached to deploy/$DEPLOY (self_id=$SELF_ID, ns=$NAMESPACE)"
 }
@@ -164,12 +229,13 @@ preconditions() {  # read-only: each returns or exits — nothing is applied yet
   require_envoy_config
   refuse_name_collision
   refuse_port_collision
+  refuse_volume_collision
   require_app_container
 }
 
 main() {
   read_inputs        # DEPLOY required; the rest defaulted or inherited
-  preconditions      # five checks that can only stop the script
+  preconditions      # six checks that can only stop the script
   note_capture_only  # no APP_CONTAINER → say what that means, once
   apply              # generate both, then the only cluster writes: cm → patch → rollout
 }


### PR DESCRIPTION
<!-- PR body for branch feat/lineage-attach-kit → main.
     Title: "Feat: Add the lineage attach kit for any running Deployment" -->

## Summary

`authbridge/lineage-attach/`: attach **per-request data lineage** to a Deployment that is *already
running*, and nothing else. It attaches the envoy-sidecar, enables the `lineage-telemetry` plugin (#761),
and every HTTP exchange becomes two facts-only spans sent to any OTLP consumer; for an uninstrumented
Python app it also bakes a propagate-only OpenTelemetry layer, activated by one environment variable,
so the pairing is correct under concurrency. Nine files, 1,998 lines, additions only.

**Depends on:** #761 (the plugin; this kit follows its wire contract v1.6 and was validated against it)
— merge after it. Based on current `main`.
**Requires Kubernetes ≥ 1.29:** the sidecar is attached as a *native sidecar* (see "Attach only" below).
**Start reading at** `RECIPE.md` (the steps with expected output and back-out), then `README.md` (the
idea, what the spans carry, the two attach routes), then `DESIGN.md` (why propagation is the app's job,
why the sidecar is native, the shim's envelope, the case that looks fine and is not, the limits).
**Supersedes #762**, which carried the kit and the demo together with the work history; this is the kit
alone, on a curated history. **A runnable demo** on the Weather Agent pair follows as its own PR once
this one lands.

## What is in the diff

| file | lines | what |
|---|---:|---|
| `attach-lineage.sh` | 472 | **the one generator** — every YAML byte: `EMIT=patch` (default), `EMIT=cm`, or `EMIT=undo` (the exact reverse patch for back-out); validates every caller input; never touches the cluster |
| `sidecar-patch.sh` | 254 | the live applier: six read-only preconditions → server-side dry-run → ConfigMap → patch → prints the exact reverse-patch back-out line → rollout wait |
| `build-otel-shim.sh` | 326 | bakes the shim onto an app image; detects interpreter and uid:gid from the image; refuses images it cannot safely wrap; attests every bake |
| `Dockerfile.otel-shim` | 85 | the propagate-only layer: eight instrumentors pinned to one contrib release, uv pinned by digest; `uv pip check` fails the build on a dependency conflict the install introduced |
| `lineage-propagate-hook.py` | 40 | the env-gated site-packages hook (`.pth` + module); the image's command is never rewritten |
| `container-runtime.sh` | 61 | podman-vs-docker detection and kind loading |
| `README.md` · `RECIPE.md` · `DESIGN.md` | 313 · 139 · 308 | as above |

## Attach only

The kit never deploys an application. It emits one strategic-merge patch (`proxy-init` and `envoy-proxy`
as init containers, two config volumes, and — opt-in — one env var and one image reference on the app's
own container) and one ConfigMap (the parser chain plus the plugin entry). Lists merge by name, so
nothing the owner wrote changes.

**`envoy-proxy` is attached as a native sidecar** — an `initContainers` entry with `restartPolicy:
Always` and a `startupProbe` on the outbound listener. `proxy-init` redirects the pod's egress the moment
it runs, so a plain-container sidecar would let an app that dials out *at process start* (peer discovery,
a config fetch) reach the redirect before the proxy is listening — connection refused, the pod "running",
the failure silent. The native sidecar makes the kubelet hold the app container until the proxy is
accepting, with no cooperation from the app. This needs **k8s ≥ 1.29** (native sidecars on by default
from 1.29, GA 1.33); on an older cluster the apiserver rejects the native-sidecar fields (`startupProbe:
Forbidden …`) — loud, on both routes: the adopt path at the applier's server dry-run, before any write
(with a needs-1.29 hint); the manifests route at the operator's own `kubectl apply` of the Deployment
(the ConfigMap from that same apply persists, inert on its own). Verified on a real 1.28 cluster.

Back-out is a **reverse patch**, not `rollout undo`: the applier prints (and `EMIT=undo` regenerates) a
strategic merge that `$patch: delete`s exactly what the attach added and restores the app image it
replaced, so it is correct at any later time and leaves every change the owner made since the attach in
place. (A `rollout undo` would restore a whole earlier pod template, silently reverting the owner's later
changes.)

Two routes to the same two objects: **adopt a live Deployment** (`DEPLOY=<name> ./sidecar-patch.sh`:
six preconditions — the Deployment exists; the platform-rendered `envoy-config` is in the namespace; no
container named `envoy-proxy`/`proxy-init`; no container declares 9090/15123/15124; no volume named
`envoy-config`/`authbridge-runtime`; `APP_CONTAINER`, if given, names a real container — then the server
dry-run, which is also the k8s-version guard),
or **bring your own manifests** (`EMIT=cm` and `EMIT=patch` to files under a `kustomization.yaml`;
verified with `kubectl kustomize` and `kubectl patch --local`: identical result). The manifests route
does not run the dry-run, but the apiserver rejects the native-sidecar fields at your own apply on < 1.29.

## Propagation

The sidecar sees every hop but cannot know which inbound caused which outbound; only code inside the
request can carry the context through. When the app does not, #761's plugin does not guess: the hop
records `parent.source=none` and fragments, visibly. For an **uninstrumented Python app**
(Starlette/ASGI/FastAPI in; httpx/requests/aiohttp/urllib3 out; `threading` across executors) the shim
supplies it: bake, then `APP_CONTAINER=<name>` merges `LINEAGE_PROPAGATE=1` into that container's env
and `APP_IMAGE` points it at the baked image; the hook runs stock auto-instrumentation at interpreter
start only under that variable, every exporter pinned to `none`. An app that **instruments itself** is
refused by the bake interlock (`REFUSING to bake …: it already instruments httpx`) and uses its own
switch. DESIGN covers the half-instrumented app, the case every per-trace check passes while attribution
is entirely lost.

## Defaults are the plugin's

`capture_io` is off unless `CAPTURE_IO=true`; the cap is the plugin's 4096 unless `MAX_PAYLOAD_BYTES`
says otherwise (`-1` attaches whole). README's prerequisites state what capture ships: PII-bearing
content, plain gRPC unless `OTEL_ENDPOINT` is `https://…`, printed into the collector's pod log on the
stock platform.

## The generated pieces

Same hardening as `demos/mtls`: all capabilities dropped, no privilege escalation, `proxy-init` adds back
exactly `NET_ADMIN` + `NET_RAW` as root, `envoy-proxy` non-root as 1337 with `seccompProfile:
RuntimeDefault`, a startup probe on its outbound listener and a readiness probe on its inbound listener,
requests and limits on both. Every caller input is validated before it is emitted (RFC 1123 / DNS-label
names, ports in 1–65535 with no leading zeros, enumerated switches, image/interpreter refs against a safe
character set, free-form values refused if they carry `"`, `\`, `'` or whitespace); a validated-input
refusal is `exit 2` (a missing required `NAME`/`DEPLOY` is `exit 1`, and the bake's refuse-to-wrap paths
are `exit 3`).

## Evidence

- Offline: real bakes across base layouts, an already-baked image refused, a hostile-image command
  injection into the build refused, gate-off inertness and gate-on propagation proven end to end — an
  inbound `traceparent` and `tracestate` survive Starlette, a thread pool and `requests` to the outbound.
- **Native sidecar, live:** an app that makes one outbound call at process start, attached behind the
  real `proxy-init` egress redirect, reaches its peer on the **first boot** (HTTP 200, 0 restarts); the
  same app with a plain-container arrangement gets connection-refused on the same cluster.
- **Full fleet, live** (11-service application, one turn, cortex span evidence only): one trace, 344
  spans, 172 request == 172 response, 0 unpaired, 171 `tracestate` + exactly 1 `wire` at the entry
  (the driver sends a `traceparent`), 0 `none`, 0
  strays — matching the pre-native-sidecar shape (no regression). Earlier runs found the `urllib3` gap
  and the plaintext-Postgres case; both fixes are here.

## Gates

`shellcheck --severity=error` (as the Security Scans job runs it): exit 0 on all four scripts (at default
severity, only info/warning remain: `SC2016`, `SC1007`). `hadolint --failure-threshold error` with the
repo's ignore list: exit 0 (`DL3066` + `DL3059`, both info). `ruff` at the pre-commit pin, `bandit -ll`: clean.
`git diff --check`: clean. Generated YAML: every mode parses and passes a server-side dry-run.

We tested the kit end to end on a kind cluster while addressing the review: repeated bakes across
base-image layouts, attach → back-out round-trips, hostile inputs against each guard (including a base
image built to attack the interpreter detection), a real 1.28 apiserver for the version story, and
multi-service fleet turns with span-shape checks. Several fixes came from that testing rather than from
review threads — the native sidecar among them.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooling to attach HTTP lineage telemetry to Kubernetes Deployments, including request/response tracing and trace-context propagation.
  * Added support for baking propagation into Python application images without enabling telemetry export.
  * Added live attachment, verification, rollout monitoring, and generated rollback workflows.
  * Added Podman and Docker support for loading images into kind clusters.

* **Bug Fixes**
  * Added safeguards for image, container, port, volume, instrumentation, and configuration conflicts.
  * Prevented unsafe sidecar configurations that could cause crash loops or stalled rollouts.

* **Documentation**
  * Documented prerequisites, configuration, troubleshooting, limitations, and Kubernetes 1.29 requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->