### PR TITLE
docs: :memo: Plugin doc updates

### DIFF
--- a/authbridge/docs/ibac-plugin.md
+++ b/authbridge/docs/ibac-plugin.md
@@ -179,6 +179,8 @@ pipeline:
 | `judge_endpoint` | Yes | — | Base URL of the LLM judge service. The plugin POSTs to `{judge_endpoint}/v1/chat/completions`. Any OpenAI-compatible endpoint works (ollama, OpenAI, vLLM, etc). |
 | `judge_model` | Yes | — | Model identifier passed in the chat-completion request, e.g. `"llama3.2:3b"`, `"gpt-4o-mini"`. |
 | `judge_bearer` | No | `""` | Bearer token for the judge endpoint. Leave empty for unauthenticated local LLMs (ollama). |
+| `judge_max_tokens` | No | `1024` | Cap on the judge LLM's reply length. Lower values risk truncating mid-key on hosted models that wrap output in markdown fences. |
+| `judge_json_mode` | No | `true` | Sets `response_format: json_object` in the judge request so hosted models suppress the markdown-fence wrapper around structured output. |
 | `system_prompt` | No | (built-in) | Override the default judge system prompt. The default instructs the model to emit `{"verdict":"allow"\|"deny","reason":"..."}` and to deny when ambiguous. |
 | `timeout_ms` | No | `5000` | Per-call timeout. Validation rejects values below `100` to catch obvious operator mistakes. |
 | `judge_inference` | No | `false` | When `true`, also judge outbound traffic where `Extensions.Inference` is populated (the agent's own LLM-reasoning loop). |

--- a/authbridge/docs/plugin-catalog.md
+++ b/authbridge/docs/plugin-catalog.md
@@ -23,12 +23,12 @@ AuthBridge pipeline YAML, not whether it is compiled into the binary
 | Name | Description | Production ready? | Direction | Default config? |
 |------|-------------|--------------------|-----------|------------------|
 | [`a2a-parser`](#a2a-parser) | Parses A2A messages into `pctx.Extensions.A2A` for downstream plugins. | Beta | Inbound | No |
-| [`context-guru`](#context-guru) | Compacts the outbound LLM request context before forwarding. | Coming Soon | Outbound | No |
-| [`cpex`](#cpex) | APL DSL + named [CPEX](https://github.com/contextforge-org/cpex) plugins (Cedar, PII, audit, …) over a single chain step. | Coming Soon | Outbound | No |
+| [`context-guru`](#context-guru) | Compacts the outbound LLM request context before forwarding. | Opt-in | Outbound | No |
+| [`cpex`](#cpex) | APL DSL + named [CPEX](https://github.com/contextforge-org/cpex) plugins (Cedar, PII, audit, …) over a single chain step. | Opt-in | Outbound | No |
 | [`ibac`](#ibac) | LLM-judge intent-based access control for outbound tool calls. | Alpha | Outbound | No |
 | [`inference-parser`](#inference-parser) | Parses LLM completions into `pctx.Extensions.Inference`. | Alpha | Outbound | No |
 | [`jwt-validation`](#jwt-validation) | Inbound JWT validation (signature, issuer, audience) against JWKS. | Ready | Inbound | YES |
-| [`litellm-budget-track`](#litellm-budget-track) | Tracks `x-litellm-response-cost` and enforces a daily budget limit. | Alpha | Inbound | No |
+| [`litellm-budget-track`](#litellm-budget-track) | Tracks `x-litellm-response-cost` (with `-original` fallback) and enforces a daily budget limit. Place on whichever chain carries LLM traffic — inbound when fronting the LLM endpoint, outbound when hosting an agent via `authbridge exec`. | Alpha | Both | No |
 | [`mcp-parser`](#mcp-parser) | Parses MCP tool calls/results into `pctx.Extensions.MCP`. | Beta | Outbound | No |
 | [`opa`](#opa) | [OPA](https://www.openpolicyagent.org/docs) policy enforcement for inbound and outbound requests. | Alpha | Both | No |
 | [`sparc`](#sparc) | Pre-tool reflection: blocks ungrounded/hallucinated tool calls. | Alpha | Outbound | No |

--- a/authbridge/docs/plugin-reference.md
+++ b/authbridge/docs/plugin-reference.md
@@ -388,7 +388,7 @@ convention:
 - `validate` requires exactly one to be set.
 - Internal state construction calls the file-read helper from
   `authlib/config` (not a new one), which tolerates transient absence
-  during pod boot (client-registration may still be writing).
+  during pod boot (the operator-managed Secret at `/shared/` may not yet be mounted).
 
 ## What Configure MUST NOT do
 

--- a/authbridge/docs/session-budget-plugin.md
+++ b/authbridge/docs/session-budget-plugin.md
@@ -45,7 +45,12 @@ pipeline:
 | Field | Default | Description |
 |-------|---------|-------------|
 | `redis_url` | — (required) | Redis/Valkey URL |
-| `max_tokens` | 0 | Token ceiling (0 = no limit) |
+| `max_tokens` | 0 | Cumulative token ceiling per session (all kinds summed). 0 = no limit. |
+| `max_input_tokens` | 0 | Per-kind ceiling on uncached prompt tokens. 0 = no limit. |
+| `max_cache_read_tokens` | 0 | Per-kind ceiling on prompt tokens served from cache. 0 = no limit. |
+| `max_cache_write_tokens` | 0 | Per-kind ceiling on prompt tokens written to cache. 0 = no limit. |
+| `max_output_tokens` | 0 | Per-kind ceiling on generated completion tokens. 0 = no limit. |
+| `max_reasoning_tokens` | 0 | Per-kind ceiling on reasoning-only output tokens (subset of output). 0 = no limit. |
 | `max_calls` | 0 | LLM/inference call cap (from `inference-parser`); MCP, A2A, and other outbound traffic do not count. 0 = no limit. See note below on enforcement scope. |
 | `max_duration_seconds` | 0 | Session lifetime cap (0 = no limit) |
 | `on_exceed` | `deny` | `deny` (403), `observe` (log only), or `pause` (webhook) |
@@ -58,7 +63,7 @@ pipeline:
 | `redis_unavailable` | `fail_open` | Only `fail_open` supported today |
 | `default_session_fallback` | `false` | Pool sessionless traffic into a shared `"default"` bucket. Single-workload only — one caller exhausting the budget denies the rest. Under `max_duration_seconds`, continuous traffic refreshes the TTL, so once elapsed exceeds the limit requests stay denied until the key expires or is deleted. |
 
-At least one of `max_tokens`, `max_calls`, `max_duration_seconds` must be > 0.
+At least one of `max_tokens`, `max_input_tokens`, `max_cache_read_tokens`, `max_cache_write_tokens`, `max_output_tokens`, `max_reasoning_tokens`, `max_calls`, `max_duration_seconds` must be > 0.
 
 **`max_calls` enforcement scope.** Only inference calls surfaced by
 `inference-parser` increment the counter, but the limit check runs on

--- a/authbridge/docs/sparc-plugin.md
+++ b/authbridge/docs/sparc-plugin.md
@@ -95,7 +95,7 @@ pipeline:
           enforcement: "mcp"             # mcp | inference
           track: "fast_track"            # fast_track|slow_track|syntax|spec_free|transformations_only
           on_reject_action: "reflect"    # observe | reflect | deny
-          deny_score_threshold: 0        # 0 disables; e.g. 2.0 → deny rejects scoring <= 2
+          deny_score_threshold: 0        # 0 disables; e.g. 0.4 → deny rejects scoring <= 0.4
           fail_policy: "open"            # open=allow+log on SPARC error; closed=block
           timeout_ms: 30000
           skip_tools: ["list_*"]         # tool-name globs NOT reflected on (e.g. read-only tools)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Doc accuracy sweep against current plugin source without overlap with #857. Fixes: litellm-budget-track direction column to Both with placement guidance (reconciling PR #847 and #851); context-guru and cpex status Coming Soon → Opt-in; sparc deny_score_threshold example from an out-of-range 2.0 to 0.4; missing session-budget per-kind ceilings, ibac judge fields, and a stale client-registration reference.

Note: cpex was not updated - #856 was opened as a follow-up issue

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented optional IBAC settings for limiting judge responses and requesting JSON-formatted output.
  * Updated the plugin catalog to show `context-guru` and `cpex` as opt-in, and clarified bidirectional cost tracking for `litellm-budget-track`.
  * Clarified file-sourced value behavior during operator-managed Secret mounting.
  * Expanded session-budget documentation with per-kind token limits.
  * Corrected the SPARC score threshold example to use a valid normalized value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->