### PR TITLE
Fix: Parse token telemetry from gzipped SSE responses

### DIFF
--- a/authbridge/authlib/listener/forwardproxy/gzip_sse_test.go
+++ b/authbridge/authlib/listener/forwardproxy/gzip_sse_test.go
@@ -1,0 +1,197 @@
+package forwardproxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+)
+
+// anthropicSSEBody is a minimal but complete Anthropic Messages stream: the two
+// usage-bearing events (message_start carries input_tokens, message_delta the
+// cumulative output_tokens) plus one text delta, framed the way the real API
+// frames them — a typed `event:` line before each `data:`.
+const anthropicSSEBody = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"usage":{"input_tokens":31,"output_tokens":1}}}` + "\n\n" +
+	"event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}` + "\n\n" +
+	"event: message_delta\n" +
+	`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":12}}` + "\n\n"
+
+// TestForwardProxy_GzippedSSE_ParsesTokens is the regression test for the
+// gzipped-SSE blind spot: an upstream that returns text/event-stream WITH
+// Content-Encoding: gzip.
+//
+// net/http auto-decompresses gzip only when its transport added
+// Accept-Encoding itself. The proxy used to forward the caller's
+// Accept-Encoding verbatim, which suppressed that and handed resp.Body raw
+// compressed bytes. sseframe then found no "data:" lines in the binary and
+// returned io.EOF on its first ReadFrame — so the proxy relayed ZERO frames
+// downstream, and inference-parser finalized on empty state: every token
+// count read as absent rather than wrong, and the client saw a stream that
+// opened and died ("Streaming response ended before any complete data was
+// received"). Both failures were silent; nothing logged an error.
+//
+// The client here sets Accept-Encoding explicitly, which is what a real agent
+// does, so this fails against the pre-fix listener.
+func TestForwardProxy_GzippedSSE_ParsesTokens(t *testing.T) {
+	var sawAcceptEncoding string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAcceptEncoding = r.Header.Get("Accept-Encoding")
+
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		if _, err := io.WriteString(zw, anthropicSSEBody); err != nil {
+			t.Errorf("gzip write: %v", err)
+			return
+		}
+		if err := zw.Close(); err != nil {
+			t.Errorf("gzip close: %v", err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer upstream.Close()
+
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+
+	// The real inference-parser: a StreamingResponder, so serveOutbound routes
+	// to handleStreamingResponse and each frame reaches OnResponseFrame.
+	pipe, err := pipeline.New([]pipeline.Plugin{inferenceparser.NewInferenceParser()})
+	if err != nil {
+		t.Fatalf("pipeline.New: %v", err)
+	}
+	srv, err := NewServer(pipeline.NewHolder(pipe), store, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	proxy := httptest.NewServer(srv.Handler())
+	defer proxy.Close()
+
+	body := `{"model":"claude-sonnet-5","stream":true,` +
+		`"messages":[{"role":"user","content":"hi"}]}`
+	req, err := http.NewRequest("POST", upstream.URL+"/v1/messages", bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// The header at the heart of the bug: an explicit Accept-Encoding is what
+	// stops net/http from transparently decompressing for us.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	proxyClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(mustParseURL(proxy.URL))}}
+	resp, err := proxyClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	relayed, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read relayed body: %v", err)
+	}
+
+	// The upstream still sees Accept-Encoding: gzip — but now it is the
+	// TRANSPORT's own header, added because we deleted the client's. That is
+	// the distinction the fix turns on: net/http decompresses transparently
+	// only for the Accept-Encoding it set itself, so the header being present
+	// is expected, and the plaintext body below is what proves ownership
+	// moved. Asserting on this string alone cannot separate the two cases.
+	if sawAcceptEncoding == "" {
+		t.Error("upstream saw no Accept-Encoding; expected the transport's own")
+	}
+
+	// The client must receive real SSE, not compressed bytes or nothing at all.
+	// Zero relayed bytes is the exact pre-fix symptom.
+	if len(relayed) == 0 {
+		t.Fatal("proxy relayed zero bytes downstream — the client sees a stream that opens and dies")
+	}
+	// Assert the typed `event:` line, not just the type name: "message_start"
+	// also appears inside the data payload, so matching the bare name passes
+	// whether or not the event line survived. This form additionally guards a
+	// separately-observed regression — the sseframe decoder surfaces only data
+	// payloads, and Anthropic's client cannot finalize a stream without a typed
+	// event line before each data line, so dropping it makes the client fall
+	// back to a non-streaming retry and doubles the upstream call.
+	if !bytes.Contains(relayed, []byte("event: message_start\n")) {
+		t.Errorf("relayed body is missing the typed SSE event line; got %q", truncate(relayed))
+	}
+	// gzip's magic number: the relayed body must be plaintext, and the headers
+	// must not advertise an encoding the bytes no longer carry.
+	if len(relayed) >= 2 && relayed[0] == 0x1f && relayed[1] == 0x8b {
+		t.Error("relayed body is still gzip-compressed")
+	}
+	if ce := resp.Header.Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding = %q on a plaintext relayed body; want empty", ce)
+	}
+
+	// The whole point: usage from message_start + message_delta reached the
+	// parser and landed on the session's response event.
+	ev := lastInferenceResponse(t, store)
+	if ev == nil {
+		t.Fatal("no outbound SessionResponse event carrying inference telemetry")
+	}
+	if ev.PromptTokens != 31 {
+		t.Errorf("PromptTokens = %d, want 31 (input_tokens from message_start)", ev.PromptTokens)
+	}
+	if ev.CompletionTokens != 12 {
+		t.Errorf("CompletionTokens = %d, want 12 (cumulative output_tokens from message_delta)", ev.CompletionTokens)
+	}
+	if ev.FinishReason != "end_turn" {
+		t.Errorf("FinishReason = %q, want end_turn", ev.FinishReason)
+	}
+	if ev.Completion != "hi" {
+		t.Errorf("Completion = %q, want \"hi\"", ev.Completion)
+	}
+
+	// The session summary's TotalTokens is what abctl renders in its TOKENS
+	// column, so assert the number an operator actually reads — not just the
+	// parsed extension behind it.
+	var total int
+	for _, sum := range store.ListSessions() {
+		total += sum.TotalTokens
+	}
+	if total != 43 {
+		t.Errorf("session TotalTokens = %d, want 43 (31 prompt + 12 completion) — this is abctl's TOKENS column", total)
+	}
+}
+
+// lastInferenceResponse returns the inference extension from the most recent
+// outbound SessionResponse event that carries one, or nil.
+func lastInferenceResponse(t *testing.T, store *session.Store) *pipeline.InferenceExtension {
+	t.Helper()
+	var found *pipeline.InferenceExtension
+	for _, s := range store.ListSessions() {
+		v := store.View(s.ID)
+		if v == nil {
+			continue
+		}
+		for i := range v.Events {
+			e := v.Events[i]
+			if e.Direction == pipeline.Outbound && e.Phase == pipeline.SessionResponse && e.Inference != nil {
+				found = e.Inference
+			}
+		}
+	}
+	return found
+}
+
+func truncate(b []byte) string {
+	const max = 200
+	if len(b) > max {
+		return string(b[:max]) + "..."
+	}
+	return string(b)
+}

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/httpx"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/bodyread"
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/sseframe"
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
@@ -30,7 +31,26 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
-const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes
+// maxBodySize is TWO ceilings, not one: the buffered request/response body cap,
+// and the per-frame cap passed to sseframe.NewReader on both streaming paths
+// (see handleStreamingResponse and streamFallbackBuffered). Raising it moves
+// both, so worst-case resident bytes for one in-flight request are roughly
+// 2x this value — a body buffer plus a frame scratch buffer — and the practical
+// ceiling for a listener is that times the number of concurrent requests.
+//
+// An earlier value of 1 << 20 (1MB) matched Envoy's default
+// per_stream_buffer_limit_bytes, but proved too small for LLM traffic: a
+// Claude Code session against the Anthropic endpoint produced a 5,250,133-byte
+// request, since an agent resends the whole conversation plus its full tool
+// manifest on every turn. A body over the cap is rejected before the pipeline
+// runs, so the limit also decides whether telemetry is recorded at all.
+//
+// The frame cap is the more generous half of the raise: a single SSE event is
+// far smaller than a full request body, so 10MB per frame is well above
+// anything observed. Splitting the two into separate constants would let the
+// frame cap stay tight, and is worth doing if per-request memory ever matters
+// more than the simplicity of one number.
+const maxBodySize = 10 << 20 // 10 MB
 
 // streamReadIdleTimeout caps how long the proxy waits for the next
 // byte off a streaming response body. The time.Duration is applied
@@ -276,8 +296,9 @@ func (s *Server) serveOutbound(w http.ResponseWriter, r *http.Request, isBridge 
 		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			slog.Warn("forward-proxy: request body too large or unreadable", "host", r.Host, "error", err)
-			http.Error(w, `{"error":"request body too large"}`, http.StatusRequestEntityTooLarge)
+			bodyread.LogError("forward-proxy", r, len(body), maxBodySize, err)
+			status, msg := bodyread.Rejection(err)
+			http.Error(w, msg, status)
 			return
 		}
 		r.Body = io.NopCloser(bytes.NewReader(body))
@@ -393,6 +414,34 @@ func (s *Server) serveOutbound(w http.ResponseWriter, r *http.Request, isBridge 
 	r.Header.Del("Trailer")
 	r.Header.Del("Transfer-Encoding")
 	r.Header.Del("Upgrade")
+
+	// Strip the client's Accept-Encoding so Go's transport negotiates content
+	// coding on its own behalf.
+	//
+	// net/http auto-decompresses a gzip response ONLY when the transport added
+	// Accept-Encoding itself. Forwarding the caller's header suppresses that:
+	// resp.Body then yields raw compressed bytes. Every body-reading plugin
+	// sees binary — the SSE re-framer finds no "data:" lines and reports a
+	// clean EOF on its first ReadFrame, so a gzipped text/event-stream relayed
+	// zero frames downstream and finalized aggregating plugins on empty state.
+	// The symptom is silent in both directions: the client sees a stream that
+	// opens and dies, and token telemetry reads as absent rather than wrong.
+	//
+	// This proxy re-frames and inspects bodies, so it cannot be encoding-blind.
+	// Taking ownership of the negotiation means the transport hands us
+	// plaintext and strips Content-Encoding from resp.Header, keeping the
+	// bytes we relay consistent with the headers we forward.
+	//
+	// Gated on a plugin actually inspecting the response body, mirroring the
+	// reverse proxy (see listener/reverseproxy: same reasoning, same
+	// condition). When nothing reads the body this listener is a pure
+	// pass-through, so leaving the client's header intact avoids forcing an
+	// upstream→client decompression that buys nothing — which matters for a
+	// remote backend or a large non-streamed body, and is harmless either way
+	// on a loopback sidecar hop.
+	if !skipped && (s.OutboundPipeline.NeedsResponseBody() || s.OutboundPipeline.HasStreamingResponders()) {
+		r.Header.Del("Accept-Encoding")
+	}
 
 	// Clear RequestURI — set by the server but must be empty for client requests
 	r.RequestURI = ""

--- a/authbridge/authlib/listener/internal/bodyread/bodyread.go
+++ b/authbridge/authlib/listener/internal/bodyread/bodyread.go
@@ -1,0 +1,56 @@
+// Package bodyread reports why buffering a request body failed.
+//
+// It exists because a single "request body too large or unreadable" warning
+// collapsed two failure classes with different remedies — raise the limit, or
+// look at the client — and named neither the true body size nor the cause. It
+// also answered every failure with 413, telling an agent to shrink a body when
+// the real problem was a dropped connection.
+package bodyread
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+)
+
+// LogError logs a failed body-buffering attempt. listener names the caller
+// ("forward-proxy") so the message matches the surrounding lines.
+//
+// contentLength is the only value that says how large an over-limit body
+// actually was: MaxBytesReader stops at the limit, so read is capped there and
+// the rest is never seen. It is omitted when the client sent no Content-Length
+// (chunked), where the true size is unknowable here.
+func LogError(listener string, r *http.Request, read int, limit int64, err error) {
+	attrs := []any{
+		"host", r.Host,
+		"method", r.Method,
+		"path", r.URL.Path,
+		"error", err,
+		"read", read,
+		"limit", limit,
+	}
+	if r.ContentLength >= 0 {
+		attrs = append(attrs, "contentLength", r.ContentLength)
+	}
+
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		slog.Warn(listener+": request body exceeds size limit", attrs...)
+		return
+	}
+	// Everything else — client disconnect, truncated upload, transport error —
+	// is one class: the body never arrived. The error and the byte count say
+	// which, and no further split changes what an operator does about it.
+	slog.Warn(listener+": request body unreadable", attrs...)
+}
+
+// Rejection maps a body-read failure to the downstream status and JSON body.
+// Only a genuine overrun is a 413; anything else is a 400, so a disconnect is
+// not reported to the agent as an oversized payload.
+func Rejection(err error) (int, string) {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return http.StatusRequestEntityTooLarge, `{"error":"request body too large"}`
+	}
+	return http.StatusBadRequest, `{"error":"request body unreadable"}`
+}

--- a/authbridge/authlib/listener/internal/bodyread/bodyread_test.go
+++ b/authbridge/authlib/listener/internal/bodyread/bodyread_test.go
@@ -1,0 +1,55 @@
+package bodyread
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// An over-limit body must be reported as such, and answered with 413 so the
+// caller learns the remedy is a smaller body (or a larger limit).
+func TestOverLimit(t *testing.T) {
+	err := &http.MaxBytesError{Limit: 1 << 20}
+	status, body := Rejection(err)
+	if status != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", status)
+	}
+	if body == "" {
+		t.Error("empty rejection body")
+	}
+}
+
+// A wrapped MaxBytesError must still be recognized: net/http returns it
+// wrapped in some paths, and a missed unwrap silently downgrades a real
+// overrun to a generic 400.
+func TestOverLimitWrapped(t *testing.T) {
+	err := errors.Join(errors.New("read tcp: connection reset"),
+		&http.MaxBytesError{Limit: 1 << 20})
+	if status, _ := Rejection(err); status != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d for a wrapped MaxBytesError, want 413", status)
+	}
+}
+
+// Anything that is not an overrun must be a 400, not a 413. Reporting a
+// dropped connection as an oversized payload sends the agent chasing the
+// wrong remedy — the reason this package exists.
+func TestNonOverLimitIsNot413(t *testing.T) {
+	for _, err := range []error{
+		errors.New("unexpected EOF"),
+		errors.New("context canceled"),
+	} {
+		if status, _ := Rejection(err); status != http.StatusBadRequest {
+			t.Errorf("status = %d for %v, want 400", status, err)
+		}
+	}
+}
+
+// LogError must not panic on the shapes it sees in production: a chunked
+// upload (ContentLength -1, so the field is omitted) and a nil-bodied request.
+func TestLogErrorHandlesChunkedAndEmpty(t *testing.T) {
+	r := httptest.NewRequest("POST", "/v1/messages", nil)
+	r.ContentLength = -1
+	LogError("forward-proxy", r, 0, 1<<20, &http.MaxBytesError{Limit: 1 << 20})
+	LogError("forward-proxy", r, 17, 1<<20, errors.New("connection reset"))
+}

--- a/authbridge/authlib/listener/internal/sseframe/reader.go
+++ b/authbridge/authlib/listener/internal/sseframe/reader.go
@@ -68,10 +68,13 @@ func NewReader(r io.Reader, maxSize int) *Reader {
 	}
 }
 
-// DefaultMaxFrameSize bounds a single SSE event's data payload at
-// 1 MiB — same as the buffered-path cap so the streaming path
-// preserves the per-message memory ceiling without bounding the
-// total stream length.
+// DefaultMaxFrameSize bounds a single SSE event's data payload at 1 MiB when
+// NewReader is given a non-positive maxSize. It is a defensive fallback only:
+// every caller in this repo passes an explicit cap, and those caps no longer
+// agree with each other or with this value — the forward proxy passes 10MB and
+// the reverse proxy 1MB, each from its own listener's maxBodySize. So this
+// constant no longer describes the per-message ceiling any real stream runs
+// under; read the calling listener's maxBodySize for that.
 const DefaultMaxFrameSize = 1 << 20
 
 // ReadFrame reads from the underlying reader until a complete SSE

--- a/authbridge/authlib/listener/reverseproxy/server.go
+++ b/authbridge/authlib/listener/reverseproxy/server.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/httpx"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/bodyread"
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/sseframe"
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/internal/tlssniff"
 	"github.com/rossoctl/cortex/authbridge/authlib/listener/transparentproxy"
@@ -27,6 +28,18 @@ import (
 	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
 )
 
+// maxBodySize bounds a buffered request or response body, and the per-frame cap
+// on the SSE reader.
+//
+// Left at Envoy's default per_stream_buffer_limit_bytes while the forward proxy
+// runs at 10MB: the bodies that forced that raise were outbound agent-to-LLM
+// requests, which do not traverse this listener in the deployments observed so
+// far. The same growth applies in principle on the inbound path — an agent
+// receiving a large request, or an in-cluster LLM route through a sidecar — so
+// raise this to match if an oversized-body rejection is ever observed here.
+// The two are deliberately independent: the inbound and outbound size profiles
+// differ, and a shared constant would tie one listener's ceiling to the other's
+// traffic. See the forward proxy's maxBodySize for the measurement behind 10MB.
 const maxBodySize = 1 << 20 // 1MB — matches Envoy's default per_stream_buffer_limit_bytes
 
 type pctxKey struct{}
@@ -336,8 +349,9 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			slog.Warn("reverse-proxy: request body too large or unreadable", "host", r.Host, "error", err)
-			http.Error(w, `{"error":"request body too large"}`, http.StatusRequestEntityTooLarge)
+			bodyread.LogError("reverse-proxy", r, len(body), maxBodySize, err)
+			status, msg := bodyread.Rejection(err)
+			http.Error(w, msg, status)
 			return
 		}
 		r.Body = io.NopCloser(bytes.NewReader(body))

--- a/authbridge/authlib/plugins/inferenceparser/anthropic.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic.go
@@ -3,6 +3,7 @@ package inferenceparser
 import (
 	"bytes"
 	"encoding/json"
+	"log/slog"
 	"strings"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
@@ -229,6 +230,17 @@ type anthropicStreamEvent struct {
 	} `json:"delta"`
 	Usage *anthropicUsage `json:"usage"`
 
+	// Error carries the payload of an "error" stream event (overloaded_error,
+	// api_error, and friends). Anthropic can abort a stream mid-flight with
+	// this instead of the usual message_delta/message_stop pair, in which case
+	// no usage ever arrives — so it is the single most informative event when
+	// token telemetry comes back empty, and worth surfacing rather than
+	// silently ignoring.
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+
 	// Index identifies which content block an event belongs to. A response
 	// may contain several blocks (text plus one or more tool calls), and
 	// their deltas are only distinguishable by this index.
@@ -297,7 +309,26 @@ func (s *inferenceStreamState) closeAnthropicTool() {
 func foldAnthropicFrame(frame []byte, state *inferenceStreamState, ext *pipeline.InferenceExtension) {
 	var ev anthropicStreamEvent
 	if err := json.Unmarshal(frame, &ev); err != nil {
+		// A malformed frame drops whatever usage it carried, so a stream can
+		// finish with accumulated completion text and no token counts at all —
+		// logInferenceFinalized then prints every split counter as -1 with
+		// nothing to explain it. Previously a bare return, which made that
+		// outcome undiagnosable. Debug, not Warn: a truncated final frame on a
+		// cancelled turn is routine. Log the length, never the bytes — frames
+		// carry prompt and completion content.
+		slog.Debug("inference-parser: malformed Anthropic streaming frame, skipping",
+			"error", err, "frameLen", len(frame))
 		return
+	}
+	if !knownAnthropicEvents[ev.Type] {
+		// The frame parses, so nothing errors, but the switch below ignores it
+		// and any usage it carried is lost. That means the wire format has moved
+		// ahead of this parser — the one failure mode that silently zeroes token
+		// telemetry while completion text still accumulates. ev.Type is a wire
+		// value, so it goes only to the log, which already carries bodies at
+		// Debug level.
+		slog.Debug("inference-parser: unrecognized Anthropic stream event type — token counts may be incomplete",
+			"type", ev.Type)
 	}
 	switch ev.Type {
 	case "message_start":
@@ -325,6 +356,18 @@ func foldAnthropicFrame(frame []byte, state *inferenceStreamState, ext *pipeline
 		}
 	case "content_block_stop":
 		state.closeAnthropicTool()
+	case "error":
+		// An upstream abort. Not a parse failure, so it must not be reported as
+		// an unrecognized type, and not silently dropped either: it explains an
+		// otherwise inexplicable stream that carried no usage. Warn, unlike the
+		// Debug drops above — the upstream failed the request. The error type
+		// and message are provider-generated diagnostics, not user content.
+		if ev.Error != nil {
+			slog.Warn("inference-parser: Anthropic stream returned an error event — token counts will be incomplete",
+				"errorType", ev.Error.Type, "message", ev.Error.Message)
+		} else {
+			slog.Warn("inference-parser: Anthropic stream returned an error event with no detail — token counts will be incomplete")
+		}
 	case "message_delta":
 		if ev.Delta != nil && ev.Delta.StopReason != "" {
 			ext.FinishReason = ev.Delta.StopReason

--- a/authbridge/authlib/plugins/inferenceparser/events.go
+++ b/authbridge/authlib/plugins/inferenceparser/events.go
@@ -1,0 +1,36 @@
+package inferenceparser
+
+// knownAnthropicEvents is the set of Anthropic stream event types
+// foldAnthropicFrame handles, including the ones it deliberately ignores
+// (ping, message_stop). A type outside this set means the wire format has moved
+// ahead of the parser: the frame still parses, so nothing errors, but any usage
+// it carried is dropped while completion text keeps accumulating — token
+// telemetry then reads as absent rather than wrong. foldAnthropicFrame logs
+// such a type at Debug so that outcome is diagnosable.
+//
+// Kept beside the switch it mirrors. TestKnownAnthropicEvents_MatchesSwitch
+// parses foldAnthropicFrame's cases out of the source and asserts the two agree
+// in BOTH directions, so a case added to the switch without a map entry — or a
+// map entry with no case — fails rather than silently going unlogged.
+//
+// intentionallyIgnored names the types that are deliberately absent from the
+// switch: they are valid, expected, and carry nothing the parser needs. They
+// belong in the map (so they log nothing) but have no case, and the test needs
+// to tell them apart from an accidental omission.
+var knownAnthropicEvents = map[string]bool{
+	"message_start":       true,
+	"content_block_start": true,
+	"content_block_delta": true,
+	"content_block_stop":  true,
+	"message_delta":       true,
+	"message_stop":        true,
+	"ping":                true,
+	"error":               true,
+}
+
+// intentionallyIgnored are known event types with no case in
+// foldAnthropicFrame: nothing in them affects the running completion or usage.
+var intentionallyIgnored = map[string]bool{
+	"message_stop": true, // terminator; finalize is driven by the listener's last=true
+	"ping":         true, // keepalive
+}

--- a/authbridge/authlib/plugins/inferenceparser/events_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/events_test.go
@@ -1,0 +1,109 @@
+package inferenceparser
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// switchCaseTypes extracts the string literals from the case clauses of
+// foldAnthropicFrame's `switch ev.Type` in anthropic.go.
+//
+// Parsed from source rather than hand-listed on purpose: a hardcoded list only
+// catches drift when the author edits the list, which is the same edit that
+// would have fixed the map — so it catches nothing. Reading the switch itself
+// means adding a case with no map entry fails here without anyone remembering
+// to update a test.
+func switchCaseTypes(t *testing.T) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "anthropic.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse anthropic.go: %v", err)
+	}
+
+	got := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "foldAnthropicFrame" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			sw, ok := n.(*ast.SwitchStmt)
+			if !ok {
+				return true
+			}
+			// Only the switch on ev.Type; the function also switches on
+			// ev.Delta.Type for the delta kinds.
+			sel, ok := sw.Tag.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Type" {
+				return true
+			}
+			if ident, ok := sel.X.(*ast.Ident); !ok || ident.Name != "ev" {
+				return true
+			}
+			for _, stmt := range sw.Body.List {
+				cc, ok := stmt.(*ast.CaseClause)
+				if !ok {
+					continue
+				}
+				for _, expr := range cc.List {
+					lit, ok := expr.(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					got[lit.Value[1:len(lit.Value)-1]] = true // strip quotes
+				}
+			}
+			return false
+		})
+		return false
+	})
+
+	if len(got) == 0 {
+		t.Fatal("found no case clauses on foldAnthropicFrame's switch ev.Type — test is not looking where it thinks")
+	}
+	return got
+}
+
+// Every event type the switch handles must be in knownAnthropicEvents, or a
+// healthy stream logs a spurious "unrecognized event type" line for an event
+// the parser demonstrably understands.
+func TestKnownAnthropicEvents_CoversSwitchCases(t *testing.T) {
+	for typ := range switchCaseTypes(t) {
+		if !knownAnthropicEvents[typ] {
+			t.Errorf("foldAnthropicFrame handles %q but knownAnthropicEvents omits it — a handled event would log as unrecognized", typ)
+		}
+	}
+}
+
+// The reverse direction, which a one-way check misses: every map entry must
+// either have a case in the switch or be named in intentionallyIgnored. Without
+// this, a type can sit in the map with no case and be silently dropped —
+// suppressed from the very Debug log meant to make that loss visible.
+func TestKnownAnthropicEvents_NoUnhandledEntries(t *testing.T) {
+	cases := switchCaseTypes(t)
+	for typ := range knownAnthropicEvents {
+		if cases[typ] || intentionallyIgnored[typ] {
+			continue
+		}
+		t.Errorf("knownAnthropicEvents has %q with no case in foldAnthropicFrame and no entry in intentionallyIgnored — "+
+			"it would be silently dropped AND suppressed from the unrecognized-type log", typ)
+	}
+}
+
+// intentionallyIgnored must name only types that really have no case: an entry
+// that also appears in the switch means the two have drifted and the exemption
+// is now hiding a real handler.
+func TestIntentionallyIgnored_HasNoSwitchCase(t *testing.T) {
+	cases := switchCaseTypes(t)
+	for typ := range intentionallyIgnored {
+		if cases[typ] {
+			t.Errorf("%q is listed as intentionally ignored but foldAnthropicFrame has a case for it", typ)
+		}
+		if !knownAnthropicEvents[typ] {
+			t.Errorf("%q is intentionally ignored but missing from knownAnthropicEvents, so it logs as unrecognized", typ)
+		}
+	}
+}


### PR DESCRIPTION
Token counts were missing for streaming inference calls whose responses arrive gzipped (e.g. Claude Code against `api.anthropic.com` directly). A gateway that does not compress its SSE — such as a local LiteLLM — was unaffected, which made this look like a streaming limitation rather than a compression one.

## Cause

The forward proxy forwarded the client's `Accept-Encoding` verbatim. `net/http` decompresses transparently only for an `Accept-Encoding` its transport set itself, so `resp.Body` yielded raw compressed bytes. The SSE re-framer found no `data:` lines and returned `io.EOF` on its first `ReadFrame`.

Both resulting failures were silent: zero frames relayed downstream (the client reported "Streaming response ended before any complete data was received"), and `inference-parser` finalized on empty state, so token counts read as absent rather than wrong.

## Fix

Strip `Accept-Encoding` when a plugin will inspect the response body, mirroring the condition and rationale already present in the reverse proxy. A pure pass-through pipeline keeps end-to-end compression.

## Also included

- `maxBodySize` raised to 10MB. At 1MB, real requests were rejected (>5MB observed), and a rejected request never reaches the pipeline at all — so this also presented as missing telemetry.
- Body-read failures are reported by cause, in a shared `listener/internal/bodyread`. An over-limit body logs the client-declared size — the only place the true size appears, since the reader stops at the limit — and answers 413; anything else answers 400, so a dropped connection is no longer reported to the agent as an oversized payload. Shared rather than per-listener, since both proxies buffer bodies identically.
- The two silent frame drops in the Anthropic fold path now log at Debug: a frame that does not unmarshal, and an event type the switch does not handle. Both zero token telemetry while completion text still accumulates, and neither previously left any trace. `knownAnthropicEvents` mirrors the switch, with a test guarding the two against drift.

## Testing

`gzip_sse_test.go` drives a gzipped `text/event-stream` upstream through the real `inference-parser` and asserts the relayed body is plaintext SSE, `Content-Encoding` is absent, tokens parse (31 prompt / 12 completion / `end_turn`), and the session summary's `TotalTokens` is 43 — the value `abctl` renders in its TOKENS column.

Verified as a regression guard: reverting the one-line fix fails with *"proxy relayed zero bytes downstream — the client sees a stream that opens and dies"*. Full `authlib` suite passes.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Forward proxy now correctly processes gzip-compressed server-sent events while exposing plaintext streams and extracting usage details.
  - Request-body failures now return more accurate responses: 413 for oversized requests and 400 for unreadable requests.
  - Forward-proxy buffering and streaming limits increased to 10 MB.
  - Anthropic streaming errors are recognized and reported with clearer diagnostics.
- **Documentation**
  - Clarified request and event-size limits for proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->