### PR TITLE
Fix: install.sh rejects every release, and stop running main on people's laptops

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ decrypted and parsed live. No Kubernetes. macOS or Linux, amd64 or arm64.
      | sh -s -- --claude-code
    ```
 
-   The URL is on `main`, but the script immediately re-runs the copy from the
-   newest **release** — so a `curl | sh` never executes an unreleased change.
-   Add `--ref=main` to opt into main anyway, or `--ref=vX.Y.Z` to pin.
+   The URL is on `main`, but the script re-runs the copy from the newest
+   **release** when one carries it, so a `curl | sh` normally does not execute
+   unreleased changes. Add `--ref=main` to opt into main, or `--ref=vX.Y.Z` to pin.
 
 2. **Open the viewer** in another terminal:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ decrypted and parsed live. No Kubernetes. macOS or Linux, amd64 or arm64.
      | sh -s -- --claude-code
    ```
 
+   The URL is on `main`, but the script immediately re-runs the copy from the
+   newest **release** — so a `curl | sh` never executes an unreleased change.
+   Add `--ref=main` to opt into main anyway, or `--ref=vX.Y.Z` to pin.
+
 2. **Open the viewer** in another terminal:
 
    ```sh

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -276,7 +276,12 @@ info "Verifying checksums..."
 # checksums.txt can't make verification fail on a file we never fetched.
 : > "${tmp}/checksums.filtered"
 for archive in "${abctl_tgz}" "${proxy_tgz}"; do
-	grep -E "[[:space:]]\*?${archive}\$" "${tmp}/checksums.txt" >> "${tmp}/checksums.filtered" \
+	# The name may be preceded by whitespace, sha256sum's binary-mode "*", or a
+	# path component: the release workflow runs `sha256sum ./*.tar.gz`, so every
+	# real line reads "HASH  ./abctl_....tar.gz". An earlier version of this
+	# pattern required the name immediately after whitespace or "*", which matched
+	# nothing against an actual release and refused every install.
+	grep -E "(^|[[:space:]*/])${archive}\$" "${tmp}/checksums.txt" >> "${tmp}/checksums.filtered" \
 		|| die "checksums.txt has no entry for ${archive} — refusing to install it unverified"
 done
 # Both entries present, and exactly the two we asked for.

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -36,8 +36,15 @@
 # curl, not sh, so the script runs without it. `sh -s -- --flag` has no such
 # failure mode. The env vars below still work.
 #
+# By default this script re-runs the copy from the newest RELEASE rather than
+# executing whatever is currently on main — main is unstable by definition, and a
+# `curl | sh` should not be the first thing to run a change nobody has released.
+# --ref=main opts back in; --ref=vX.Y.Z pins.
+#
 # Environment:
-#   AUTHBRIDGE_VERSION=vX.Y.Z   install a specific release tag (default: newest)
+#   AUTHBRIDGE_REF=REF          same as --ref
+#   AUTHBRIDGE_VERSION=vX.Y.Z   install binaries from a specific release
+#                               (default: the release this script came from)
 #   AUTHBRIDGE_INSTALL_ONLY=1   same as --install-only
 #   AUTHBRIDGE_SKIP_DOWNLOAD=1  use the already-installed binaries in ~/.local/bin
 #                               instead of downloading (re-run setup offline)
@@ -77,6 +84,10 @@ Options:
   --claude-code    after starting, offer to configure Claude Code to use it, so
                    it runs as plain `claude` with no environment variables
   --local          the default, spelled out
+  --ref=REF        take THIS SCRIPT from a git ref instead of the newest release
+                   (e.g. --ref=main for unreleased changes, --ref=v0.7.0-alpha.4
+                   to pin). Binaries come from the same release unless
+                   AUTHBRIDGE_VERSION says otherwise.
   -h, --help       this text
 
 Environment:
@@ -97,6 +108,7 @@ for arg in "$@"; do
 	case "$arg" in
 		--install-only) MODE=install-only ;;
 		--claude-code) WIRE_CLAUDE_CODE=1 ;;
+		--ref=*) AUTHBRIDGE_REF="${arg#*=}" ;;
 		# --local is the default; accepted so writing it out explicitly works, and
 		# so it mirrors the proxy flag of the same name.
 		--local) MODE=local ;;
@@ -104,7 +116,7 @@ for arg in "$@"; do
 			usage
 			exit 0
 			;;
-		*) die "unknown option: $arg (try --claude-code, --install-only, --local, or no argument)" ;;
+		*) die "unknown option: $arg (try --claude-code, --install-only, --local, --ref=REF, or no argument)" ;;
 	esac
 done
 # Env form kept working; the flag wins if both are given.
@@ -114,6 +126,70 @@ fi
 
 command -v curl >/dev/null 2>&1 || die "curl is required"
 command -v tar  >/dev/null 2>&1 || die "tar is required"
+
+# newest_release prints the newest release tag, prereleases included.
+# `releases/latest` excludes prereleases and this project ships them, so list
+# releases (newest first) and take the first tag_name.
+newest_release() {
+	curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null \
+		| grep -m1 '"tag_name"' | sed -e 's/.*"tag_name": *"//' -e 's/".*//'
+}
+
+# --- run the released copy of this script, not the one from main ---
+#
+# The documented command fetches this file from main, which is whatever landed
+# last: an unreviewed or half-finished change there runs on someone's laptop
+# immediately. Releases are tested, so by default this bootstrap re-runs the copy
+# from the newest release and hands it the same arguments.
+#
+# SCRIPT_REF names the ref this copy came from and doubles as the recursion guard:
+# the child sees it set and does not bootstrap again.
+SCRIPT_REF="${AUTHBRIDGE_SCRIPT_REF:-}"
+if [ -z "${SCRIPT_REF}" ]; then
+	want_ref="${AUTHBRIDGE_REF:-}"
+	if [ -z "${want_ref}" ]; then
+		want_ref="$(newest_release)" || true
+	fi
+	if [ -z "${want_ref}" ]; then
+		warn "could not resolve the newest release; continuing with the copy from main"
+		SCRIPT_REF="main"
+	elif [ "${want_ref}" = "main" ]; then
+		# Explicitly asked for main: this copy already is main.
+		SCRIPT_REF="main"
+	else
+		# Rebuild the argument list without --ref: it is meta, consumed here, and a
+		# released script from before --ref existed rejects it as an unknown option.
+		# Rotating the positional parameters keeps arguments with spaces intact,
+		# which building a string would not.
+		argc=$#
+		argi=0
+		while [ "${argi}" -lt "${argc}" ]; do
+			a="$1"
+			shift
+			argi=$((argi + 1))
+			case "$a" in
+				--ref=*) ;;
+				*) set -- "$@" "$a" ;;
+			esac
+		done
+
+		boot=$(mktemp)
+		url="https://raw.githubusercontent.com/${REPO}/${want_ref}/authbridge/install.sh"
+		if curl -fsSL "${url}" -o "${boot}" 2>/dev/null && [ -s "${boot}" ]; then
+			info "Using the installer from ${want_ref}."
+			AUTHBRIDGE_SCRIPT_REF="${want_ref}" sh "${boot}" "$@"
+			status=$?
+			rm -f "${boot}"
+			exit "${status}"
+		fi
+		rm -f "${boot}"
+		# A release from before this script existed under that name, or a network
+		# blip. Falling back is better than refusing to install, but say which
+		# copy is running so a surprise is attributable.
+		warn "${want_ref} has no authbridge/install.sh; continuing with the copy from main"
+		SCRIPT_REF="main"
+	fi
+fi
 
 # Verify the checklist file passed as $1 (run from the directory holding the
 # files). shasum is preferred: it's always present on macOS and its -c reads the
@@ -241,14 +317,18 @@ if [ "${AUTHBRIDGE_SKIP_DOWNLOAD:-}" = "1" ]; then
 else
 
 # --- resolve the release tag ---
-# `releases/latest` excludes prereleases, and the project ships prereleases, so
-# list releases (newest first) and take the first tag_name instead.
 version="${AUTHBRIDGE_VERSION:-}"
 if [ -z "$version" ]; then
-	info "Resolving newest release..."
-	version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" \
-		| grep -m1 '"tag_name"' | sed -e 's/.*"tag_name": *"//' -e 's/".*//')
-	[ -n "$version" ] || die "could not resolve the newest release (set AUTHBRIDGE_VERSION=vX.Y.Z)"
+	# Default the binaries to the same release this script came from, so the
+	# script and the binaries it installs are one tested set rather than two
+	# independently-moving things.
+	case "${SCRIPT_REF}" in
+		v*) version="${SCRIPT_REF}" ;;
+		*)
+			info "Resolving newest release..."
+			version=$(newest_release) || die "could not resolve the newest release (set AUTHBRIDGE_VERSION=vX.Y.Z)"
+			;;
+	esac
 fi
 info "Release: $version"
 

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -131,8 +131,24 @@ command -v tar  >/dev/null 2>&1 || die "tar is required"
 # `releases/latest` excludes prereleases and this project ships them, so list
 # releases (newest first) and take the first tag_name.
 newest_release() {
-	curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null \
-		| grep -m1 '"tag_name"' | sed -e 's/.*"tag_name": *"//' -e 's/".*//'
+	# Returns non-zero on empty. The pipeline ends in sed, which exits 0 for empty
+	# input, so `version=$(newest_release) || die` could never fire on a
+	# rate-limited or offline API — the caller got an empty tag and failed later
+	# with an unactionable "download failed: abctl__darwin_arm64.tar.gz".
+	_tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null \
+		| grep -m1 '"tag_name"' | sed -e 's/.*"tag_name": *"//' -e 's/".*//')
+	[ -n "${_tag}" ] || return 1
+	printf '%s\n' "${_tag}"
+}
+
+# ere_escape quotes the ERE metacharacters in a literal so it matches exactly.
+# Archive names contain dots, and an unescaped "." matches any character: the
+# pattern for abctl_v0.7.0-alpha.3_..tar.gz also accepted
+# abctl_v0X7X0-alpha_3_..Xtar.gz. Nothing exploitable followed — the count check
+# or sha_check rejected it — but this script's whole subject is precision here.
+ere_escape() {
+	# shellcheck disable=SC2016 # the sed script is literal on purpose
+	printf '%s' "$1" | sed 's/[].[^$()*+?{}|\\]/\\&/g'
 }
 
 # --- run the released copy of this script, not the one from main ---
@@ -175,19 +191,42 @@ if [ -z "${SCRIPT_REF}" ]; then
 
 		boot=$(mktemp)
 		url="https://raw.githubusercontent.com/${REPO}/${want_ref}/authbridge/install.sh"
-		if curl -fsSL "${url}" -o "${boot}" 2>/dev/null && [ -s "${boot}" ]; then
+		# Capture the status code rather than collapsing every failure into one
+		# branch. A 404 means that ref genuinely predates this script — fall back.
+		# A transport error means we could not ask, and silently dropping to main
+		# there would break the exact guarantee this bootstrap exists to give.
+		# On a transport failure curl still prints "000" via -w AND exits non-zero,
+		# so appending our own default produced "HTTP 000000". Overwrite instead.
+		http=$(curl -sSL -o "${boot}" -w '%{http_code}' "${url}" 2>/dev/null) || http="000"
+		[ -n "${http}" ] || http="000"
+		if [ "${http}" = "200" ] && [ -s "${boot}" ]; then
 			info "Using the installer from ${want_ref}."
-			AUTHBRIDGE_SCRIPT_REF="${want_ref}" sh "${boot}" "$@"
-			status=$?
+			# set -e would abort the parent on a non-zero child before any of the
+			# lines below ran, leaking the downloaded script on every failed
+			# install. The if/else keeps the status and still cleans up.
+			if AUTHBRIDGE_SCRIPT_REF="${want_ref}" sh "${boot}" "$@"; then
+				status=0
+			else
+				status=$?
+			fi
 			rm -f "${boot}"
 			exit "${status}"
 		fi
 		rm -f "${boot}"
-		# A release from before this script existed under that name, or a network
-		# blip. Falling back is better than refusing to install, but say which
-		# copy is running so a surprise is attributable.
-		warn "${want_ref} has no authbridge/install.sh; continuing with the copy from main"
-		SCRIPT_REF="main"
+		if [ "${http}" = "404" ]; then
+			# A release from before this script existed under that name. Falling
+			# back beats refusing to install, but name the copy that is running so
+			# a surprise is attributable.
+			warn "${want_ref} has no authbridge/install.sh (HTTP 404); continuing with the copy from main"
+			SCRIPT_REF="main"
+		else
+			# Blocked, offline, rate-limited, proxied, 5xx. We cannot tell whether a
+			# released installer exists, so do not quietly run main instead.
+			die "could not fetch the installer for ${want_ref} (HTTP ${http}) from ${url}.
+  Check the network, or choose explicitly:
+    --ref=main       run the copy from main (unreleased changes)
+    --ref=vX.Y.Z     use a specific release"
+		fi
 	fi
 fi
 
@@ -361,7 +400,8 @@ for archive in "${abctl_tgz}" "${proxy_tgz}"; do
 	# real line reads "HASH  ./abctl_....tar.gz". An earlier version of this
 	# pattern required the name immediately after whitespace or "*", which matched
 	# nothing against an actual release and refused every install.
-	grep -E "(^|[[:space:]*/])${archive}\$" "${tmp}/checksums.txt" >> "${tmp}/checksums.filtered" \
+	archive_re=$(ere_escape "${archive}")
+	grep -E "(^|[[:space:]*/])${archive_re}\$" "${tmp}/checksums.txt" >> "${tmp}/checksums.filtered" \
 		|| die "checksums.txt has no entry for ${archive} — refusing to install it unverified"
 done
 # Both entries present, and exactly the two we asked for.

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -400,9 +400,19 @@ for archive in "${abctl_tgz}" "${proxy_tgz}"; do
 	# real line reads "HASH  ./abctl_....tar.gz". An earlier version of this
 	# pattern required the name immediately after whitespace or "*", which matched
 	# nothing against an actual release and refused every install.
+	# Anchored to the whole line and to the exact shape our own workflow emits:
+	# "HASH  ./name" (from `cd dist && sha256sum ./*.tar.gz`), with a bare name and
+	# binary-mode "*" also accepted.
+	#
+	# Deliberately NOT any path. sha_check runs from ${tmp}, so a permissive class
+	# let a crafted entry like "HASH  ../name" or "HASH  /etc/name" match and be
+	# verified against a file outside the download directory — passing verification
+	# for something other than the archive we then extract. Only ./ and a bare name
+	# are ours, so nothing else is accepted.
 	archive_re=$(ere_escape "${archive}")
-	grep -E "(^|[[:space:]*/])${archive_re}\$" "${tmp}/checksums.txt" >> "${tmp}/checksums.filtered" \
-		|| die "checksums.txt has no entry for ${archive} — refusing to install it unverified"
+	grep -E "^[0-9a-fA-F]+[[:space:]]+\*?(\./)?${archive_re}\$" "${tmp}/checksums.txt" \
+		>> "${tmp}/checksums.filtered" \
+		|| die "checksums.txt has no usable entry for ${archive} — refusing to install it unverified"
 done
 # Both entries present, and exactly the two we asked for.
 lines=$(wc -l < "${tmp}/checksums.filtered" | tr -d '[:space:]')


### PR DESCRIPTION
Two commits: a broken installer, and the reason a broken installer reached users
at all.

## 1. `install.sh` refuses every install

```
$ curl -fsSL .../authbridge/install.sh | sh -s -- --claude-code
Resolving newest release...
Release: v0.7.0-alpha.3
Downloading binaries for darwin/arm64...
Verifying checksums...
error: checksums.txt has no entry for abctl_v0.7.0-alpha.3_darwin_arm64.tar.gz
       — refusing to install it unverified
```

The entry **is** there. `release-binaries.yaml` generates checksums with
`sha256sum ./*.tar.gz`, so every line reads:

```
8d657b2f…  ./abctl_v0.7.0-alpha.3_darwin_arm64.tar.gz
```

My pattern from #855 (`79f2f575`) was `[[:space:]]\*?${archive}$` — the name must
follow whitespace or a binary-mode `*` immediately. The `./` means nothing matches.

That commit fixed a genuine fail-**open** (an alternation `grep -E "(a|b)$"`
succeeds on one of two archives, so a partial `checksums.txt` installed the other
unverified). Replacing it with a per-archive grep was right; tightening the anchor
at the same time was not. Fail-closed is the safer direction, but it still blocks
everyone — and the first version was only ever run against fixtures I wrote from
the same wrong assumption about the format, never against a real `checksums.txt`.

Fix: `(^|[[:space:]*/])${archive}$`. Tested against the **real published**
`checksums.txt` for `v0.7.0-alpha.3` plus six constructed cases:

| case | result |
|---|---|
| real alpha.3 (`./` prefix) | both match |
| no prefix | both match |
| binary mode (`*name`) | both match |
| nested path (`dist/name`) | both match |
| partial coverage (one missing) | **still caught** — the fail-open this exists for |
| decoy, name mid-line | rejected |
| suffix impostor `xyzabctl_….tar.gz` | rejected |

End to end, the failing command now succeeds:

```
./abctl_v0.7.0-alpha.3_darwin_arm64.tar.gz: OK
./authbridge-proxy_v0.7.0-alpha.3_darwin_arm64.tar.gz: OK
Installed abctl and authbridge-proxy (v0.7.0-alpha.3)
```

## 2. Don't run `main` in the first place

The bug above shipped to a user the moment it merged, because the documented
command fetches `install.sh` from `main` and runs it. `main` is whatever landed
last. A `curl | sh` should not be the first thing to execute an unreleased change.

The script now re-runs the copy from the **newest release**, passing the same
arguments. Releases are tested; `main` is not.

```sh
# default — the installer from the newest release
curl -fsSL .../authbridge/install.sh | sh -s -- --claude-code

# escape hatches
... | sh -s -- --ref=main            # unreleased changes
... | sh -s -- --ref=v0.7.0-alpha.4  # pin
```

`AUTHBRIDGE_REF` is the env equivalent. When the script came from a release tag the
binaries default to that same tag, so the script and the binaries it installs are
one tested set. `AUTHBRIDGE_VERSION` still overrides.

Details that needed a test:

- **`--ref` is stripped before re-exec.** A released script from before `--ref`
  existed rejects it — which is what happened on my first run.
- **Arguments are rebuilt by rotating positional parameters**, not string-building,
  so an argument containing a space survives.
- **`AUTHBRIDGE_SCRIPT_REF` is both the ref name and the recursion guard.**
  Verified the bootstrap fires exactly once.
- **Fallback when the ref has no `authbridge/install.sh`**: warn, continue with the
  current copy. Live path today — `v0.7.0-alpha.3` predates the rename from
  `install-demo.sh`, so its tree 404s. Becomes fully effective at the next tag.

Tested: the default, `--ref=main`, `--ref=<sha>` against a ref that does have the
script, `AUTHBRIDGE_REF`, the recursion guard, argument propagation, version
pinning, and `--help` through the documented pipe.

The SHA test is the one worth naming: the parent had commit 1's fix and the child
did not, and the child failed on the checksum bug — direct evidence the re-exec
runs the pinned copy's code, not the parent's.

## Ordering

Merge, then cut the next tag. From then on the default resolves to a release whose
tree carries this installer, and `main` leaves the path entirely.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
