### PR TITLE
Fix: explain a script/binary version mismatch instead of dying on an unknown flag

### DIFF
--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -440,6 +440,34 @@ rm -rf "$tmp"
 trap - EXIT
 fi # end of download block
 
+# --- refuse to drive binaries older than this script ---
+#
+# The script and the binaries can come from different releases: when the resolved
+# release has no authbridge/install.sh the bootstrap falls back to the copy from
+# main, but the BINARIES still come from that older release. A newer script then
+# passes flags and subcommands the older binaries never had, and the run dies
+# deep in startup with "flag provided but not defined: -local" — which reads like
+# a bug in Cortex rather than a version mismatch.
+#
+# Probing the flag beats comparing version strings: the flags are the actual
+# contract, and a probe needs no updating when the scheme changes. `--local`
+# arrived in the same change as abctl's `claude-code` and `tools scan`
+# subcommands, so it stands in for all of them.
+if ! "${BIN_DIR}/authbridge-proxy" --help 2>&1 | grep -q -- '-local'; then
+	# Deliberately not suggesting --ref=${version}: a release old enough to fail
+	# this probe is old enough that its tree has no authbridge/install.sh either,
+	# so the bootstrap would 404, fall back to main, and land right back here.
+	die "the ${version} binaries are older than this installer.
+  They have no --local (it was --demo then), and their abctl has no claude-code
+  or tools subcommands, so this script cannot drive them — and no installer can
+  give you --claude-code from ${version}, because the feature is not in it.
+  Either:
+    wait for a release newer than ${version}, or set
+    AUTHBRIDGE_VERSION=<newer tag> to install newer binaries with this script;
+  or run that release's own installer, which matches its binaries:
+    curl -fsSL https://raw.githubusercontent.com/${REPO}/${version}/authbridge/install-demo.sh | sh"
+fi
+
 # --- report ---
 proxy="${BIN_DIR}/authbridge-proxy"
 ca_dir="${CORTEX_DIR}/ca" # matches defaultCortexDir()+caDirName in local.go


### PR DESCRIPTION
## Reported from a real run

```
warning: v0.7.0-alpha.3 has no authbridge/install.sh (HTTP 404);
         continuing with the copy from main
...
warning: Cortex exited during startup — last log lines:
flag provided but not defined: -local
```

## What's happening

#871's bootstrap stops us running an unreleased **script**. The fallback path
reintroduces the mismatch from the other side: when the resolved release has no
installer, the script comes from `main` while the **binaries** still come from that
older release. A newer script then passes flags an older binary never had, and the
run dies deep in startup with a message that reads like a bug in Cortex.

It is not one flag. `v0.7.0-alpha.3`'s `abctl` has **no subcommand dispatch at
all**, so `claude-code` and `tools scan` are absent too:

```
$ alpha3/authbridge-proxy --help | grep '^  -'
  -ca-dir string
  -config string
  -demo            <- not --local
  -version

$ alpha3/abctl claude-code
abctl: could not open a new TTY…      <- fell through to the TUI; no subcommands
```

So that script cannot drive those binaries at all, and **no installer can give
`--claude-code` from alpha.3** — the feature isn't in it.

## The change

Probe for `--local` before using the binaries, and stop with an explanation:

```
error: the v0.7.0-alpha.3 binaries are older than this installer.
  They have no --local (it was --demo then), and their abctl has no claude-code
  or tools subcommands, so this script cannot drive them — and no installer can
  give you --claude-code from v0.7.0-alpha.3, because the feature is not in it.
  Either:
    wait for a release newer than v0.7.0-alpha.3, or set
    AUTHBRIDGE_VERSION=<newer tag> to install newer binaries with this script;
  or run that release's own installer, which matches its binaries:
    curl -fsSL .../v0.7.0-alpha.3/authbridge/install-demo.sh | sh
```

Probing the flag beats comparing version strings: the flags are the actual
contract, and a probe needs no updating when the scheme changes. `--local` arrived
in the same change as abctl's subcommands, so it stands in for all of them.

## One thing I got wrong first

My initial message suggested `--ref=${version}`. That is **circular** — a release
old enough to fail the probe has no `authbridge/install.sh` either, so the
bootstrap 404s, falls back to `main`, and lands back on the same error. Verified,
then removed. The message now names only the two things that work, and I confirmed
the old-installer command installs.

## Scope

This makes the failure legible. The actual fix is a release whose binaries match
the installer — i.e. the next tag. Until then this guard is the difference between
an explanation and `flag provided but not defined`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
