### PR TITLE
Feat: Keep Cortex running across crashes and logins (launchd / systemd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/ins
 ```
 
 That is the install. It asks before changing your Claude Code settings, then runs
-Cortex as a background service that restarts itself and comes back at login.
+Cortex as a background service that comes back at login and restarts itself if it
+crashes.
+
+> **macOS note:** launchd defers agents added mid-session, so automatic
+> restart-after-crash may not take effect until your next login. Starting at login
+> works from now on. `abctl service start` restarts it by hand in the meantime.
 
 Now open two terminals:
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ That is the install. It asks before changing your Claude Code settings, then run
 Cortex as a background service that comes back at login and restarts itself if it
 crashes.
 
-> **macOS note:** launchd defers agents added mid-session, so automatic
-> restart-after-crash may not take effect until your next login. Starting at login
-> works from now on. `abctl service start` restarts it by hand in the meantime.
+> **macOS note:** launchd will not restart a user agent added mid-session, so on
+> macOS the proxy runs under a small supervisor process that does. Verify with
+> `kill -9 $(pgrep -f 'authbridge-proxy --config')` — it comes back within ~2s.
 
 Now open two terminals:
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Claude Code's calls stream into `abctl`. Cortex only reads them; nothing is rewr
 4–20% of the prompt per turn, median 6%:
 **[one more command](./authbridge/docs/laptop-token-savings.md)**.
 
-**Turning it off** — `abctl service stop` pauses it, `abctl claude-code disable`
-unwires Claude Code, and
-**[removing it](./authbridge/docs/laptop-uninstall.md)** is four lines.
+**Starting, stopping, removing** — `abctl service status | start | stop`, and
+`abctl claude-code disable` to unwire Claude Code:
+**[the full lifecycle](./authbridge/docs/laptop-service.md)**.
 
 Any agent works, not just Claude Code — point it at `localhost:47600` and trust
 `~/.cortex/ca/ca.crt`. The URL is on `main`, but the script re-runs the copy from the

--- a/README.md
+++ b/README.md
@@ -15,40 +15,34 @@ It ships as a single binary; the identity and access layer is **AuthBridge**, an
 See what Claude Code sends: model calls, tool calls, and agent-to-agent traffic,
 decrypted and parsed live. No Kubernetes. macOS or Linux, amd64 or arm64.
 
-1. **Install, and point Claude Code at it** (asks first, changes nothing else):
+```sh
+curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
+  | sh -s -- --claude-code
+```
 
-   ```sh
-   curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
-     | sh -s -- --claude-code
-   ```
+That is the install. It asks before changing your Claude Code settings, then runs
+Cortex as a background service that restarts itself and comes back at login.
 
-   The URL is on `main`, but the script re-runs the copy from the newest
-   **release** when one carries it, so a `curl | sh` normally does not execute
-   unreleased changes. Add `--ref=main` to opt into main, or `--ref=vX.Y.Z` to pin.
+Now open two terminals:
 
-2. **Open the viewer** in another terminal:
+```sh
+abctl      # the viewer
+claude     # Claude Code, as usual — no environment variables needed
+```
 
-   ```sh
-   abctl
-   ```
+Claude Code's calls stream into `abctl`. Cortex only reads them; nothing is rewritten.
 
-3. **Run Claude Code:**
-
-   ```sh
-   claude
-   ```
-
-Its calls stream into `abctl`. Cortex only reads them — nothing is rewritten.
-
-Stop it with `pkill -f authbridge-proxy`. Undo step 1 with
-`abctl claude-code disable`.
-
-**Cut token cost too:** Cortex can strip the tool definitions your agent never
-calls, worth **4–20% of the prompt per turn, median 6%** —
+**Cut token cost too** — strip the tool definitions your agent never calls, worth
+4–20% of the prompt per turn, median 6%:
 **[one more command](./authbridge/docs/laptop-token-savings.md)**.
 
-Any agent works, not just Claude Code — point it at the proxy on
-`localhost:47600` and trust `~/.cortex/ca/ca.crt`.
+**Turning it off** — `abctl service stop` pauses it, `abctl claude-code disable`
+unwires Claude Code, and
+**[removing it](./authbridge/docs/laptop-uninstall.md)** is four lines.
+
+Any agent works, not just Claude Code — point it at `localhost:47600` and trust
+`~/.cortex/ca/ca.crt`. The URL is on `main`, but the script re-runs the copy from the
+newest **release**, so `curl | sh` does not run unreleased code — `--ref` overrides.
 
 ## Running on Kubernetes
 

--- a/authbridge/authlib/config/config.go
+++ b/authbridge/authlib/config/config.go
@@ -437,6 +437,25 @@ type ListenerConfig struct {
 	// loopback on another port; leaving it empty keeps the preset default.
 	HealthAddr string `yaml:"health_addr" json:"health_addr"`
 
+	// BindLoopbackOnly rewrites EVERY listener address in this config (and the
+	// stats address) to 127.0.0.1, keeping each port. Off by default, which
+	// preserves Kubernetes behaviour exactly.
+	//
+	// Why a flag and not the default: in a pod, a wildcard bind is correct and
+	// necessary — the network namespace is the boundary, and kubelet probes health
+	// from outside the container's loopback, so forcing 127.0.0.1 there would fail
+	// every liveness probe. On a laptop there is no namespace, and the same default
+	// publishes the listener on Wi-Fi.
+	//
+	// Why a flag and not a per-listener pin: pinning each address protects only the
+	// listeners someone remembered to name. A config written before a pin existed
+	// never receives it (writeBuiltinConfig never overwrites, so hand edits
+	// survive), and a listener added later starts wide with nothing to catch it.
+	// This was not hypothetical: a laptop config predating the health and
+	// transparent pins was serving *:9091 and *:8082 on every interface. One rule
+	// covers listeners that do not exist yet.
+	BindLoopbackOnly bool `yaml:"bind_loopback_only" json:"bind_loopback_only"`
+
 	// SkipHosts lists outbound destination host patterns whose traffic
 	// bypasses the plugin pipeline AND session recording entirely. The
 	// listener forwards matched requests as a transparent proxy without

--- a/authbridge/authlib/config/loopback_bind_test.go
+++ b/authbridge/authlib/config/loopback_bind_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func loadFrom(t *testing.T, body string) *Config {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "c.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Mirror the binaries: main.go calls Load and then ApplyPreset. Testing Load
+	// alone hides ordering bugs — the first version of this rule sat in Load, ran
+	// before the wildcard defaults existed, and protected nothing.
+	ApplyPreset(cfg)
+	return cfg
+}
+
+// TestBindLoopbackOnly_CoversListenersNobodyPinned is the whole point: the two
+// addresses a laptop config forgot were serving on every interface. The flag has to
+// protect the ones nobody named, including any added later.
+func TestBindLoopbackOnly_CoversListenersNobodyPinned(t *testing.T) {
+	cfg := loadFrom(t, `mode: proxy-sidecar
+listener:
+  roles: [forward]
+  bind_loopback_only: true
+  forward_proxy_addr: 127.0.0.1:47600
+  session_api_addr: 127.0.0.1:47601
+`)
+	// health and transparent were never named; the preset gave them :9091 / :8082.
+	for name, got := range map[string]string{
+		"health_addr":            cfg.Listener.HealthAddr,
+		"transparent_proxy_addr": cfg.Listener.TransparentProxyAddr,
+		"stats address":          cfg.Stats.StatsAddress,
+	} {
+		if got == "" {
+			continue // not defaulted in this mode; nothing to protect
+		}
+		if !strings.HasPrefix(got, "127.0.0.1:") {
+			t.Errorf("%s = %q, want a 127.0.0.1 bind — this is the *:9091 bug", name, got)
+		}
+	}
+	// Ports must survive: this rewrites the host, it does not renumber anything.
+	if cfg.Listener.HealthAddr != "127.0.0.1:9091" {
+		t.Errorf("health_addr = %q, want the preset port kept", cfg.Listener.HealthAddr)
+	}
+	// And an address the operator DID pin is untouched.
+	if cfg.Listener.ForwardProxyAddr != "127.0.0.1:47600" {
+		t.Errorf("forward_proxy_addr = %q", cfg.Listener.ForwardProxyAddr)
+	}
+}
+
+// TestBindLoopbackOnly_OffByDefault: Kubernetes must keep wildcard binds. Forcing
+// health to loopback would fail every kubelet liveness probe.
+func TestBindLoopbackOnly_OffByDefault(t *testing.T) {
+	cfg := loadFrom(t, "mode: proxy-sidecar\nlistener:\n  roles: [forward]\n")
+	if cfg.Listener.BindLoopbackOnly {
+		t.Fatal("bind_loopback_only defaulted to true; that would break kubelet probes")
+	}
+	if cfg.Listener.HealthAddr != ":9091" {
+		t.Errorf("health_addr = %q, want the wildcard preset untouched", cfg.Listener.HealthAddr)
+	}
+}
+
+// TestBindLoopbackOnly_RewritesExplicitWildcards: someone may write 0.0.0.0 or
+// [::] by hand. The flag has to win over that too, or it is advisory.
+func TestBindLoopbackOnly_RewritesExplicitWildcards(t *testing.T) {
+	cfg := loadFrom(t, `mode: proxy-sidecar
+listener:
+  roles: [forward]
+  bind_loopback_only: true
+  forward_proxy_addr: 0.0.0.0:47600
+  session_api_addr: "[::]:47601"
+  health_addr: ":47604"
+`)
+	for name, got := range map[string]string{
+		"forward": cfg.Listener.ForwardProxyAddr,
+		"session": cfg.Listener.SessionAPIAddr,
+		"health":  cfg.Listener.HealthAddr,
+	} {
+		if !strings.HasPrefix(got, "127.0.0.1:") {
+			t.Errorf("%s = %q, want 127.0.0.1", name, got)
+		}
+	}
+	if cfg.Listener.SessionAPIAddr != "127.0.0.1:47601" {
+		t.Errorf("IPv6 wildcard mishandled: %q", cfg.Listener.SessionAPIAddr)
+	}
+}
+
+// TestBindLoopbackOnly_LeavesEmptyAddressesEmpty: an address that is genuinely
+// unset must not become a live 127.0.0.1 listener. (Note: an explicit
+// session_api_addr: "" does NOT stay empty — setDefault treats "" as unset and the
+// preset refills it. That is pre-existing, documented behaviour, not this rule.)
+func TestBindLoopbackOnly_LeavesEmptyAddressesEmpty(t *testing.T) {
+	cfg := loadFrom(t, `mode: proxy-sidecar
+listener:
+  roles: [forward]
+  bind_loopback_only: true
+`)
+	// ext_proc is only defaulted for envoy-sidecar, so in this mode it stays unset.
+	if cfg.Listener.ExtProcAddr != "" {
+		t.Errorf("ext_proc_addr = %q, want it to stay unset rather than become a listener",
+			cfg.Listener.ExtProcAddr)
+	}
+}
+
+// TestForceLocalhost_EmptyStaysEmpty pins the primitive directly, since the rule
+// above leans on it for every address.
+func TestForceLocalhost_EmptyStaysEmpty(t *testing.T) {
+	if got := forceLocalhost(""); got != "" {
+		t.Errorf("forceLocalhost(\"\") = %q, want empty", got)
+	}
+}

--- a/authbridge/authlib/config/presets.go
+++ b/authbridge/authlib/config/presets.go
@@ -48,6 +48,27 @@ func ApplyPreset(cfg *Config) {
 	// Health server is default-on for every mode; ":9091" is what the operator's
 	// probe config and the container images expect.
 	setDefault(&cfg.Listener.HealthAddr, ":9091")
+
+	// LAST, so it wins over every default set above. This must live in ApplyPreset
+	// and not in Load: the binaries call Load first and ApplyPreset second, so a
+	// rule placed in Load runs BEFORE the wildcard defaults exist and silently
+	// protects nothing — which is precisely the health_addr / transparent_proxy_addr
+	// case it is here to fix.
+	if cfg.Listener.BindLoopbackOnly {
+		for _, addr := range []*string{
+			&cfg.Listener.ExtProcAddr,
+			&cfg.Listener.ExtAuthzAddr,
+			&cfg.Listener.ForwardProxyAddr,
+			&cfg.Listener.ReverseProxyAddr,
+			&cfg.Listener.TransparentInboundAddr,
+			&cfg.Listener.TransparentProxyAddr,
+			&cfg.Listener.SessionAPIAddr,
+			&cfg.Listener.HealthAddr,
+			&cfg.Stats.StatsAddress,
+		} {
+			*addr = forceLocalhost(*addr)
+		}
+	}
 }
 
 func setDefault(field *string, value string) {

--- a/authbridge/cmd/abctl/cluster/e2e_test.go
+++ b/authbridge/cmd/abctl/cluster/e2e_test.go
@@ -13,7 +13,7 @@ import (
 // TestE2ESmoke runs against the active kubectl context. Set up by
 // running the IBAC demo (make demo-ibac) before invoking:
 //
-//   go test -tags=e2e ./cluster/ -run TestE2ESmoke -v
+//	go test -tags=e2e ./cluster/ -run TestE2ESmoke -v
 //
 // The test fails clearly if no AuthBridge agent is found.
 func TestE2ESmoke(t *testing.T) {

--- a/authbridge/cmd/abctl/cmd_config_migrate.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate.go
@@ -23,12 +23,27 @@ type pinnedListener struct {
 	key     string
 	value   string
 	comment string
+	// isFlag marks a boolean key, checked against the parsed config differently
+	// from an address.
+	isFlag bool
 	// unpinnedDefault is what the preset fills in when the key is absent, and
 	// what makes the omission worth fixing rather than tidy.
 	unpinnedDefault string
 }
 
 var listenerPins = []pinnedListener{
+	{
+		// The durable half of this migration. The two address pins below fix the two
+		// listeners that were known to be wildcard; this covers every other listener
+		// in the config, and any added later, without a further migration.
+		key:   "bind_loopback_only",
+		value: "true",
+		comment: "Added by abctl: bind every listener to 127.0.0.1, including any not named\n" +
+			"here. Without it a listener falls back to a preset default that binds every\n" +
+			"interface — on a laptop, the Wi-Fi.",
+		isFlag:          true,
+		unpinnedDefault: "wildcard binds for anything unpinned",
+	},
 	{
 		key:             "health_addr",
 		value:           "127.0.0.1:47604",
@@ -60,6 +75,10 @@ func migrateConfig(path string, stdout io.Writer) (changed bool, err error) {
 	missing := make([]pinnedListener, 0, len(listenerPins))
 	for _, pin := range listenerPins {
 		switch pin.key {
+		case "bind_loopback_only":
+			if !cfg.Listener.BindLoopbackOnly {
+				missing = append(missing, pin)
+			}
 		case "health_addr":
 			if cfg.Listener.HealthAddr == "" {
 				missing = append(missing, pin)
@@ -103,6 +122,10 @@ func migrateConfig(path string, stdout io.Writer) (changed bool, err error) {
 
 	fmt.Fprintf(stdout, "Updated %s (previous kept as %s):\n", path, bak)
 	for _, pin := range missing {
+		if pin.isFlag {
+			fmt.Fprintf(stdout, "  + %s: %s   (was: %s)\n", pin.key, pin.value, pin.unpinnedDefault)
+			continue
+		}
 		fmt.Fprintf(stdout, "  + %s: %s   (was defaulting to %s — every interface)\n",
 			pin.key, pin.value, pin.unpinnedDefault)
 	}

--- a/authbridge/cmd/abctl/cmd_config_migrate.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate.go
@@ -23,9 +23,13 @@ type pinnedListener struct {
 	key     string
 	value   string
 	comment string
-	// isFlag marks a boolean key, checked against the parsed config differently
-	// from an address.
+	// isFlag marks a boolean key, reported differently from an address.
 	isFlag bool
+	// absent reports whether this pin is missing from a parsed config. It lives on
+	// the pin, not in a switch elsewhere, because a switch is a second list that has
+	// to stay in sync with this one — and a pin added without its case would compile,
+	// run, and silently migrate nothing.
+	absent func(*config.Config) bool
 	// unpinnedDefault is what the preset fills in when the key is absent, and
 	// what makes the omission worth fixing rather than tidy.
 	unpinnedDefault string
@@ -43,19 +47,22 @@ var listenerPins = []pinnedListener{
 			"interface — on a laptop, the Wi-Fi.",
 		isFlag:          true,
 		unpinnedDefault: "wildcard binds for anything unpinned",
+		absent:          func(c *config.Config) bool { return !c.Listener.BindLoopbackOnly },
 	},
 	{
 		key:             "health_addr",
 		value:           "127.0.0.1:47604",
 		comment:         "Added by abctl: unpinned, the preset binds health on :9091 — every interface.",
 		unpinnedDefault: ":9091",
+		absent:          func(c *config.Config) bool { return c.Listener.HealthAddr == "" },
 	},
 	{
 		key:   "transparent_proxy_addr",
 		value: "127.0.0.1:47603",
 		comment: "Added by abctl: unpinned, the preset binds :8082 on every interface. --local skips\n" +
-			"    this listener but --config does not, and the service runs with --config.",
+			"this listener but --config does not, and the service runs with --config.",
 		unpinnedDefault: ":8082",
+		absent:          func(c *config.Config) bool { return c.Listener.TransparentProxyAddr == "" },
 	},
 }
 
@@ -74,19 +81,11 @@ func migrateConfig(path string, stdout io.Writer) (changed bool, err error) {
 	}
 	missing := make([]pinnedListener, 0, len(listenerPins))
 	for _, pin := range listenerPins {
-		switch pin.key {
-		case "bind_loopback_only":
-			if !cfg.Listener.BindLoopbackOnly {
-				missing = append(missing, pin)
-			}
-		case "health_addr":
-			if cfg.Listener.HealthAddr == "" {
-				missing = append(missing, pin)
-			}
-		case "transparent_proxy_addr":
-			if cfg.Listener.TransparentProxyAddr == "" {
-				missing = append(missing, pin)
-			}
+		if pin.absent == nil {
+			return false, fmt.Errorf("pin %q has no absent predicate; this is a bug", pin.key)
+		}
+		if pin.absent(cfg) {
+			missing = append(missing, pin)
 		}
 	}
 	if len(missing) == 0 {

--- a/authbridge/cmd/abctl/cmd_config_migrate.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"gopkg.in/yaml.v3"
 )
 
 // A config written by an older build keeps its own shape forever:
@@ -25,11 +26,6 @@ type pinnedListener struct {
 	comment string
 	// isFlag marks a boolean key, reported differently from an address.
 	isFlag bool
-	// absent reports whether this pin is missing from a parsed config. It lives on
-	// the pin, not in a switch elsewhere, because a switch is a second list that has
-	// to stay in sync with this one — and a pin added without its case would compile,
-	// run, and silently migrate nothing.
-	absent func(*config.Config) bool
 	// unpinnedDefault is what the preset fills in when the key is absent, and
 	// what makes the omission worth fixing rather than tidy.
 	unpinnedDefault string
@@ -47,14 +43,12 @@ var listenerPins = []pinnedListener{
 			"interface — on a laptop, the Wi-Fi.",
 		isFlag:          true,
 		unpinnedDefault: "wildcard binds for anything unpinned",
-		absent:          func(c *config.Config) bool { return !c.Listener.BindLoopbackOnly },
 	},
 	{
 		key:             "health_addr",
 		value:           "127.0.0.1:47604",
 		comment:         "Added by abctl: unpinned, the preset binds health on :9091 — every interface.",
 		unpinnedDefault: ":9091",
-		absent:          func(c *config.Config) bool { return c.Listener.HealthAddr == "" },
 	},
 	{
 		key:   "transparent_proxy_addr",
@@ -62,7 +56,6 @@ var listenerPins = []pinnedListener{
 		comment: "Added by abctl: unpinned, the preset binds :8082 on every interface. --local skips\n" +
 			"this listener but --config does not, and the service runs with --config.",
 		unpinnedDefault: ":8082",
-		absent:          func(c *config.Config) bool { return c.Listener.TransparentProxyAddr == "" },
 	},
 }
 
@@ -75,16 +68,24 @@ func migrateConfig(path string, stdout io.Writer) (changed bool, err error) {
 	}
 	// Decide what is missing from the PARSED config, not from a text search: a key
 	// could appear in a comment, and a commented-out key is still absent.
-	cfg, err := config.Load(path)
-	if err != nil {
+	// Parsed only to establish the config is valid before editing it; the keys
+	// themselves come from listenerKeys below.
+	if _, err := config.Load(path); err != nil {
 		return false, fmt.Errorf("%s does not parse (%w); not touching it", path, err)
+	}
+	// Presence is decided against the DOCUMENT, not the parsed value. An explicit
+	// `health_addr: ""` or `bind_loopback_only: false` is present but parses as the
+	// zero value, so a value-based check appended a second copy of the key — and
+	// config.Load then rejected the duplicate, failing the migration on a config that
+	// was perfectly valid. Reading the keys also removes the need for a per-pin
+	// predicate, so there is no second list to keep in sync.
+	present, perr := listenerKeys(raw)
+	if perr != nil {
+		return false, perr
 	}
 	missing := make([]pinnedListener, 0, len(listenerPins))
 	for _, pin := range listenerPins {
-		if pin.absent == nil {
-			return false, fmt.Errorf("pin %q has no absent predicate; this is a bug", pin.key)
-		}
-		if pin.absent(cfg) {
+		if _, ok := present[pin.key]; !ok {
 			missing = append(missing, pin)
 		}
 	}
@@ -171,7 +172,16 @@ func insertListenerKeys(src string, pins []pinnedListener) (string, error) {
 		}
 	}
 	if childIndent < 0 {
-		// An empty listener block: indent one level in from the parent.
+		// No child lines at all. If the block is flow-style (`listener: {}` or
+		// `listener: {roles: [forward]}`) then appending block-style children beneath it
+		// is invalid YAML. That fails closed — the validation before the rename catches
+		// it and the original survives — but the user would see a bare parse error
+		// instead of being told the shape is unsupported.
+		if rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[listenerAt]), "listener:")); rest != "" {
+			return "", fmt.Errorf("listener: is written in flow style (%s); "+
+				"rewrite it as an indented block, or add the keys by hand", rest)
+		}
+		// A genuinely empty block: indent one level in from the parent.
 		childIndent = parentIndent + 2
 	}
 	// Insert after the last non-blank line of the block so trailing blank lines
@@ -195,4 +205,28 @@ func insertListenerKeys(src string, pins []pinnedListener) (string, error) {
 	out = append(out, add...)
 	out = append(out, lines[insertAt:]...)
 	return strings.Join(out, "\n"), nil
+}
+
+// listenerKeys returns the keys explicitly written under `listener:`.
+//
+// Generic YAML rather than the typed config, because the typed struct cannot
+// distinguish "absent" from "present and set to the zero value".
+func listenerKeys(raw []byte) (map[string]struct{}, error) {
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("reading the config's keys: %w", err)
+	}
+	out := map[string]struct{}{}
+	l, ok := doc["listener"]
+	if !ok {
+		return out, nil
+	}
+	m, ok := l.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("listener: is not a mapping; not editing this config")
+	}
+	for k := range m {
+		out[k] = struct{}{}
+	}
+	return out, nil
 }

--- a/authbridge/cmd/abctl/cmd_config_migrate.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+)
+
+// A config written by an older build keeps its own shape forever:
+// writeBuiltinConfig deliberately never overwrites an existing file, so that a
+// hand-edited prune list survives a restart. The cost is that fixes to the
+// built-in config never reach anyone who already has one — a config from before
+// the health/transparent pins leaves those listeners on the preset defaults,
+// which bind EVERY interface. On a laptop on an untrusted network that is a
+// listener nobody asked for.
+//
+// So the pins are added to configs that lack them: only ever ADDING keys, never
+// changing a value the user set, with the previous file kept alongside.
+type pinnedListener struct {
+	key     string
+	value   string
+	comment string
+	// unpinnedDefault is what the preset fills in when the key is absent, and
+	// what makes the omission worth fixing rather than tidy.
+	unpinnedDefault string
+}
+
+var listenerPins = []pinnedListener{
+	{
+		key:             "health_addr",
+		value:           "127.0.0.1:47604",
+		comment:         "Added by abctl: unpinned, the preset binds health on :9091 — every interface.",
+		unpinnedDefault: ":9091",
+	},
+	{
+		key:   "transparent_proxy_addr",
+		value: "127.0.0.1:47603",
+		comment: "Added by abctl: unpinned, the preset binds :8082 on every interface. --local skips\n" +
+			"    this listener but --config does not, and the service runs with --config.",
+		unpinnedDefault: ":8082",
+	},
+}
+
+// migrateConfig adds any missing listener pins. It reports what it changed and
+// whether anything did.
+func migrateConfig(path string, stdout io.Writer) (changed bool, err error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return false, err
+	}
+	// Decide what is missing from the PARSED config, not from a text search: a key
+	// could appear in a comment, and a commented-out key is still absent.
+	cfg, err := config.Load(path)
+	if err != nil {
+		return false, fmt.Errorf("%s does not parse (%w); not touching it", path, err)
+	}
+	missing := make([]pinnedListener, 0, len(listenerPins))
+	for _, pin := range listenerPins {
+		switch pin.key {
+		case "health_addr":
+			if cfg.Listener.HealthAddr == "" {
+				missing = append(missing, pin)
+			}
+		case "transparent_proxy_addr":
+			if cfg.Listener.TransparentProxyAddr == "" {
+				missing = append(missing, pin)
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return false, nil
+	}
+
+	updated, err := insertListenerKeys(string(raw), missing)
+	if err != nil {
+		return false, err
+	}
+
+	// Keep the previous file once, under a distinct name so it cannot be confused
+	// with the config itself.
+	bak := path + ".before-abctl-migrate"
+	if _, serr := os.Stat(bak); os.IsNotExist(serr) {
+		if werr := os.WriteFile(bak, raw, 0o600); werr != nil {
+			return false, fmt.Errorf("writing %s: %w", bak, werr)
+		}
+	}
+	tmp := path + ".tmp"
+	if werr := os.WriteFile(tmp, []byte(updated), 0o600); werr != nil {
+		return false, werr
+	}
+	// Validate the result before it replaces anything: a migration that produces
+	// an unparseable config would take the proxy down on next start.
+	if _, verr := config.Load(tmp); verr != nil {
+		_ = os.Remove(tmp)
+		return false, fmt.Errorf("the migrated config would not parse (%w); left %s alone", verr, path)
+	}
+	if rerr := os.Rename(tmp, path); rerr != nil {
+		return false, rerr
+	}
+
+	fmt.Fprintf(stdout, "Updated %s (previous kept as %s):\n", path, bak)
+	for _, pin := range missing {
+		fmt.Fprintf(stdout, "  + %s: %s   (was defaulting to %s — every interface)\n",
+			pin.key, pin.value, pin.unpinnedDefault)
+	}
+	return true, nil
+}
+
+// insertListenerKeys adds keys to the listener block, matching whatever
+// indentation the file already uses.
+//
+// Indentation is read from the file rather than assumed: a real config turned up
+// with the whole document indented two spaces, which is valid YAML and would have
+// produced a broken file from any hardcoded guess.
+func insertListenerKeys(src string, pins []pinnedListener) (string, error) {
+	lines := strings.Split(src, "\n")
+
+	listenerAt := -1
+	for i, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "listener:") && !strings.HasPrefix(strings.TrimSpace(l), "#") {
+			listenerAt = i
+			break
+		}
+	}
+	if listenerAt < 0 {
+		return "", fmt.Errorf("no listener: block found")
+	}
+	parentIndent := len(lines[listenerAt]) - len(strings.TrimLeft(lines[listenerAt], " "))
+
+	// The block ends at the first later line whose indentation is <= the parent's
+	// and which is not blank. Child indentation comes from the first child seen.
+	childIndent := -1
+	end := len(lines)
+	for i := listenerAt + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		indent := len(lines[i]) - len(strings.TrimLeft(lines[i], " "))
+		if indent <= parentIndent {
+			end = i
+			break
+		}
+		if childIndent < 0 {
+			childIndent = indent
+		}
+	}
+	if childIndent < 0 {
+		// An empty listener block: indent one level in from the parent.
+		childIndent = parentIndent + 2
+	}
+	// Insert after the last non-blank line of the block so trailing blank lines
+	// stay where the author put them.
+	insertAt := end
+	for insertAt > listenerAt+1 && strings.TrimSpace(lines[insertAt-1]) == "" {
+		insertAt--
+	}
+
+	pad := strings.Repeat(" ", childIndent)
+	add := make([]string, 0, len(pins)*3)
+	for _, pin := range pins {
+		for _, cl := range strings.Split(pin.comment, "\n") {
+			add = append(add, pad+"# "+strings.TrimSpace(cl))
+		}
+		add = append(add, pad+pin.key+": "+pin.value)
+	}
+
+	out := make([]string, 0, len(lines)+len(add))
+	out = append(out, lines[:insertAt]...)
+	out = append(out, add...)
+	out = append(out, lines[insertAt:]...)
+	return strings.Join(out, "\n"), nil
+}

--- a/authbridge/cmd/abctl/cmd_config_migrate_test.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+)
+
+// oldStyleConfig is shaped like a config written before the pins existed.
+const oldStyleConfig = `mode: proxy-sidecar
+listener:
+  roles: [forward]
+  forward_proxy_addr: 127.0.0.1:47600
+  session_api_addr: 127.0.0.1:47601
+stats:
+  address: 127.0.0.1:47602
+tls_bridge:
+  mode: enabled
+  ca_dir: "CADIR"
+  generate_ca: true
+pipeline:
+  outbound:
+    plugins:
+      - name: inference-parser
+      - name: tool-prune
+        config:
+          remove: [CronCreate, WebSearch]
+`
+
+// indentedConfig is a REAL shape found on a machine: the whole document indented
+// two spaces. Valid YAML, and fatal to any migration that hardcodes indentation.
+const indentedConfig = `  mode: proxy-sidecar
+  listener:
+    roles: [forward]
+    forward_proxy_addr: 127.0.0.1:47600
+    session_api_addr: 127.0.0.1:47601
+  stats:
+    address: 127.0.0.1:47602
+  tls_bridge:
+    mode: enabled
+    ca_dir: "CADIR"
+    generate_ca: true
+  pipeline:
+    outbound:
+      plugins:
+        - name: inference-parser
+`
+
+func writeCfg(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(p, []byte(strings.Replace(body, "CADIR", filepath.Join(dir, "ca"), 1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestMigrateConfig_AddsThePins is the point: an old config leaves health and the
+// transparent listener on preset defaults that bind EVERY interface.
+func TestMigrateConfig_AddsThePins(t *testing.T) {
+	p := writeCfg(t, oldStyleConfig)
+
+	before, err := config.Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Listener.HealthAddr != "" || before.Listener.TransparentProxyAddr != "" {
+		t.Fatal("fixture already has the pins")
+	}
+
+	var out bytes.Buffer
+	changed, err := migrateConfig(p, &out)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !changed {
+		t.Fatal("reported no change")
+	}
+
+	after, err := config.Load(p)
+	if err != nil {
+		t.Fatalf("migrated config does not parse: %v", err)
+	}
+	if after.Listener.HealthAddr != "127.0.0.1:47604" {
+		t.Errorf("health_addr = %q", after.Listener.HealthAddr)
+	}
+	if after.Listener.TransparentProxyAddr != "127.0.0.1:47603" {
+		t.Errorf("transparent_proxy_addr = %q", after.Listener.TransparentProxyAddr)
+	}
+	// Untouched: everything the user had.
+	if after.Listener.ForwardProxyAddr != before.Listener.ForwardProxyAddr {
+		t.Error("forward_proxy_addr changed")
+	}
+	if after.Stats.StatsAddress != before.Stats.StatsAddress {
+		t.Error("stats address changed")
+	}
+	if !strings.Contains(readFile(t, p), "remove: [CronCreate, WebSearch]") {
+		t.Error("the prune list was lost")
+	}
+	if _, serr := os.Stat(p + ".before-abctl-migrate"); serr != nil {
+		t.Errorf("no backup kept: %v", serr)
+	}
+}
+
+// TestMigrateConfig_HandlesAnIndentedDocument covers the real-world shape that
+// would break a hardcoded indent.
+func TestMigrateConfig_HandlesAnIndentedDocument(t *testing.T) {
+	p := writeCfg(t, indentedConfig)
+	var out bytes.Buffer
+	if _, err := migrateConfig(p, &out); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatalf("migrated config does not parse: %v\n%s", err, readFile(t, p))
+	}
+	if cfg.Listener.HealthAddr != "127.0.0.1:47604" {
+		t.Errorf("health_addr = %q\n%s", cfg.Listener.HealthAddr, readFile(t, p))
+	}
+	// The inserted lines must match the document's own indentation, or the YAML is
+	// valid-but-wrong (a key landing in the wrong block) or invalid outright.
+	for _, line := range strings.Split(readFile(t, p), "\n") {
+		if strings.Contains(line, "health_addr:") {
+			if indent := len(line) - len(strings.TrimLeft(line, " ")); indent != 4 {
+				t.Errorf("health_addr indented %d spaces, want 4 to match the document", indent)
+			}
+		}
+	}
+}
+
+// TestMigrateConfig_Idempotent: this runs on every service install.
+func TestMigrateConfig_Idempotent(t *testing.T) {
+	p := writeCfg(t, oldStyleConfig)
+	var out bytes.Buffer
+	if changed, err := migrateConfig(p, &out); err != nil || !changed {
+		t.Fatalf("first: changed=%v err=%v", changed, err)
+	}
+	first := readFile(t, p)
+	changed, err := migrateConfig(p, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("second run changed the file again")
+	}
+	if readFile(t, p) != first {
+		t.Error("second run modified the file")
+	}
+}
+
+// TestMigrateConfig_LeavesUserValuesAlone: a value the operator chose is theirs.
+// Migration only ever ADDS.
+func TestMigrateConfig_LeavesUserValuesAlone(t *testing.T) {
+	body := strings.Replace(oldStyleConfig,
+		"  session_api_addr: 127.0.0.1:47601",
+		"  session_api_addr: 127.0.0.1:47601\n  health_addr: 127.0.0.1:59999", 1)
+	p := writeCfg(t, body)
+	var out bytes.Buffer
+	if _, err := migrateConfig(p, &out); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Listener.HealthAddr != "127.0.0.1:59999" {
+		t.Errorf("health_addr = %q, want the operator's 59999", cfg.Listener.HealthAddr)
+	}
+	if strings.Count(readFile(t, p), "health_addr:") != 1 {
+		t.Error("health_addr was duplicated")
+	}
+}
+
+// TestMigrateConfig_RefusesAnUnparseableConfig: rewriting a file we cannot read
+// would destroy settings we never understood.
+func TestMigrateConfig_RefusesAnUnparseableConfig(t *testing.T) {
+	p := writeCfg(t, "listener:\n  roles: [forward\n")
+	var out bytes.Buffer
+	if _, err := migrateConfig(p, &out); err == nil {
+		t.Fatal("accepted an unparseable config")
+	}
+	if !strings.Contains(readFile(t, p), "roles: [forward") {
+		t.Error("the unparseable file was modified")
+	}
+}
+
+// TestMigrateConfig_NoListenerBlock: nothing to migrate into, and we must not
+// invent one.
+func TestMigrateConfig_NoListenerBlock(t *testing.T) {
+	p := writeCfg(t, "mode: proxy-sidecar\nstats:\n  address: 127.0.0.1:47602\n")
+	var out bytes.Buffer
+	_, err := migrateConfig(p, &out)
+	if err == nil {
+		t.Fatal("expected an error with no listener block")
+	}
+	if !strings.Contains(err.Error(), "listener") {
+		t.Errorf("error does not name the problem: %v", err)
+	}
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/authbridge/cmd/abctl/cmd_config_migrate_test.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate_test.go
@@ -92,6 +92,10 @@ func TestMigrateConfig_AddsThePins(t *testing.T) {
 	if after.Listener.TransparentProxyAddr != "127.0.0.1:47603" {
 		t.Errorf("transparent_proxy_addr = %q", after.Listener.TransparentProxyAddr)
 	}
+	// The durable half: covers listeners this migration does not name.
+	if !after.Listener.BindLoopbackOnly {
+		t.Error("bind_loopback_only was not added; a future listener would bind wide")
+	}
 	// Untouched: everything the user had.
 	if after.Listener.ForwardProxyAddr != before.Listener.ForwardProxyAddr {
 		t.Error("forward_proxy_addr changed")
@@ -210,4 +214,57 @@ func readFile(t *testing.T, p string) string {
 		t.Fatal(err)
 	}
 	return string(b)
+}
+
+// TestMigrateConfig_FlagAloneIsEnoughToBeUpToDate: someone who set the flag by hand
+// should not be nagged, and must not have it duplicated.
+func TestMigrateConfig_FlagAlreadySet(t *testing.T) {
+	body := strings.Replace(oldStyleConfig,
+		"  roles: [forward]",
+		"  roles: [forward]\n  bind_loopback_only: true", 1)
+	p := writeCfg(t, body)
+	var out bytes.Buffer
+	if _, err := migrateConfig(p, &out); err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(readFile(t, p), "bind_loopback_only"); n != 1 {
+		t.Errorf("bind_loopback_only appears %d times, want 1", n)
+	}
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Listener.BindLoopbackOnly {
+		t.Error("the operator's flag was lost")
+	}
+}
+
+// TestMigratedConfigActuallyBindsLoopback is the end of the chain: the migration is
+// only worth anything if the running proxy binds loopback afterwards. Asserts
+// against the real Load+ApplyPreset sequence the binaries use.
+func TestMigratedConfigActuallyBindsLoopback(t *testing.T) {
+	p := writeCfg(t, oldStyleConfig)
+	var out bytes.Buffer
+	if _, err := migrateConfig(p, &out); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ApplyPreset(cfg)
+	for name, addr := range map[string]string{
+		"forward":     cfg.Listener.ForwardProxyAddr,
+		"session":     cfg.Listener.SessionAPIAddr,
+		"health":      cfg.Listener.HealthAddr,
+		"transparent": cfg.Listener.TransparentProxyAddr,
+		"stats":       cfg.Stats.StatsAddress,
+	} {
+		if addr == "" {
+			continue
+		}
+		if !strings.HasPrefix(addr, "127.0.0.1:") {
+			t.Errorf("%s binds %q after migration — still exposed", name, addr)
+		}
+	}
 }

--- a/authbridge/cmd/abctl/cmd_config_migrate_zero_test.go
+++ b/authbridge/cmd/abctl/cmd_config_migrate_zero_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An explicit zero value is PRESENT but parses as the zero value, so an
+// absence check based on the parsed value appends a duplicate key.
+func TestMigrate_ExplicitZeroValues(t *testing.T) {
+	for _, tc := range []struct{ name, line string }{
+		{"bind_loopback_only false", "  bind_loopback_only: false"},
+		{"empty health_addr", `  health_addr: ""`},
+		{"empty transparent", `  transparent_proxy_addr: ""`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "config.yaml")
+			body := "mode: proxy-sidecar\nlistener:\n  roles: [forward]\n  forward_proxy_addr: 127.0.0.1:47600\n" +
+				tc.line + "\nstats:\n  address: 127.0.0.1:47602\n"
+			if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var out bytes.Buffer
+			_, err := migrateConfig(p, &out)
+			after, _ := os.ReadFile(p)
+			key := strings.TrimSpace(strings.SplitN(tc.line, ":", 2)[0])
+			n := strings.Count(string(after), key+":")
+			t.Logf("err=%v  occurrences of %s = %d", err, key, n)
+			if n > 1 {
+				t.Errorf("DUPLICATE %s written (%d times)", key, n)
+			}
+			if err != nil {
+				t.Errorf("migration errored on a valid config: %v", err)
+			}
+		})
+	}
+}
+
+// TestMigrate_FlowStyleListener: a flow-style block cannot take block-style
+// children. It already failed closed; now it says why.
+func TestMigrate_FlowStyleListener(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	body := "mode: proxy-sidecar\nlistener: {roles: [forward], forward_proxy_addr: 127.0.0.1:47600}\n" +
+		"stats:\n  address: 127.0.0.1:47602\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	_, err := migrateConfig(p, &out)
+	if err == nil {
+		t.Fatal("expected a refusal for a flow-style listener block")
+	}
+	if !strings.Contains(err.Error(), "flow style") {
+		t.Errorf("error does not explain the shape: %v", err)
+	}
+	after, _ := os.ReadFile(p)
+	if string(after) != body {
+		t.Error("the original config was modified")
+	}
+}
+
+// TestWildcardListeners names what is exposed, which is what a refusal reports.
+func TestWildcardListeners(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	body := "mode: proxy-sidecar\nlistener:\n  roles: [forward]\n" +
+		"  forward_proxy_addr: 127.0.0.1:47600\n  health_addr: \":9091\"\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := wildcardListeners(p)
+	found := false
+	for _, g := range got {
+		if g == "health_addr" {
+			found = true
+		}
+		if g == "forward_proxy_addr" {
+			t.Error("a loopback-bound listener was reported as exposed")
+		}
+	}
+	if !found {
+		t.Errorf("health_addr on :9091 not reported as exposed; got %v", got)
+	}
+}

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -340,23 +340,12 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "\nRunning under %s.\n", supervisorName())
 	if runtime.GOOS == "darwin" {
-		// Measured on macOS 26.5.2: an agent bootstrapped into an already-running
-		// login domain is deferred — launchd logs "pending spawn, domain in
-		// on-demand-only mode" and honours neither RunAtLoad nor KeepAlive, while an
-		// explicit kickstart works. Reproduced with a throwaway agent from a real GUI
-		// terminal, with and without ProcessType, via modern bootstrap and legacy
-		// load -w, with the executable approved in Login Items. The 454 agents loaded
-		// at login on that machine all run normally, so the distinguishing factor is
-		// when the job entered the domain.
-		//
-		// Say so rather than let "restarts on failure" read as already true: a promise
-		// that silently does not hold until the next login is worse than a stated
-		// caveat.
-		fmt.Fprintln(stdout, "\n  Note (macOS): starting at login works from now on, but automatic")
-		fmt.Fprintln(stdout, "  restart-after-crash may not take effect until your next login —")
-		fmt.Fprintln(stdout, "  launchd defers agents added mid-session. To check afterwards:")
-		fmt.Fprintln(stdout, "    kill -9 $(pgrep -f 'authbridge-proxy --config')  # should come back in ~10s")
-		fmt.Fprintln(stdout, "  Until then, restart it yourself with: abctl service start")
+		// launchd does not restart these agents — see the comment in the plist and in
+		// cmd/authbridge-proxy/supervise.go — so the proxy runs under --supervise and
+		// crash recovery belongs to that supervisor, not to KeepAlive.
+		fmt.Fprintln(stdout, "  Crash recovery is handled by a supervisor process, because launchd")
+		fmt.Fprintln(stdout, "  does not restart user agents added mid-session. Check it with:")
+		fmt.Fprintln(stdout, "    kill -9 $(pgrep -f 'authbridge-proxy --config')  # back within ~2s")
 	}
 	return 0
 }

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -207,6 +207,8 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		_ = os.Remove(p.pidFile)
 	}
 
+	tightenLog(p.logFile, stderr)
+
 	if err := os.MkdirAll(filepath.Dir(p.unitFile), 0o755); err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
@@ -319,5 +321,20 @@ func serviceControl(action string, p servicePaths, stdout, stderr io.Writer) int
 		}
 		fmt.Fprintf(stdout, "%sed.\n", strings.ToUpper(action[:1])+action[1:])
 		return 0
+	}
+}
+
+// tightenLog makes the proxy log owner-only before the supervisor opens it.
+//
+// The supervisor creates it with its own umask — 0644 in practice — and it records
+// every host the proxy talks to. Creating it first means the supervisor appends to a
+// file that is already tight; the chmod also catches one an earlier install left
+// loose. Best-effort throughout: a log mode is not worth failing an install over.
+func tightenLog(path string, stderr io.Writer) {
+	if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
+		_ = f.Close()
+	}
+	if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(stderr, "abctl: could not tighten %s (%v); continuing\n", path, err)
 	}
 }

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -298,6 +298,25 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "\nRunning under %s.\n", supervisorName())
+	if runtime.GOOS == "darwin" {
+		// Measured on macOS 26.5.2: an agent bootstrapped into an already-running
+		// login domain is deferred — launchd logs "pending spawn, domain in
+		// on-demand-only mode" and honours neither RunAtLoad nor KeepAlive, while an
+		// explicit kickstart works. Reproduced with a throwaway agent from a real GUI
+		// terminal, with and without ProcessType, via modern bootstrap and legacy
+		// load -w, with the executable approved in Login Items. The 454 agents loaded
+		// at login on that machine all run normally, so the distinguishing factor is
+		// when the job entered the domain.
+		//
+		// Say so rather than let "restarts on failure" read as already true: a promise
+		// that silently does not hold until the next login is worse than a stated
+		// caveat.
+		fmt.Fprintln(stdout, "\n  Note (macOS): starting at login works from now on, but automatic")
+		fmt.Fprintln(stdout, "  restart-after-crash may not take effect until your next login —")
+		fmt.Fprintln(stdout, "  launchd defers agents added mid-session. To check afterwards:")
+		fmt.Fprintln(stdout, "    kill -9 $(pgrep -f 'authbridge-proxy --config')  # should come back in ~10s")
+		fmt.Fprintln(stdout, "  Until then, restart it yourself with: abctl service start")
+	}
 	return 0
 }
 

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -24,6 +24,9 @@ import (
 const (
 	launchdLabel = "io.rossoctl.cortex"
 	systemdUnit  = "cortex.service"
+	// maxLogBytes bounds one generation of proxy.log; rotateLog keeps one previous
+	// file, so the pair tops out near twice this.
+	maxLogBytes  = 8 << 20
 	serviceUsage = `abctl service — keep Cortex running across crashes and logins
 
 Usage:
@@ -64,7 +67,10 @@ type servicePaths struct {
 	logFile    string
 	pidFile    string
 	healthURL  string
-	home       string // set explicitly: a supervisor's environment is minimal
+	// forwardAddr is the proxy port clients point at, used only to count attached
+	// sessions before a stop.
+	forwardAddr string
+	home        string // set explicitly: a supervisor's environment is minimal
 }
 
 func runService(args []string, stdout, stderr io.Writer) int {
@@ -157,6 +163,10 @@ func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
 	}
 
 	p.healthURL = resolveHealthURL(cortexCfg)
+	if cfg, cerr := config.Load(cortexCfg); cerr == nil {
+		config.ApplyPreset(cfg)
+		p.forwardAddr = cfg.Listener.ForwardProxyAddr
+	}
 	return p, nil
 }
 
@@ -234,6 +244,7 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		_ = os.Remove(p.pidFile)
 	}
 
+	rotateLog(p.logFile, maxLogBytes)
 	tightenLog(p.logFile, stderr)
 
 	if err := os.MkdirAll(filepath.Dir(p.unitFile), 0o755); err != nil {
@@ -324,6 +335,16 @@ func serviceStatus(p servicePaths, stdout io.Writer) int {
 		return 0
 	}
 	fmt.Fprintf(stdout, "installed: %s\n", p.unitFile)
+	// Skew is worth naming before anything else: if the unit was written by a
+	// different abctl, the rest of this output describes a job this binary may not be
+	// able to manage.
+	if w := unitWriterVersion(p.unitFile); w != "" && w != version {
+		fmt.Fprintf(stdout, "WARNING: this unit was written by abctl %s; you are running %s.\n"+
+			"  The unit also pins a fixed authbridge-proxy path, which that abctl chose.\n"+
+			"  Reinstall with this build to bring them back in step:  abctl service install\n",
+			w, version)
+	}
+
 	if p.healthURL == "" {
 		return 0
 	}
@@ -350,14 +371,29 @@ func serviceControl(action string, p servicePaths, stdout, stderr io.Writer) int
 			"  abctl service install\n", p.unitFile)
 		return 1
 	}
+	// Counted BEFORE the stop, while the connections still exist.
+	n := -1
+	if action == "stop" {
+		n = establishedConns(p.forwardAddr)
+	}
+	if action == "start" || action == "restart" {
+		rotateLog(p.logFile, maxLogBytes)
+	}
 	if err := controlService(action, p); err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
 	}
 	switch action {
 	case "stop":
-		fmt.Fprintln(stdout, "Stopped. Claude Code will fail until it is running again:")
+		fmt.Fprintln(stdout, "Stopped, and it will stay stopped across logins.")
 		fmt.Fprintln(stdout, "  abctl service start")
+		if n > 0 {
+			fmt.Fprintf(stdout, "\n  %d connection(s) were attached to %s and have just been cut.\n",
+				n, p.forwardAddr)
+			fmt.Fprintln(stdout, "  A running Claude Code cannot fall back to a direct connection —")
+			fmt.Fprintln(stdout, "  HTTPS_PROXY is fixed in its environment at startup — so restart any")
+			fmt.Fprintln(stdout, "  session that now fails to connect.")
+		}
 		return 0
 	default:
 		if p.healthURL != "" && !waitHealthy(p.healthURL, serviceReadyTimeout) {

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -85,6 +85,13 @@ func runService(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	action := args[0]
+	// `abctl service --help` used to fail with "unknown service action", which sends
+	// someone looking for the command list to the one place that refuses to print it.
+	switch action {
+	case "-h", "--help", "help":
+		fmt.Fprint(stdout, serviceUsage)
+		return 0
+	}
 
 	fs := newFlagSet("service "+action, stderr)
 	yes := fs.Bool("yes", false, "do not prompt for confirmation")

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -30,11 +30,16 @@ Usage:
   abctl service install   [--yes] [--config PATH]
   abctl service uninstall [--yes]
   abctl service status
+  abctl service stop | start | restart
 
 install hands the proxy to the OS supervisor — a launchd user agent on macOS, a
 systemd user unit on Linux — so it restarts on failure and comes back at login.
 Claude Code depends on the proxy being up once "abctl claude-code enable" has run,
 and nothing else keeps it up.
+
+stop/start/restart exist so there is never a reason to reach for launchctl,
+systemctl, kill or pkill: under a supervisor a plain kill is undone within seconds,
+which looks like the process refusing to die.
 
 If a proxy you started by hand is already running, install stops it first and
 supervises a fresh one: two copies cannot share the ports, and the supervised one
@@ -151,12 +156,26 @@ func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
 		p.unitFile = unitOverride
 	}
 
-	// The health endpoint is the only thing that proves it is serving rather than
-	// merely loaded, and it comes from the config so it cannot drift.
-	if cfg, cerr := config.Load(cortexCfg); cerr == nil && cfg.Listener.HealthAddr != "" {
-		p.healthURL = "http://" + dialableAddr(cfg.Listener.HealthAddr) + "/healthz"
-	}
+	p.healthURL = resolveHealthURL(cortexCfg)
 	return p, nil
+}
+
+// resolveHealthURL reads the health endpoint out of the config.
+//
+// ApplyPreset is applied because the binaries do: without it an unpinned
+// health_addr reads as empty, so a config that never received the health pin
+// produced no URL at all — and install then reported "Running under launchd" having
+// probed nothing, for exactly the older configs that most need checking.
+func resolveHealthURL(cortexCfg string) string {
+	cfg, err := config.Load(cortexCfg)
+	if err != nil {
+		return ""
+	}
+	config.ApplyPreset(cfg)
+	if cfg.Listener.HealthAddr == "" {
+		return ""
+	}
+	return "http://" + dialableAddr(cfg.Listener.HealthAddr) + "/healthz"
 }
 
 func serviceInstalled(p servicePaths) bool {
@@ -166,7 +185,10 @@ func serviceInstalled(p servicePaths) bool {
 
 func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	if _, err := os.Stat(p.configFile); err != nil {
-		fmt.Fprintf(stderr, "abctl: no config at %s — run the installer first\n", p.configFile)
+		// Not "run the installer first": the installer is what calls this, so that
+		// advice sent people in a circle. Name the command that creates the file.
+		fmt.Fprintf(stderr, "abctl: no config at %s. Create it with:\n"+
+			"  authbridge-proxy --local --write-config\n", p.configFile)
 		return 1
 	}
 
@@ -193,9 +215,14 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	// older config up to date: the service starts it with --config, which honours
 	// listeners that --local skipped, so an unpinned transparent_proxy_addr would
 	// start binding every interface precisely now.
-	if _, mErr := migrateConfig(p.configFile, stdout); mErr != nil {
+	if changed, mErr := migrateConfig(p.configFile, stdout); mErr != nil {
 		fmt.Fprintf(stderr, "abctl: could not update %s (%v); continuing with it as-is\n",
 			p.configFile, mErr)
+	} else if changed {
+		// The paths were resolved from the pre-migration config, so anything the
+		// migration added — health_addr above all — is not in them yet. Without this
+		// the probe below is skipped for precisely the configs that were just fixed.
+		p.healthURL = resolveHealthURL(p.configFile)
 	}
 
 	if adopt > 0 {
@@ -220,6 +247,12 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Wrote %s\n", p.unitFile)
 
 	if err := loadService(p); err != nil {
+		// Leaving the unit behind would make serviceInstalled() true for something
+		// that never loaded, so `service status` would report it installed and
+		// `service stop` would act on a job the supervisor does not have.
+		if rmErr := os.Remove(p.unitFile); rmErr != nil && !os.IsNotExist(rmErr) {
+			fmt.Fprintf(stderr, "abctl: also could not remove %s: %v\n", p.unitFile, rmErr)
+		}
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
 	}
@@ -227,6 +260,21 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	// "Loaded" is not "serving". A bad config is fatal at startup and a supervisor
 	// turns that into a restart loop, so probe the health endpoint before claiming
 	// success.
+	// Health alone is not proof: an unadopted proxy (started by hand, no pidfile)
+	// keeps the ports, the supervised copy loses the bind race and crash-loops, and
+	// the probe cheerfully succeeds against the survivor. Ask the supervisor whether
+	// OUR job is actually up before believing the probe.
+	if running, why := supervisorRunning(p); !running {
+		fmt.Fprintf(stderr, "abctl: the unit loaded but the supervisor does not report it running (%s).\n"+
+			"  Something else may hold the ports — check for a Cortex you started by hand:\n"+
+			"    pgrep -fl authbridge-prox\n"+
+			"  Last log lines:\n", why)
+		for _, line := range lastLines(p.logFile, 5) {
+			fmt.Fprintf(stderr, "    %s\n", line)
+		}
+		return 1
+	}
+
 	if p.healthURL != "" {
 		if waitHealthy(p.healthURL, serviceReadyTimeout) {
 			fmt.Fprintf(stdout, "\nRunning under %s and healthy. Claude Code will keep working across\n"+

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -97,12 +97,13 @@ func runService(args []string, stdout, stderr io.Writer) int {
 	yes := fs.Bool("yes", false, "do not prompt for confirmation")
 	cortexCfg := fs.String("config", "", "Cortex config file")
 	unitOverride := fs.String("unit-file", "", "unit file path (testing)")
+	proxyPath := fs.String("proxy", "", "authbridge-proxy binary to supervise (default: the one installed beside abctl)")
 	printUnit := fs.Bool("print-unit", false, "print the unit file and exit, installing nothing")
 	if err := fs.Parse(args[1:]); err != nil {
 		return 2
 	}
 
-	p, err := resolveServicePaths(*cortexCfg, *unitOverride)
+	p, err := resolveServicePaths(*cortexCfg, *unitOverride, *proxyPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
@@ -133,7 +134,7 @@ func runService(args []string, stdout, stderr io.Writer) int {
 
 // resolveServicePaths refuses early on an unsupported platform rather than
 // writing a unit file that will never be honoured.
-func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
+func resolveServicePaths(cortexCfg, unitOverride, proxyOverride string) (servicePaths, error) {
 	var p servicePaths
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
@@ -148,9 +149,28 @@ func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
 	p.pidFile = filepath.Join(filepath.Dir(cortexCfg), "proxy.pid")
 
 	// An absolute binary path: a supervisor has no shell PATH to search.
-	bin, err := exec.LookPath("authbridge-proxy")
-	if err != nil {
-		bin = filepath.Join(home, ".local", "bin", "authbridge-proxy")
+	//
+	// Resolution order matters. PATH first was wrong: an end-to-end run found the
+	// plist pointing at an OLDER authbridge-proxy that happened to sit earlier on
+	// PATH, which then rejected --supervise and exited, so the service never came up.
+	// abctl and the proxy are installed together, so the sibling of the running abctl
+	// is the one that matches it; PATH is only a fallback. An explicit --proxy wins
+	// over both, which is what install.sh passes so the service uses the binary it
+	// just installed.
+	bin := proxyOverride
+	if bin == "" {
+		if self, serr := os.Executable(); serr == nil {
+			if sib := filepath.Join(filepath.Dir(self), "authbridge-proxy"); fileExists(sib) {
+				bin = sib
+			}
+		}
+	}
+	if bin == "" {
+		if found, lerr := exec.LookPath("authbridge-proxy"); lerr == nil {
+			bin = found
+		} else {
+			bin = filepath.Join(home, ".local", "bin", "authbridge-proxy")
+		}
 	}
 	if abs, aerr := filepath.Abs(bin); aerr == nil {
 		bin = abs
@@ -378,7 +398,13 @@ func serviceUninstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "abctl: removing %s: %v\n", p.unitFile, err)
 		return 1
 	}
-	fmt.Fprintf(stdout, "\nRemoved. Start it yourself with:\n  %s --config %s &\n", p.binary, p.configFile)
+	// Not "start it yourself with a backgrounded proxy": running unsupervised is no
+	// longer a mode this tool offers, and on macOS a hand-started proxy gets no crash
+	// recovery at all. Point back at the supported path.
+	fmt.Fprintf(stdout, "\nRemoved. Cortex is stopped; Claude Code will fail until it runs again.\n"+
+		"  Set it up again with:  abctl service install\n"+
+		"  Or unwire Claude Code: abctl claude-code disable\n"+
+		"  The config and CA are untouched in %s\n", filepath.Dir(p.configFile))
 	return 0
 }
 
@@ -434,6 +460,10 @@ func serviceControl(action string, p servicePaths, stdout, stderr io.Writer) int
 	}
 	if action == "start" || action == "restart" {
 		rotateLog(p.logFile, maxLogBytes)
+		// tightenLog must follow every rotation, not just the install. Rotation renames
+		// the old file away, so the supervisor creates a fresh one under its own
+		// umask — measured at 0644, which silently undid the 0600 this sets.
+		tightenLog(p.logFile, stderr)
 	}
 	if err := controlService(action, p); err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
@@ -527,4 +557,9 @@ func isLoopbackHost(host string) bool {
 		return ip.IsLoopback()
 	}
 	return host == "localhost"
+}
+
+func fileExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir()
 }

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+)
+
+// Once Claude Code's settings point at the proxy, every request goes there — so a
+// proxy that is not running means Claude Code does not work. `nohup … &` survives
+// neither a crash nor a logout, which makes "it worked yesterday" the normal
+// experience after a reboot. These commands hand the process to the OS supervisor
+// instead.
+//
+// User-scoped only, never a system daemon: this process holds the bridge CA's
+// private key, and running it as root to gain "robustness" would be a bad trade.
+const (
+	launchdLabel = "io.rossoctl.cortex"
+	systemdUnit  = "cortex.service"
+	serviceUsage = `abctl service — keep Cortex running across crashes and logins
+
+Usage:
+  abctl service install   [--yes] [--config PATH]
+  abctl service uninstall [--yes]
+  abctl service status
+
+install hands the proxy to the OS supervisor — a launchd user agent on macOS, a
+systemd user unit on Linux — so it restarts on failure and comes back at login.
+Claude Code depends on the proxy being up once "abctl claude-code enable" has run,
+and nothing else keeps it up.
+
+If a proxy you started by hand is already running, install stops it first and
+supervises a fresh one: two copies cannot share the ports, and the supervised one
+would otherwise crash-loop while the old one kept serving — broken in a way that
+only shows up at your next reboot.
+
+Never installed as root. The proxy holds a CA private key; this stays a user
+service.
+`
+	// serviceReadyTimeout bounds the post-start health probe. The supervisor
+	// reports "loaded", not "serving", and the difference is where a bad config
+	// hides.
+	serviceReadyTimeout = 15 * time.Second
+)
+
+// servicePaths is everything the platform-specific bits need, gathered so tests
+// can point all of it at a temp dir instead of the real ~/Library/LaunchAgents.
+type servicePaths struct {
+	unitFile   string // plist or .service
+	binary     string // absolute path to authbridge-proxy
+	configFile string // ~/.cortex/config.yaml
+	logFile    string
+	pidFile    string
+	healthURL  string
+	home       string // set explicitly: a supervisor's environment is minimal
+}
+
+func runService(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, serviceUsage)
+		return 2
+	}
+	action := args[0]
+
+	fs := newFlagSet("service "+action, stderr)
+	yes := fs.Bool("yes", false, "do not prompt for confirmation")
+	cortexCfg := fs.String("config", "", "Cortex config file")
+	unitOverride := fs.String("unit-file", "", "unit file path (testing)")
+	printUnit := fs.Bool("print-unit", false, "print the unit file and exit, installing nothing")
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+
+	p, err := resolveServicePaths(*cortexCfg, *unitOverride)
+	if err != nil {
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		return 1
+	}
+
+	if *printUnit {
+		// Inspect before installing. Also the only way to exercise rendering without
+		// registering a real agent in the caller's session.
+		fmt.Fprint(stdout, renderUnit(p))
+		return 0
+	}
+
+	switch action {
+	case "install":
+		return serviceInstall(p, *yes, stdout, stderr)
+	case "uninstall":
+		return serviceUninstall(p, *yes, stdout, stderr)
+	case "status":
+		return serviceStatus(p, stdout)
+	default:
+		fmt.Fprintf(stderr, "abctl: unknown service action %q (install, uninstall, status)\n", action)
+		return 2
+	}
+}
+
+// resolveServicePaths refuses early on an unsupported platform rather than
+// writing a unit file that will never be honoured.
+func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
+	var p servicePaths
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return p, fmt.Errorf("cannot determine your home directory (is $HOME set?)")
+	}
+	if cortexCfg == "" {
+		cortexCfg = filepath.Join(home, ".cortex", "config.yaml")
+	}
+	p.home = home
+	p.configFile = cortexCfg
+	p.logFile = filepath.Join(filepath.Dir(cortexCfg), "proxy.log")
+	p.pidFile = filepath.Join(filepath.Dir(cortexCfg), "proxy.pid")
+
+	// An absolute binary path: a supervisor has no shell PATH to search.
+	bin, err := exec.LookPath("authbridge-proxy")
+	if err != nil {
+		bin = filepath.Join(home, ".local", "bin", "authbridge-proxy")
+	}
+	if abs, aerr := filepath.Abs(bin); aerr == nil {
+		bin = abs
+	}
+	if _, serr := os.Stat(bin); serr != nil {
+		return p, fmt.Errorf("authbridge-proxy not found at %s; install it first", bin)
+	}
+	p.binary = bin
+
+	switch unitOverride {
+	case "":
+		switch runtime.GOOS {
+		case "darwin":
+			p.unitFile = filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist")
+		case "linux":
+			p.unitFile = filepath.Join(home, ".config", "systemd", "user", systemdUnit)
+		default:
+			return p, fmt.Errorf("no supervisor integration for %s; start the proxy yourself:\n"+
+				"  authbridge-proxy --config %s &", runtime.GOOS, cortexCfg)
+		}
+	default:
+		p.unitFile = unitOverride
+	}
+
+	// The health endpoint is the only thing that proves it is serving rather than
+	// merely loaded, and it comes from the config so it cannot drift.
+	if cfg, cerr := config.Load(cortexCfg); cerr == nil && cfg.Listener.HealthAddr != "" {
+		p.healthURL = "http://" + dialableAddr(cfg.Listener.HealthAddr) + "/healthz"
+	}
+	return p, nil
+}
+
+func serviceInstalled(p servicePaths) bool {
+	_, err := os.Stat(p.unitFile)
+	return err == nil
+}
+
+func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
+	if _, err := os.Stat(p.configFile); err != nil {
+		fmt.Fprintf(stderr, "abctl: no config at %s — run the installer first\n", p.configFile)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "This will install a %s that runs:\n  %s --config %s\n\n",
+		supervisorName(), p.binary, p.configFile)
+	fmt.Fprintf(stdout, "It restarts on failure and starts at login, so Claude Code keeps working\n"+
+		"after a crash or a reboot. Unit file: %s\n\n", p.unitFile)
+
+	// Adopt rather than collide. Two copies cannot share the ports, and the
+	// supervised one would lose the race and crash-loop while the hand-started one
+	// kept serving — a break that only surfaces at the next reboot.
+	adopt := runningPID(p.pidFile)
+	if adopt > 0 {
+		fmt.Fprintf(stdout, "A Cortex you started by hand is running (pid %d). It will be stopped\n"+
+			"so the supervised one can take the ports.\n\n", adopt)
+	}
+	fmt.Fprintf(stdout, "Undo with: abctl service uninstall\n\n")
+	if !yes && !confirm(stdout) {
+		fmt.Fprintln(stdout, "Not changed.")
+		return exitDeclined
+	}
+
+	if adopt > 0 {
+		fmt.Fprintf(stdout, "Stopping pid %d...\n", adopt)
+		if err := stopPID(adopt); err != nil {
+			fmt.Fprintf(stderr, "abctl: could not stop pid %d (%v); stop it yourself and re-run\n", adopt, err)
+			return 1
+		}
+		_ = os.Remove(p.pidFile)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(p.unitFile), 0o755); err != nil {
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(p.unitFile, []byte(renderUnit(p)), 0o644); err != nil {
+		fmt.Fprintf(stderr, "abctl: writing %s: %v\n", p.unitFile, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Wrote %s\n", p.unitFile)
+
+	if err := loadService(p); err != nil {
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		return 1
+	}
+
+	// "Loaded" is not "serving". A bad config is fatal at startup and a supervisor
+	// turns that into a restart loop, so probe the health endpoint before claiming
+	// success.
+	if p.healthURL != "" {
+		if waitHealthy(p.healthURL, serviceReadyTimeout) {
+			fmt.Fprintf(stdout, "\nRunning under %s and healthy. Claude Code will keep working across\n"+
+				"crashes and logins.\n", supervisorName())
+			return 0
+		}
+		fmt.Fprintf(stderr, "\nabctl: installed, but nothing answered %s within %s.\n"+
+			"  Check %s — a config error is fatal at startup and the supervisor will keep retrying.\n"+
+			"  abctl service status shows the current state.\n", p.healthURL, serviceReadyTimeout, p.logFile)
+		return 1
+	}
+	fmt.Fprintf(stdout, "\nRunning under %s.\n", supervisorName())
+	return 0
+}
+
+func serviceUninstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
+	if !serviceInstalled(p) {
+		fmt.Fprintf(stdout, "Nothing to do: no unit at %s\n", p.unitFile)
+		return 0
+	}
+	fmt.Fprintf(stdout, "This will stop and remove the %s at:\n  %s\n\n", supervisorName(), p.unitFile)
+	fmt.Fprintf(stdout, "Cortex will no longer start at login. Claude Code stops working whenever\n"+
+		"the proxy is not running — `abctl claude-code disable` removes that dependency.\n\n")
+	if !yes && !confirm(stdout) {
+		fmt.Fprintln(stdout, "Not changed.")
+		return exitDeclined
+	}
+	if err := unloadService(p); err != nil {
+		// Report but keep going: leaving the unit file behind would make a
+		// reinstall look installed-but-dead.
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+	}
+	if err := os.Remove(p.unitFile); err != nil {
+		fmt.Fprintf(stderr, "abctl: removing %s: %v\n", p.unitFile, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "\nRemoved. Start it yourself with:\n  %s --config %s &\n", p.binary, p.configFile)
+	return 0
+}
+
+func serviceStatus(p servicePaths, stdout io.Writer) int {
+	if !serviceInstalled(p) {
+		fmt.Fprintf(stdout, "not installed (%s)\n", p.unitFile)
+		if pid := runningPID(p.pidFile); pid > 0 {
+			fmt.Fprintf(stdout, "  a hand-started Cortex is running (pid %d); nothing restarts it\n", pid)
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "installed: %s\n", p.unitFile)
+	if p.healthURL == "" {
+		return 0
+	}
+	if waitHealthy(p.healthURL, 2*time.Second) {
+		fmt.Fprintf(stdout, "healthy: %s\n", p.healthURL)
+		return 0
+	}
+	// Installed but not serving is the state worth naming loudly: Claude Code is
+	// pointed at a proxy that is not answering.
+	fmt.Fprintf(stdout, "NOT answering %s\n", p.healthURL)
+	fmt.Fprintf(stdout, "  Claude Code will fail while this is true. Last log lines:\n")
+	for _, line := range lastLines(p.logFile, 5) {
+		fmt.Fprintf(stdout, "    %s\n", line)
+	}
+	return 1
+}

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -70,7 +73,10 @@ type servicePaths struct {
 	// forwardAddr is the proxy port clients point at, used only to count attached
 	// sessions before a stop.
 	forwardAddr string
-	home        string // set explicitly: a supervisor's environment is minimal
+	// configErr is why the config would not load, if it would not. Carried rather
+	// than returned so uninstall and status still work on a broken config.
+	configErr error
+	home      string // set explicitly: a supervisor's environment is minimal
 }
 
 func runService(args []string, stdout, stderr io.Writer) int {
@@ -142,9 +148,11 @@ func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
 	if abs, aerr := filepath.Abs(bin); aerr == nil {
 		bin = abs
 	}
-	if _, serr := os.Stat(bin); serr != nil {
-		return p, fmt.Errorf("authbridge-proxy not found at %s; install it first", bin)
-	}
+	// Deliberately NOT an error here. resolveServicePaths runs for every action, and
+	// uninstall/status are exactly what you reach for when the binary is gone or
+	// renamed — refusing them at that point leaves a loaded unit with no way to
+	// remove or diagnose it. serviceInstall validates the binary itself, since it is
+	// the only action that needs one.
 	p.binary = bin
 
 	switch unitOverride {
@@ -163,7 +171,13 @@ func resolveServicePaths(cortexCfg, unitOverride string) (servicePaths, error) {
 	}
 
 	p.healthURL = resolveHealthURL(cortexCfg)
-	if cfg, cerr := config.Load(cortexCfg); cerr == nil {
+	// Kept, not discarded: install must refuse a config that cannot load, or it
+	// writes the unit, gets an empty healthURL, skips the probe and calls a proxy
+	// that cannot start "running". uninstall and status stay usable regardless,
+	// which is the whole point of not returning it as an error here.
+	if cfg, cerr := config.Load(cortexCfg); cerr != nil {
+		p.configErr = cerr
+	} else {
 		config.ApplyPreset(cfg)
 		p.forwardAddr = cfg.Listener.ForwardProxyAddr
 	}
@@ -221,12 +235,35 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		return exitDeclined
 	}
 
+	if _, serr := os.Stat(p.binary); serr != nil {
+		fmt.Fprintf(stderr, "abctl: authbridge-proxy not found at %s; install it first\n", p.binary)
+		return 1
+	}
+	if p.configErr != nil {
+		fmt.Fprintf(stderr, "abctl: %s will not load, so a supervised proxy could not start:\n  %v\n"+
+			"  Fix it (or delete it and run: authbridge-proxy --local --write-config), then re-run.\n",
+			p.configFile, p.configErr)
+		return 1
+	}
+
 	// Taking ownership of how the proxy runs is the natural moment to bring an
 	// older config up to date: the service starts it with --config, which honours
 	// listeners that --local skipped, so an unpinned transparent_proxy_addr would
 	// start binding every interface precisely now.
 	if changed, mErr := migrateConfig(p.configFile, stdout); mErr != nil {
-		fmt.Fprintf(stderr, "abctl: could not update %s (%v); continuing with it as-is\n",
+		// Refuse only if continuing would actually expose something. A migration that
+		// fails on a config already bound to loopback costs nothing to skip; one that
+		// fails on a config with wildcard listeners would supervise a proxy publishing
+		// on every interface, which is not a thing to do quietly.
+		if exposed := wildcardListeners(p.configFile); len(exposed) > 0 {
+			fmt.Fprintf(stderr, "abctl: could not update %s (%v),\n"+
+				"  and as it stands it binds %s on every interface.\n"+
+				"  Refusing to supervise that. Add `bind_loopback_only: true` under listener:,\n"+
+				"  or delete the file and run: authbridge-proxy --local --write-config\n",
+				p.configFile, mErr, strings.Join(exposed, ", "))
+			return 1
+		}
+		fmt.Fprintf(stderr, "abctl: could not update %s (%v); it already binds loopback only, continuing\n",
 			p.configFile, mErr)
 	} else if changed {
 		// The paths were resolved from the pre-migration config, so anything the
@@ -257,7 +294,11 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "Wrote %s\n", p.unitFile)
 
-	if err := loadService(p); err != nil {
+	if err := loadService(p); errors.Is(err, errLingerUnavailable) {
+		// The unit IS loaded, so this is a caveat rather than a failure: keep going,
+		// but never claim it survives a logout.
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+	} else if err != nil {
 		// Leaving the unit behind would make serviceInstalled() true for something
 		// that never loaded, so `service status` would report it installed and
 		// `service stop` would act on a job the supervisor does not have.
@@ -415,6 +456,17 @@ func serviceControl(action string, p servicePaths, stdout, stderr io.Writer) int
 		}
 		return 0
 	default:
+		// Same gate install uses: an unadopted proxy holding the ports answers the
+		// probe while OUR job crash-loops on the bind, so health alone would report a
+		// restart that did not happen.
+		if running, why := supervisorRunning(p); !running {
+			fmt.Fprintf(stderr, "abctl: %sed, but the supervisor does not report it running (%s).\n"+
+				"  Check for a Cortex started by hand holding the ports: pgrep -fl authbridge-prox\n", action, why)
+			for _, line := range lastLines(p.logFile, 5) {
+				fmt.Fprintf(stderr, "    %s\n", line)
+			}
+			return 1
+		}
 		if p.healthURL != "" && !waitHealthy(p.healthURL, serviceReadyTimeout) {
 			fmt.Fprintf(stderr, "abctl: %sed, but nothing answered %s. Last log lines:\n", action, p.healthURL)
 			for _, line := range lastLines(p.logFile, 5) {
@@ -440,4 +492,43 @@ func tightenLog(path string, stderr io.Writer) {
 	if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
 		fmt.Fprintf(stderr, "abctl: could not tighten %s (%v); continuing\n", path, err)
 	}
+}
+
+// wildcardListeners names the listener addresses that are not bound to loopback,
+// so a refusal can say what is actually exposed.
+func wildcardListeners(cortexCfg string) []string {
+	cfg, err := config.Load(cortexCfg)
+	if err != nil {
+		return nil // unreadable: the caller's own error already covers it
+	}
+	config.ApplyPreset(cfg)
+	var out []string
+	for name, addr := range map[string]string{
+		"forward_proxy_addr":     cfg.Listener.ForwardProxyAddr,
+		"session_api_addr":       cfg.Listener.SessionAPIAddr,
+		"health_addr":            cfg.Listener.HealthAddr,
+		"transparent_proxy_addr": cfg.Listener.TransparentProxyAddr,
+		"stats address":          cfg.Stats.StatsAddress,
+	} {
+		if addr == "" {
+			continue
+		}
+		if host, _, serr := net.SplitHostPort(addr); serr == nil && !isLoopbackHost(host) {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// isLoopbackHost treats an empty host as a wildcard, which is exactly what ":9091"
+// means.
+func isLoopbackHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return host == "localhost"
 }

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/config"
@@ -97,8 +98,11 @@ func runService(args []string, stdout, stderr io.Writer) int {
 		return serviceUninstall(p, *yes, stdout, stderr)
 	case "status":
 		return serviceStatus(p, stdout)
+	case "stop", "start", "restart":
+		return serviceControl(action, p, stdout, stderr)
 	default:
-		fmt.Fprintf(stderr, "abctl: unknown service action %q (install, uninstall, status)\n", action)
+		fmt.Fprintf(stderr, "abctl: unknown service action %q "+
+			"(install, uninstall, status, stop, start, restart)\n", action)
 		return 2
 	}
 }
@@ -183,6 +187,15 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	if !yes && !confirm(stdout) {
 		fmt.Fprintln(stdout, "Not changed.")
 		return exitDeclined
+	}
+
+	// Taking ownership of how the proxy runs is the natural moment to bring an
+	// older config up to date: the service starts it with --config, which honours
+	// listeners that --local skipped, so an unpinned transparent_proxy_addr would
+	// start binding every interface precisely now.
+	if _, mErr := migrateConfig(p.configFile, stdout); mErr != nil {
+		fmt.Fprintf(stderr, "abctl: could not update %s (%v); continuing with it as-is\n",
+			p.configFile, mErr)
 	}
 
 	if adopt > 0 {
@@ -276,4 +289,35 @@ func serviceStatus(p servicePaths, stdout io.Writer) int {
 		fmt.Fprintf(stdout, "    %s\n", line)
 	}
 	return 1
+}
+
+// serviceControl is the whole reason users never need launchctl or systemctl: a
+// plain kill against a supervised process is undone in seconds, which reads as the
+// process refusing to die.
+func serviceControl(action string, p servicePaths, stdout, stderr io.Writer) int {
+	if !serviceInstalled(p) {
+		fmt.Fprintf(stderr, "abctl: no service installed (%s). Install it with:\n"+
+			"  abctl service install\n", p.unitFile)
+		return 1
+	}
+	if err := controlService(action, p); err != nil {
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		return 1
+	}
+	switch action {
+	case "stop":
+		fmt.Fprintln(stdout, "Stopped. Claude Code will fail until it is running again:")
+		fmt.Fprintln(stdout, "  abctl service start")
+		return 0
+	default:
+		if p.healthURL != "" && !waitHealthy(p.healthURL, serviceReadyTimeout) {
+			fmt.Fprintf(stderr, "abctl: %sed, but nothing answered %s. Last log lines:\n", action, p.healthURL)
+			for _, line := range lastLines(p.logFile, 5) {
+				fmt.Fprintf(stderr, "    %s\n", line)
+			}
+			return 1
+		}
+		fmt.Fprintf(stdout, "%sed.\n", strings.ToUpper(action[:1])+action[1:])
+		return 0
+	}
 }

--- a/authbridge/cmd/abctl/cmd_service_durable_test.go
+++ b/authbridge/cmd/abctl/cmd_service_durable_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStopIsDurable pins the contract the PR title claims: a stop must still be a
+// stop after a login. On macOS bootout alone is undone when launchd re-bootstraps
+// ~/Library/LaunchAgents; on Linux `systemctl stop` leaves the unit enabled.
+//
+// This reads the source rather than driving the commands, because controlService
+// shells out to the real supervisor and there is no seam to inject a fake. So treat
+// it as a canary against the persistent forms being dropped, NOT as evidence that
+// stop survives a login — that needs a real logout, which no test here performs.
+func TestStopIsDurable(t *testing.T) {
+	src, err := os.ReadFile("cmd_service_platform.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(src)
+
+	t.Run("macOS pairs bootout with a persistent disable", func(t *testing.T) {
+		if !strings.Contains(body, `"launchctl", "disable", target`) {
+			t.Error("stop does not disable the label; it would restart at next login")
+		}
+	})
+
+	t.Run("and start clears that disable, or nothing could start again", func(t *testing.T) {
+		if !strings.Contains(body, `"launchctl", "enable", "gui/"+uid+"/"+launchdLabel`) {
+			t.Error("loadService does not enable; a stop would make every later start fail")
+		}
+	})
+
+	t.Run("systemd stop disables too, since a stopped unit stays enabled", func(t *testing.T) {
+		if !strings.Contains(body, `"--user", "disable", "--now", systemdUnit`) {
+			t.Error("systemd stop is transient; the unit would return at boot")
+		}
+		if !strings.Contains(body, `"--user", "enable", "--now", systemdUnit`) {
+			t.Error("systemd start does not re-enable")
+		}
+	})
+}
+
+// TestUnitCarriesItsWriter covers the skew that made a live launchd job
+// unmanageable on a real machine: a newer build wrote the plist, an older abctl on
+// PATH could not even parse `service`.
+func TestUnitCarriesItsWriter(t *testing.T) {
+	p := servicePaths{
+		binary:     "/u/bin/authbridge-proxy",
+		configFile: "/u/.cortex/config.yaml",
+		logFile:    "/u/.cortex/proxy.log",
+		home:       "/u",
+	}
+	for _, goos := range []string{"darwin", "linux"} {
+		dir := t.TempDir()
+		unit := filepath.Join(dir, "unit")
+		if err := os.WriteFile(unit, []byte(renderUnitFor(goos, p)), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got := unitWriterVersion(unit)
+		if got != version {
+			t.Errorf("%s: unitWriterVersion = %q, want %q", goos, got, version)
+		}
+	}
+	t.Run("an unstamped unit reads as unknown, not as a false match", func(t *testing.T) {
+		unit := filepath.Join(t.TempDir(), "old")
+		if err := os.WriteFile(unit, []byte("[Unit]\nDescription=old\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := unitWriterVersion(unit); got != "" {
+			t.Errorf("got %q, want empty for an unstamped unit", got)
+		}
+	})
+}
+
+// TestRotateLog bounds the crash-loop case: KeepAlive plus ThrottleInterval 10 is
+// ~6 restarts a minute, each writing a startup banner into one unrotated file.
+func TestRotateLog(t *testing.T) {
+	t.Run("rotates once past the cap", func(t *testing.T) {
+		dir := t.TempDir()
+		log := filepath.Join(dir, "proxy.log")
+		if err := os.WriteFile(log, make([]byte, 100), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rotateLog(log, 50)
+		if _, err := os.Stat(log + ".1"); err != nil {
+			t.Errorf("previous generation not kept: %v", err)
+		}
+		if _, err := os.Stat(log); !os.IsNotExist(err) {
+			t.Error("the live path should be free for the next spawn to create")
+		}
+	})
+
+	t.Run("leaves a small log alone", func(t *testing.T) {
+		dir := t.TempDir()
+		log := filepath.Join(dir, "proxy.log")
+		if err := os.WriteFile(log, make([]byte, 10), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rotateLog(log, 50)
+		if _, err := os.Stat(log); err != nil {
+			t.Errorf("rotated a log under the cap: %v", err)
+		}
+		if _, err := os.Stat(log + ".1"); err == nil {
+			t.Error("created a generation it did not need")
+		}
+	})
+
+	t.Run("a missing log is not an error", func(t *testing.T) {
+		rotateLog(filepath.Join(t.TempDir(), "absent.log"), 1)
+	})
+}
+
+// TestEstablishedConns_CannotTellIsNotZero: reporting "0 sessions" when we simply
+// cannot look would be worse than staying quiet.
+func TestEstablishedConns_CannotTellIsNotZero(t *testing.T) {
+	if got := establishedConns(""); got != -1 {
+		t.Errorf("establishedConns(\"\") = %d, want -1 (unknown)", got)
+	}
+	if got := establishedConns("not-an-address"); got != -1 {
+		t.Errorf("malformed address = %d, want -1 (unknown)", got)
+	}
+}

--- a/authbridge/cmd/abctl/cmd_service_perm_test.go
+++ b/authbridge/cmd/abctl/cmd_service_perm_test.go
@@ -97,3 +97,31 @@ func TestTightenLog(t *testing.T) {
 		}
 	})
 }
+
+// TestRotateThenTighten: rotation renames the old log away and the supervisor
+// creates a fresh one under its own umask (0644 in practice), so a rotation without
+// a following tighten silently undoes the 0600. Observed in an end-to-end run.
+func TestRotateThenTighten(t *testing.T) {
+	dir := t.TempDir()
+	log := filepath.Join(dir, "proxy.log")
+	if err := os.WriteFile(log, make([]byte, 100), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rotateLog(log, 50)
+	if _, err := os.Stat(log); !os.IsNotExist(err) {
+		t.Fatal("rotate should have left the live path free")
+	}
+	// Stand in for the supervisor recreating it loosely.
+	if err := os.WriteFile(log, nil, 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	var errOut bytes.Buffer
+	tightenLog(log, &errOut)
+	fi, err := os.Stat(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode after rotate+tighten = %o, want 600", got)
+	}
+}

--- a/authbridge/cmd/abctl/cmd_service_perm_test.go
+++ b/authbridge/cmd/abctl/cmd_service_perm_test.go
@@ -52,13 +52,48 @@ func TestTightenLog(t *testing.T) {
 		}
 	})
 
-	t.Run("an unwritable path is reported, not fatal", func(t *testing.T) {
-		// A directory that cannot be created into: install must still proceed.
+	t.Run("an uncreatable path is survivable and stays quiet", func(t *testing.T) {
+		// A missing parent directory: install must proceed regardless. tightenLog
+		// deliberately suppresses IsNotExist, because the supervisor will create the
+		// log itself — so the contract here is "no file, no complaint, no panic",
+		// not "reports an error".
 		log := filepath.Join(t.TempDir(), "nope", "proxy.log")
 		var errOut bytes.Buffer
-		tightenLog(log, &errOut) // must not panic
+		tightenLog(log, &errOut)
 		if _, err := os.Stat(log); err == nil {
 			t.Error("unexpectedly created the file")
+		}
+		if errOut.Len() != 0 {
+			t.Errorf("IsNotExist should be suppressed, got: %s", errOut.String())
+		}
+	})
+
+	t.Run("a real chmod failure IS reported", func(t *testing.T) {
+		// Distinguishes "quiet because suppressed" from "quiet because nothing runs":
+		// a path that exists but cannot be chmod'ed must produce a complaint.
+		dir := t.TempDir()
+		log := filepath.Join(dir, "proxy.log")
+		if err := os.WriteFile(log, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(dir, 0o500); err != nil { // no write on the parent
+			t.Skipf("cannot make the parent read-only here: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+		if os.Getuid() == 0 {
+			t.Skip("root ignores directory permissions")
+		}
+		// chmod on an existing file still succeeds for its owner, so assert the
+		// suppression boundary instead: a genuinely absent file stays quiet, and this
+		// existing one is tightened.
+		var errOut bytes.Buffer
+		tightenLog(log, &errOut)
+		fi, err := os.Stat(log)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode().Perm() != 0o600 {
+			t.Errorf("mode = %o, want 600", fi.Mode().Perm())
 		}
 	})
 }

--- a/authbridge/cmd/abctl/cmd_service_perm_test.go
+++ b/authbridge/cmd/abctl/cmd_service_perm_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestTightenLog covers what install relies on: the log records every host the
+// proxy talks to, and the supervisor would create it 0644.
+func TestTightenLog(t *testing.T) {
+	t.Run("tightens one an earlier install left loose", func(t *testing.T) {
+		log := filepath.Join(t.TempDir(), "proxy.log")
+		if err := os.WriteFile(log, []byte("old\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		var errOut bytes.Buffer
+		tightenLog(log, &errOut)
+
+		fi, err := os.Stat(log)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("mode = %o, want 600", got)
+		}
+		// Append-only: losing a log to a permission fix would be its own bug.
+		b, err := os.ReadFile(log)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != "old\n" {
+			t.Errorf("content = %q, want the previous content kept", string(b))
+		}
+		if errOut.Len() != 0 {
+			t.Errorf("unexpected complaint: %s", errOut.String())
+		}
+	})
+
+	t.Run("creates it 0600 when absent, so the supervisor never makes it 0644", func(t *testing.T) {
+		log := filepath.Join(t.TempDir(), "proxy.log")
+		var errOut bytes.Buffer
+		tightenLog(log, &errOut)
+
+		fi, err := os.Stat(log)
+		if err != nil {
+			t.Fatalf("not created: %v", err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("mode = %o, want 600", got)
+		}
+	})
+
+	t.Run("an unwritable path is reported, not fatal", func(t *testing.T) {
+		// A directory that cannot be created into: install must still proceed.
+		log := filepath.Join(t.TempDir(), "nope", "proxy.log")
+		var errOut bytes.Buffer
+		tightenLog(log, &errOut) // must not panic
+		if _, err := os.Stat(log); err == nil {
+			t.Error("unexpectedly created the file")
+		}
+	})
+}

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func newFlagSet(name string, stderr io.Writer) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	return fs
+}
+
+func supervisorName() string {
+	if runtime.GOOS == "darwin" {
+		return "launchd user agent"
+	}
+	return "systemd user unit"
+}
+
+// renderUnit produces the plist or unit file.
+//
+// Two choices are load-bearing on both platforms:
+//
+//   - Restart on FAILURE only. launchd's KeepAlive=true respawns even after a
+//     clean exit, which makes a deliberate stop impossible; SuccessfulExit=false
+//     restarts a crash and honours a stop.
+//   - A throttle. A config error is fatal at startup, so without one a bad edit
+//     becomes a tight respawn loop.
+func renderUnit(p servicePaths) string { return renderUnitFor(runtime.GOOS, p) }
+
+// renderUnitFor takes the OS explicitly so both renderings are testable from
+// either platform. Without it the systemd unit would be written on a Mac and
+// never exercised until a Linux user hit it.
+func renderUnitFor(goos string, p servicePaths) string {
+	if goos == "darwin" {
+		// HOME is set explicitly: the config interpolates ${HOME} at load, and an
+		// agent's environment is minimal enough not to rely on inheritance.
+		return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>` + launchdLabel + `</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>` + p.binary + `</string>
+    <string>--config</string>
+    <string>` + p.configFile + `</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict><key>HOME</key><string>` + p.home + `</string></dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>StandardOutPath</key><string>` + p.logFile + `</string>
+  <key>StandardErrorPath</key><string>` + p.logFile + `</string>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>
+`
+	}
+	// StartLimit* live in [Unit], not [Service]: systemd moved them in v229 and
+	// deprecates them in [Service], where they can be ignored outright — silently
+	// voiding the crash-loop throttle they exist to provide. It gives up rather than
+	// loop forever, leaving a failed unit that `systemctl --user status` reports.
+	//
+	// No After=network-online.target: that target is not part of a user manager, and
+	// every listener here is loopback, so ordering against the network would be a
+	// dependency that never arrives.
+	return `[Unit]
+Description=Cortex local proxy (authbridge-proxy)
+Documentation=https://github.com/rossoctl/cortex
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+ExecStart=` + p.binary + ` --config ` + p.configFile + `
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:` + p.logFile + `
+StandardError=append:` + p.logFile + `
+
+[Install]
+WantedBy=default.target
+`
+}
+
+func loadService(p servicePaths) error {
+	if runtime.GOOS == "darwin" {
+		uid := strconv.Itoa(os.Getuid())
+		// bootout first so a reinstall replaces cleanly; ignore its error, the
+		// service may not be loaded at all.
+		_ = exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchdLabel).Run() //nolint:errcheck
+		out, err := exec.Command("launchctl", "bootstrap", "gui/"+uid, p.unitFile).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("launchctl bootstrap failed: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return fmt.Errorf("systemctl not found — this system has no systemd (WSL1 or a container?).\n" +
+			"  Remove the unit file and start the proxy yourself instead")
+	}
+	if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl --user daemon-reload: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	if out, err := exec.Command("systemctl", "--user", "enable", "--now", systemdUnit).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl --user enable --now %s: %v: %s", systemdUnit, err, strings.TrimSpace(string(out)))
+	}
+	// Without lingering, a user unit stops at logout — which defeats the point on a
+	// headless or SSH-only box. Best-effort: it needs polkit on some systems.
+	if u := os.Getenv("USER"); u != "" {
+		_ = exec.Command("loginctl", "enable-linger", u).Run() //nolint:errcheck
+	}
+	return nil
+}
+
+func unloadService(p servicePaths) error {
+	if runtime.GOOS == "darwin" {
+		uid := strconv.Itoa(os.Getuid())
+		if out, err := exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchdLabel).CombinedOutput(); err != nil {
+			return fmt.Errorf("launchctl bootout: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return nil // nothing could have been loaded
+	}
+	if out, err := exec.Command("systemctl", "--user", "disable", "--now", systemdUnit).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl --user disable --now %s: %v: %s", systemdUnit, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// runningPID returns the pid from a pidfile only when it is alive AND is one of
+// ours. Same narrow check install.sh uses: the name is truncated to 15 characters
+// on Linux, so match a prefix rather than the full 16-character name.
+func runningPID(pidFile string) int {
+	b, err := os.ReadFile(pidFile) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		return 0
+	}
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if err != nil || !strings.Contains(string(out), "authbridge-prox") {
+		return 0 // pid recycled onto something else
+	}
+	return pid
+}
+
+// stopPID asks politely, then waits. The proxy allows itself 15s to drain, so
+// this waits longer than that before giving up rather than reporting success on a
+// process that still holds the ports.
+func stopPID(pid int) error {
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		return err
+	}
+	for i := 0; i < 90; i++ {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("still alive after 18s")
+}
+
+func waitHealthy(url string, within time.Duration) bool {
+	c := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		resp, err := c.Get(url) //nolint:noctx // bounded by Timeout
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return true
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return false
+}
+
+func lastLines(path string, n int) []string {
+	f, err := os.Open(path) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return []string{"(no log at " + path + ")"}
+	}
+	defer f.Close()
+	var ring []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		ring = append(ring, sc.Text())
+		if len(ring) > n {
+			ring = ring[1:]
+		}
+	}
+	if len(ring) == 0 {
+		return []string{"(log is empty)"}
+	}
+	return ring
+}
+
+// dialableAddr turns a bind address into one a client can connect to. Named apart
+// from the existing dialable() predicate in local_endpoint.go, which answers a
+// different question.
+func dialableAddr(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -393,18 +393,34 @@ func controlService(action string, p servicePaths) error {
 func supervisorRunning(p servicePaths) (bool, string) {
 	if runtime.GOOS == "darwin" {
 		target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + launchdLabel
-		out, err := exec.Command("launchctl", "print", target).CombinedOutput()
-		if err != nil {
-			return false, "launchctl print: job not found"
-		}
-		for _, line := range strings.Split(string(out), "\n") {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "state = ") {
-				st := strings.TrimPrefix(line, "state = ")
-				return st == "running", "state = " + st
+		// Poll rather than sample once. Immediately after a kickstart the job passes
+		// through transient states — "xpcproxy" while launchd's exec helper is still
+		// in the middle of the exec — and reading one of those as a verdict failed an
+		// install whose service was merely still starting.
+		deadline := time.Now().Add(serviceReadyTimeout)
+		last := "no state reported"
+		for {
+			out, err := exec.Command("launchctl", "print", target).CombinedOutput()
+			if err != nil {
+				last = "launchctl print: job not found"
+			} else {
+				for _, line := range strings.Split(string(out), "\n") {
+					line = strings.TrimSpace(line)
+					if strings.HasPrefix(line, "state = ") {
+						st := strings.TrimPrefix(line, "state = ")
+						if st == "running" {
+							return true, "state = running"
+						}
+						last = "state = " + st
+						break
+					}
+				}
 			}
+			if time.Now().After(deadline) {
+				return false, last
+			}
+			time.Sleep(300 * time.Millisecond)
 		}
-		return false, "launchctl print reported no state"
 	}
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return true, "" // no systemd to ask; do not block on a check we cannot make

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/xml"
 	"flag"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -57,6 +59,21 @@ func renderUnit(p servicePaths) string { return renderUnitFor(runtime.GOOS, p) }
 // renderUnitFor takes the OS explicitly so both renderings are testable from
 // either platform. Without it the systemd unit would be written on a Mac and
 // never exercised until a Linux user hit it.
+// xmlStr renders a plist <string> with its content XML-escaped. $HOME and a
+// --config path are user-supplied: an "&" or "<" in either produces a plist that
+// launchctl bootstrap rejects as malformed.
+func xmlStr(v string) string {
+	var b strings.Builder
+	_ = xml.EscapeText(&b, []byte(v))
+	return b.String()
+}
+
+// shQuote single-quotes a systemd ExecStart argument. systemd splits ExecStart on
+// whitespace, so an unquoted path containing a space becomes two wrong arguments.
+func shQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"
+}
+
 func renderUnitFor(goos string, p servicePaths) string {
 	if goos == "darwin" {
 		// HOME is set explicitly: the config interpolates ${HOME} at load, and an
@@ -68,17 +85,17 @@ func renderUnitFor(goos string, p servicePaths) string {
   <key>Label</key><string>` + launchdLabel + `</string>
   <key>ProgramArguments</key>
   <array>
-    <string>` + p.binary + `</string>
+    <string>` + xmlStr(p.binary) + `</string>
     <string>--config</string>
-    <string>` + p.configFile + `</string>
+    <string>` + xmlStr(p.configFile) + `</string>
   </array>
   <key>EnvironmentVariables</key>
-  <dict><key>HOME</key><string>` + p.home + `</string></dict>
+  <dict><key>HOME</key><string>` + xmlStr(p.home) + `</string></dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>10</integer>
-  <key>StandardOutPath</key><string>` + p.logFile + `</string>
-  <key>StandardErrorPath</key><string>` + p.logFile + `</string>
+  <key>StandardOutPath</key><string>` + xmlStr(p.logFile) + `</string>
+  <key>StandardErrorPath</key><string>` + xmlStr(p.logFile) + `</string>
   <key>ProcessType</key><string>Background</string>
 </dict>
 </plist>
@@ -100,7 +117,7 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
-ExecStart=` + p.binary + ` --config ` + p.configFile + `
+ExecStart=` + shQuote(p.binary) + ` --config ` + shQuote(p.configFile) + `
 Restart=on-failure
 RestartSec=10
 StandardOutput=append:` + p.logFile + `
@@ -145,10 +162,36 @@ func loadService(p servicePaths) error {
 	}
 	// Without lingering, a user unit stops at logout — which defeats the point on a
 	// headless or SSH-only box. Best-effort: it needs polkit on some systems.
-	if u := os.Getenv("USER"); u != "" {
-		_ = exec.Command("loginctl", "enable-linger", u).Run() //nolint:errcheck
+	//
+	// uid, not $USER: a supervisor environment may not set USER at all, and the uid is
+	// already what every other call here uses. loginctl accepts either.
+	//
+	// Record it only when WE turn it on, so uninstall can undo exactly that. Linger is
+	// a per-user setting shared with every other user unit, so disabling it
+	// unconditionally on uninstall could stop services that have nothing to do with
+	// Cortex.
+	uid := strconv.Itoa(os.Getuid())
+	if !lingerEnabled(uid) {
+		if err := exec.Command("loginctl", "enable-linger", uid).Run(); err == nil {
+			_ = os.WriteFile(lingerMarker(p), []byte("enabled by abctl\n"), 0o600) //nolint:errcheck
+		}
 	}
 	return nil
+}
+
+// lingerMarker records that we enabled lingering, so uninstall undoes only that.
+func lingerMarker(p servicePaths) string {
+	return filepath.Join(filepath.Dir(p.configFile), "linger-enabled-by-abctl")
+}
+
+// lingerEnabled reports whether lingering is already on. A parse failure reads as
+// "already on", which errs toward leaving the user's setting alone.
+func lingerEnabled(uid string) bool {
+	out, err := exec.Command("loginctl", "show-user", uid, "--property=Linger").Output()
+	if err != nil {
+		return true
+	}
+	return !strings.Contains(strings.ToLower(string(out)), "linger=no")
 }
 
 func unloadService(p servicePaths) error {
@@ -161,6 +204,13 @@ func unloadService(p servicePaths) error {
 	}
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return nil // nothing could have been loaded
+	}
+	// Undo lingering only if we are the ones who enabled it.
+	if marker := lingerMarker(p); marker != "" {
+		if _, serr := os.Stat(marker); serr == nil {
+			_ = exec.Command("loginctl", "disable-linger", strconv.Itoa(os.Getuid())).Run() //nolint:errcheck
+			_ = os.Remove(marker)                                                           //nolint:errcheck
+		}
 	}
 	if out, err := exec.Command("systemctl", "--user", "disable", "--now", systemdUnit).CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl --user disable --now %s: %v: %s", systemdUnit, err, strings.TrimSpace(string(out)))
@@ -280,12 +330,38 @@ func controlService(action string, p servicePaths) error {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return fmt.Errorf("systemctl not found; this system has no systemd")
 	}
-	verb := action
-	if action == "start" {
-		verb = "start"
-	}
-	if out, err := exec.Command("systemctl", "--user", verb, systemdUnit).CombinedOutput(); err != nil {
-		return fmt.Errorf("systemctl --user %s %s: %v: %s", verb, systemdUnit, err, strings.TrimSpace(string(out)))
+	if out, err := exec.Command("systemctl", "--user", action, systemdUnit).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl --user %s %s: %v: %s", action, systemdUnit, err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// supervisorRunning asks the supervisor whether OUR job is up, which health alone
+// cannot establish: an unadopted proxy keeps the ports, the supervised copy
+// crash-loops on the bind, and the probe succeeds against the survivor.
+func supervisorRunning(p servicePaths) (bool, string) {
+	if runtime.GOOS == "darwin" {
+		target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + launchdLabel
+		out, err := exec.Command("launchctl", "print", target).CombinedOutput()
+		if err != nil {
+			return false, "launchctl print: job not found"
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "state = ") {
+				st := strings.TrimPrefix(line, "state = ")
+				return st == "running", "state = " + st
+			}
+		}
+		return false, "launchctl print reported no state"
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return true, "" // no systemd to ask; do not block on a check we cannot make
+	}
+	out, err := exec.Command("systemctl", "--user", "is-active", systemdUnit).Output()
+	st := strings.TrimSpace(string(out))
+	if err != nil && st == "" {
+		return false, "systemctl is-active gave no answer"
+	}
+	return st == "active", "is-active = " + st
 }

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -256,3 +256,36 @@ func dialableAddr(addr string) string {
 	}
 	return net.JoinHostPort(host, port)
 }
+
+// controlService maps stop/start/restart onto the platform's supervisor.
+func controlService(action string, p servicePaths) error {
+	if runtime.GOOS == "darwin" {
+		target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + launchdLabel
+		switch action {
+		case "stop":
+			// `launchctl stop` is undone by KeepAlive. bootout removes the job from
+			// the domain, which is the only stop that sticks; start re-bootstraps.
+			out, err := exec.Command("launchctl", "bootout", target).CombinedOutput()
+			if err != nil && !strings.Contains(string(out), "No such process") {
+				return fmt.Errorf("launchctl bootout: %v: %s", err, strings.TrimSpace(string(out)))
+			}
+			return nil
+		case "start":
+			return loadService(p)
+		default: // restart
+			_ = exec.Command("launchctl", "bootout", target).Run() //nolint:errcheck
+			return loadService(p)
+		}
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return fmt.Errorf("systemctl not found; this system has no systemd")
+	}
+	verb := action
+	if action == "start" {
+		verb = "start"
+	}
+	if out, err := exec.Command("systemctl", "--user", verb, systemdUnit).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl --user %s %s: %v: %s", verb, systemdUnit, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -76,6 +76,19 @@ func shQuote(v string) string {
 	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"
 }
 
+// renderUnitFor builds the unit for goos.
+//
+// The macOS plist runs the proxy under --supervise. launchd will not restart these
+// agents itself: in a gui/<uid> domain an agent bootstrapped mid-session gets
+// "pending spawn, domain in on-demand-only mode", and neither KeepAlive nor
+// StartInterval nor RunAtLoad fires (measured on macOS 26.5.2, active Aqua session,
+// approved in Login Items, via both bootstrap and legacy load -w). Only kickstart
+// starts it. So launchd starts a supervisor and the supervisor restarts the proxy.
+// KeepAlive stays in the plist for the cases launchd does honour, such as a
+// login-time load; it is no longer what crash recovery depends on.
+//
+// The systemd unit deliberately does NOT use --supervise: Restart=on-failure works
+// there and counts restarts against StartLimit, which a nested supervisor would hide.
 func renderUnitFor(goos string, p servicePaths) string {
 	if goos == "darwin" {
 		// HOME is set explicitly: the config interpolates ${HOME} at load, and an
@@ -88,6 +101,7 @@ func renderUnitFor(goos string, p servicePaths) string {
   <key>ProgramArguments</key>
   <array>
     <string>` + xmlStr(p.binary) + `</string>
+    <string>--supervise</string>
     <string>--config</string>
     <string>` + xmlStr(p.configFile) + `</string>
   </array>

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/xml"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -178,12 +180,21 @@ func loadService(p servicePaths) error {
 	// Cortex.
 	uid := strconv.Itoa(os.Getuid())
 	if !lingerEnabled(uid) {
-		if err := exec.Command("loginctl", "enable-linger", uid).Run(); err == nil {
-			_ = os.WriteFile(lingerMarker(p), []byte("enabled by abctl\n"), 0o600) //nolint:errcheck
+		if err := exec.Command("loginctl", "enable-linger", uid).Run(); err != nil {
+			// Not fatal — the unit is loaded and serving — but it does mean the service
+			// stops at logout, so it must not be reported as surviving one. polkit
+			// refuses this on some systems.
+			return errLingerUnavailable
 		}
+		_ = os.WriteFile(lingerMarker(p), []byte("enabled by abctl\n"), 0o600) //nolint:errcheck
 	}
 	return nil
 }
+
+// errLingerUnavailable means the unit loaded but will not outlive a logout.
+var errLingerUnavailable = errors.New(
+	"loaded, but `loginctl enable-linger` failed: the service will stop when you log out. " +
+		"Ask an administrator to run: loginctl enable-linger $USER")
 
 // lingerMarker records that we enabled lingering, so uninstall undoes only that.
 func lingerMarker(p servicePaths) string {
@@ -414,10 +425,16 @@ func establishedConns(addr string) int {
 	if _, err := exec.LookPath("lsof"); err != nil {
 		return -1
 	}
-	out, err := exec.Command("lsof", "-nP", "-iTCP:"+port, "-sTCP:ESTABLISHED").Output()
+	cmd := exec.Command("lsof", "-nP", "-iTCP:"+port, "-sTCP:ESTABLISHED")
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	out, err := cmd.Output()
 	if err != nil {
-		// lsof exits 1 with no output when nothing matches, which is a real zero.
-		if len(out) == 0 {
+		// lsof exits 1 both when nothing matches and on real failures (permission,
+		// for one). Only the silent case is a true zero; anything that complained on
+		// stderr is unknown, because reporting "0 attached" when we could not look
+		// would be a confident wrong answer.
+		if len(out) == 0 && errBuf.Len() == 0 {
 			return 0
 		}
 		return -1

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -33,9 +33,23 @@ func supervisorName() string {
 //
 // Two choices are load-bearing on both platforms:
 //
-//   - Restart on FAILURE only. launchd's KeepAlive=true respawns even after a
-//     clean exit, which makes a deliberate stop impossible; SuccessfulExit=false
-//     restarts a crash and honours a stop.
+//   - launchd gets unconditional KeepAlive; systemd gets Restart=on-failure.
+//     KeepAlive=true is the simpler guarantee for the requirement that matters —
+//     come back after a crash — and it costs nothing, because the way to stop this
+//     deliberately is `service uninstall`, which boots the job out rather than
+//     leaning on a KeepAlive condition. Apple's {SuccessfulExit:false} form is
+//     documented in terms of EXIT STATUS, which makes its behaviour on death by
+//     signal ambiguous; there is no reason to depend on resolving that.
+//
+//     systemd needs no such trade: on-failure covers signal death, and a
+//     `systemctl stop` is distinguishable from a crash, so a stop stays stopped.
+//
+//     NOT verified end to end: restart-after-crash could not be observed from the
+//     session this was developed in. launchd logged "pending spawn, domain in
+//     on-demand-only mode", i.e. it queued the respawn rather than running it —
+//     a property of a headless context, not of this plist. Worth one manual
+//     `kill -9` from a real GUI login before trusting it.
+//
 //   - A throttle. A config error is fatal at startup, so without one a bad edit
 //     becomes a tight respawn loop.
 func renderUnit(p servicePaths) string { return renderUnitFor(runtime.GOOS, p) }
@@ -61,7 +75,7 @@ func renderUnitFor(goos string, p servicePaths) string {
   <key>EnvironmentVariables</key>
   <dict><key>HOME</key><string>` + p.home + `</string></dict>
   <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>
+  <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>10</integer>
   <key>StandardOutPath</key><string>` + p.logFile + `</string>
   <key>StandardErrorPath</key><string>` + p.logFile + `</string>
@@ -106,6 +120,16 @@ func loadService(p servicePaths) error {
 		out, err := exec.Command("launchctl", "bootstrap", "gui/"+uid, p.unitFile).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("launchctl bootstrap failed: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+		// bootstrap REGISTERS the job; it does not reliably start it. Observed on a
+		// real install: the agent loaded, `state = not running`, nothing served, and
+		// Claude Code was broken until an explicit kickstart — RunAtLoad
+		// notwithstanding. launchd's log said "pending spawn, domain in
+		// on-demand-only mode", so whether a given session spawns at bootstrap
+		// depends on the domain's state. Start it deliberately instead of depending
+		// on that.
+		if out, err := exec.Command("launchctl", "kickstart", "-p", "gui/"+uid+"/"+launchdLabel).CombinedOutput(); err != nil {
+			return fmt.Errorf("launchctl kickstart failed: %v: %s", err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	}

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -94,6 +94,7 @@ func renderUnitFor(goos string, p servicePaths) string {
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ThrottleInterval</key><integer>10</integer>
+  <key>AbctlVersion</key><string>` + xmlStr(version) + `</string>
   <key>StandardOutPath</key><string>` + xmlStr(p.logFile) + `</string>
   <key>StandardErrorPath</key><string>` + xmlStr(p.logFile) + `</string>
   <key>ProcessType</key><string>Background</string>
@@ -112,6 +113,7 @@ func renderUnitFor(goos string, p servicePaths) string {
 	return `[Unit]
 Description=Cortex local proxy (authbridge-proxy)
 Documentation=https://github.com/rossoctl/cortex
+X-AbctlVersion=` + version + `
 StartLimitIntervalSec=300
 StartLimitBurst=5
 
@@ -131,6 +133,10 @@ WantedBy=default.target
 func loadService(p servicePaths) error {
 	if runtime.GOOS == "darwin" {
 		uid := strconv.Itoa(os.Getuid())
+		// Clear any disable left by `service stop`: a disabled label cannot be
+		// bootstrapped, so without this a stop would make every later start and
+		// install fail for a reason nothing on screen explains.
+		_ = exec.Command("launchctl", "enable", "gui/"+uid+"/"+launchdLabel).Run() //nolint:errcheck
 		// bootout first so a reinstall replaces cleanly; ignore its error, the
 		// service may not be loaded at all.
 		_ = exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchdLabel).Run() //nolint:errcheck
@@ -313,15 +319,25 @@ func controlService(action string, p servicePaths) error {
 		target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + launchdLabel
 		switch action {
 		case "stop":
-			// `launchctl stop` is undone by KeepAlive. bootout removes the job from
-			// the domain, which is the only stop that sticks; start re-bootstraps.
+			// Two steps, because either alone is not a stop.
+			//
+			// `launchctl stop` is undone by KeepAlive within seconds. bootout removes
+			// the job from the running domain — but the plist stays in
+			// ~/Library/LaunchAgents, which launchd bootstraps again at next login, and
+			// RunAtLoad then starts Cortex right back up. A "stop" that quietly undoes
+			// itself when you log in is worse than no stop command, so pair it with
+			// launchctl disable, which persists in the per-user disabled database.
 			out, err := exec.Command("launchctl", "bootout", target).CombinedOutput()
 			if err != nil && !strings.Contains(string(out), "No such process") {
 				return fmt.Errorf("launchctl bootout: %v: %s", err, strings.TrimSpace(string(out)))
 			}
+			if out, derr := exec.Command("launchctl", "disable", target).CombinedOutput(); derr != nil {
+				return fmt.Errorf("launchctl disable (stop would not survive a login): %v: %s",
+					derr, strings.TrimSpace(string(out)))
+			}
 			return nil
 		case "start":
-			return loadService(p)
+			return loadService(p) // loadService clears the disable
 		default: // restart
 			_ = exec.Command("launchctl", "bootout", target).Run() //nolint:errcheck
 			return loadService(p)
@@ -330,8 +346,18 @@ func controlService(action string, p servicePaths) error {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return fmt.Errorf("systemctl not found; this system has no systemd")
 	}
-	if out, err := exec.Command("systemctl", "--user", action, systemdUnit).CombinedOutput(); err != nil {
-		return fmt.Errorf("systemctl --user %s %s: %v: %s", action, systemdUnit, err, strings.TrimSpace(string(out)))
+	// `systemctl --user stop` leaves the unit ENABLED, so it comes back at the next
+	// boot exactly as launchd's plist does. Use the persistent forms for stop/start so
+	// both platforms mean the same thing by those words; restart stays transient.
+	args := []string{"--user", action, systemdUnit}
+	switch action {
+	case "stop":
+		args = []string{"--user", "disable", "--now", systemdUnit}
+	case "start":
+		args = []string{"--user", "enable", "--now", systemdUnit}
+	}
+	if out, err := exec.Command("systemctl", args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl %s: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }
@@ -364,4 +390,91 @@ func supervisorRunning(p servicePaths) (bool, string) {
 		return false, "systemctl is-active gave no answer"
 	}
 	return st == "active", "is-active = " + st
+}
+
+// establishedConns counts live TCP connections to addr's port, best-effort.
+//
+// Stopping the proxy cannot be made graceful from this side: HTTPS_PROXY is baked
+// into each Claude Code process's environment at startup, so a running session has
+// no way to fall back to a direct connection and `claude-code disable` cannot reach
+// it. The stop therefore breaks every in-flight session, and the failure surfaces as
+// a bare CURLE_COULDNT_CONNECT that looks like a Cortex bug. Naming the number of
+// attached clients first turns that into a five-second diagnosis.
+//
+// Returns -1 when it cannot tell (no lsof), so the caller can stay silent rather
+// than claim zero.
+func establishedConns(addr string) int {
+	if addr == "" {
+		return -1
+	}
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return -1
+	}
+	if _, err := exec.LookPath("lsof"); err != nil {
+		return -1
+	}
+	out, err := exec.Command("lsof", "-nP", "-iTCP:"+port, "-sTCP:ESTABLISHED").Output()
+	if err != nil {
+		// lsof exits 1 with no output when nothing matches, which is a real zero.
+		if len(out) == 0 {
+			return 0
+		}
+		return -1
+	}
+	n := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" || strings.HasPrefix(line, "COMMAND") {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// rotateLog keeps one previous generation once the log passes maxBytes.
+//
+// One unrotated file on a permanently-on service is a slow leak on its own — the
+// proxy logs a line per inference request and response — and a fatal config error
+// turns it into a fast one: unconditional KeepAlive with ThrottleInterval 10 means
+// roughly six restarts a minute, each writing its startup banner. Rotating at
+// start-of-run bounds exactly that case, because every one of those restarts passes
+// through here.
+func rotateLog(path string, maxBytes int64) {
+	fi, err := os.Stat(path)
+	if err != nil || fi.Size() <= maxBytes {
+		return
+	}
+	// Rename, not truncate: the supervisor opens the path per spawn, so the next
+	// start gets a fresh file while anything still holding the old inode keeps
+	// writing there harmlessly.
+	_ = os.Rename(path, path+".1") //nolint:errcheck
+}
+
+// unitWriterVersion reports which abctl wrote the installed unit, or "" if it
+// carries no stamp (written before stamping existed).
+//
+// The unit outlives the tool that manages it. A newer build can write a plist while
+// an older abctl stays on PATH, and that older one answers `service status` with
+// "unknown subcommand" — so the launchd artifact is live and unmanageable, with no
+// hint anywhere that the two disagree. Observed on a real machine.
+func unitWriterVersion(unitFile string) string {
+	b, err := os.ReadFile(unitFile) //nolint:gosec // path we wrote
+	if err != nil {
+		return ""
+	}
+	body := string(b)
+	for _, marker := range []string{"<key>AbctlVersion</key><string>", "X-AbctlVersion="} {
+		i := strings.Index(body, marker)
+		if i < 0 {
+			continue
+		}
+		rest := body[i+len(marker):]
+		end := strings.IndexAny(rest, "<\n")
+		if end < 0 {
+			continue
+		}
+		return strings.TrimSpace(rest[:end])
+	}
+	return ""
 }

--- a/authbridge/cmd/abctl/cmd_service_recovery_test.go
+++ b/authbridge/cmd/abctl/cmd_service_recovery_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveServicePaths_SurvivesAMissingBinary: uninstall and status are what you
+// reach for when things are broken, including when the proxy binary is gone.
+// Refusing to resolve paths then would leave a loaded unit with no way to remove it.
+func TestResolveServicePaths_SurvivesAMissingBinary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", filepath.Join(home, "nowhere")) // no authbridge-proxy anywhere
+	cfgDir := filepath.Join(home, ".cortex")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(cfgDir, "config.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: proxy-sidecar\nlistener:\n  roles: [forward]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := resolveServicePaths(cfg, "")
+	if err != nil {
+		t.Fatalf("resolveServicePaths failed with no binary present: %v\n"+
+			"uninstall and status must still work in that state", err)
+	}
+	if p.unitFile == "" {
+		t.Error("no unit path resolved, so uninstall would have nothing to remove")
+	}
+}
+
+// TestServiceInstall_RefusesABrokenConfig: without this, install writes the unit,
+// gets an empty healthURL, skips the probe, and calls a proxy that cannot start
+// "running".
+func TestServiceInstall_RefusesABrokenConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgDir := filepath.Join(home, ".cortex")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(cfgDir, "config.yaml")
+	// Invalid YAML: an unterminated flow sequence.
+	if err := os.WriteFile(cfg, []byte("listener:\n  roles: [forward\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A binary that exists, so this isolates the config check.
+	bin := filepath.Join(home, "authbridge-proxy")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+
+	p, err := resolveServicePaths(cfg, filepath.Join(home, "unit"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.binary = bin
+	if p.configErr == nil {
+		t.Fatal("an invalid config did not record a load error")
+	}
+
+	var out, errOut bytes.Buffer
+	if code := serviceInstall(p, true, &out, &errOut); code == 0 {
+		t.Error("install succeeded on a config that cannot load")
+	}
+	if !strings.Contains(errOut.String(), "will not load") {
+		t.Errorf("the reason was not reported: %s", errOut.String())
+	}
+	if _, serr := os.Stat(p.unitFile); serr == nil {
+		t.Error("a unit was written for a config that cannot load")
+	}
+}

--- a/authbridge/cmd/abctl/cmd_service_recovery_test.go
+++ b/authbridge/cmd/abctl/cmd_service_recovery_test.go
@@ -24,7 +24,7 @@ func TestResolveServicePaths_SurvivesAMissingBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := resolveServicePaths(cfg, "")
+	p, err := resolveServicePaths(cfg, "", "")
 	if err != nil {
 		t.Fatalf("resolveServicePaths failed with no binary present: %v\n"+
 			"uninstall and status must still work in that state", err)
@@ -55,7 +55,7 @@ func TestServiceInstall_RefusesABrokenConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p, err := resolveServicePaths(cfg, filepath.Join(home, "unit"))
+	p, err := resolveServicePaths(cfg, filepath.Join(home, "unit"), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/authbridge/cmd/abctl/cmd_service_test.go
+++ b/authbridge/cmd/abctl/cmd_service_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func servicePathsFixture(t *testing.T) servicePaths {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "authbridge-proxy")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return servicePaths{
+		unitFile:   filepath.Join(dir, "unit"),
+		binary:     bin,
+		configFile: filepath.Join(dir, "config.yaml"),
+		logFile:    filepath.Join(dir, "proxy.log"),
+		pidFile:    filepath.Join(dir, "proxy.pid"),
+		healthURL:  "http://127.0.0.1:1/healthz",
+		home:       dir,
+	}
+}
+
+// TestRenderUnit_BothPlatforms exercises the launchd and systemd renderings from
+// either host. Keying off runtime.GOOS meant the systemd unit was written on a Mac
+// and never checked until a Linux user hit it.
+func TestRenderUnit_BothPlatforms(t *testing.T) {
+	p := servicePathsFixture(t)
+
+	t.Run("darwin restarts on failure only", func(t *testing.T) {
+		// KeepAlive=true respawns even after a clean exit, so `launchctl stop` could
+		// never stick.
+		u := renderUnitFor("darwin", p)
+		if !strings.Contains(u, "<key>SuccessfulExit</key>") {
+			t.Error("KeepAlive is not scoped to failures")
+		}
+		if strings.Contains(u, "<key>KeepAlive</key><true/>") {
+			t.Error("unconditional KeepAlive")
+		}
+		if !strings.Contains(u, "ThrottleInterval") {
+			t.Error("no ThrottleInterval; a bad config would respawn tightly")
+		}
+		if !strings.Contains(u, "<key>HOME</key>") || !strings.Contains(u, p.home) {
+			t.Error("HOME not set; the config's ${HOME} would not expand")
+		}
+		if !strings.Contains(u, "<key>RunAtLoad</key><true/>") {
+			t.Error("does not start at login")
+		}
+	})
+
+	t.Run("linux restarts on failure only", func(t *testing.T) {
+		u := renderUnitFor("linux", p)
+		if !strings.Contains(u, "Restart=on-failure") {
+			t.Errorf("not on-failure:\n%s", u)
+		}
+		if strings.Contains(u, "Restart=always") {
+			t.Error("Restart=always; a stop could never stick")
+		}
+		for _, want := range []string{
+			"[Unit]", "[Service]", "[Install]",
+			"ExecStart=", "RestartSec=", "StartLimitBurst=",
+			"WantedBy=default.target",
+			"append:" + p.logFile, // restarts must not truncate the evidence
+		} {
+			if !strings.Contains(u, want) {
+				t.Errorf("unit missing %q:\n%s", want, u)
+			}
+		}
+		// StartLimit* must sit in [Unit]. systemd moved them there in v229 and
+		// deprecated them in [Service], where they can be ignored outright —
+		// silently voiding the crash-loop throttle.
+		unitSec := u[strings.Index(u, "[Unit]"):strings.Index(u, "[Service]")]
+		for _, want := range []string{"StartLimitIntervalSec=", "StartLimitBurst="} {
+			if !strings.Contains(unitSec, want) {
+				t.Errorf("%s is not in the [Unit] section:\n%s", want, u)
+			}
+		}
+		// A user manager has no network-online.target; ordering against it would be
+		// a dependency that never resolves, and every listener here is loopback.
+		if strings.Contains(u, "network-online.target") {
+			t.Error("user unit orders against network-online.target")
+		}
+		// One ExecStart, and it names absolute paths — a unit has no shell PATH.
+		if n := strings.Count(u, "ExecStart="); n != 1 {
+			t.Errorf("ExecStart appears %d times, want 1", n)
+		}
+		if !strings.Contains(u, p.binary+" --config "+p.configFile) {
+			t.Errorf("ExecStart does not invoke absolute paths:\n%s", u)
+		}
+	})
+
+	t.Run("both name the same log file", func(t *testing.T) {
+		for _, goos := range []string{"darwin", "linux"} {
+			if !strings.Contains(renderUnitFor(goos, p), p.logFile) {
+				t.Errorf("%s unit does not log to %s", goos, p.logFile)
+			}
+		}
+	})
+
+	t.Run("systemd unit has no unescaped newline hazards", func(t *testing.T) {
+		// A stray blank key or a value spanning lines makes systemd reject the unit
+		// at daemon-reload, which surfaces only as a non-zero exit.
+		for _, line := range strings.Split(renderUnitFor("linux", p), "\n") {
+			l := strings.TrimSpace(line)
+			if l == "" || strings.HasPrefix(l, "#") || strings.HasPrefix(l, "[") {
+				continue
+			}
+			if !strings.Contains(l, "=") {
+				t.Errorf("unit line is neither section, comment nor key=value: %q", l)
+			}
+		}
+	})
+}
+
+// TestRenderedPlistIsValid runs plutil, so a malformed plist cannot ship: launchd
+// would reject it at bootstrap and the user would see a bare exit status.
+func TestRenderedPlistIsValid(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("plutil is macOS-only")
+	}
+	if _, err := exec.LookPath("plutil"); err != nil {
+		t.Skip("plutil not available")
+	}
+	p := servicePathsFixture(t)
+	path := filepath.Join(t.TempDir(), "t.plist")
+	if err := os.WriteFile(path, []byte(renderUnit(p)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("plutil", "-lint", path).CombinedOutput(); err != nil {
+		t.Errorf("plutil rejected the plist: %v\n%s\n%s", err, out, renderUnit(p))
+	}
+}
+
+// TestRunningPID_OnlyClaimsOurOwnProcess: the pidfile can name a recycled pid, and
+// install stops whatever it reports. Stopping a stranger's process would be the
+// worst possible bug in this command.
+func TestRunningPID_OnlyClaimsOurOwnProcess(t *testing.T) {
+	dir := t.TempDir()
+	pf := filepath.Join(dir, "proxy.pid")
+
+	// No file.
+	if got := runningPID(pf); got != 0 {
+		t.Errorf("absent pidfile -> %d, want 0", got)
+	}
+	// Garbage.
+	_ = os.WriteFile(pf, []byte("not-a-pid\n"), 0o600)
+	if got := runningPID(pf); got != 0 {
+		t.Errorf("garbage pidfile -> %d, want 0", got)
+	}
+	// A live pid that is NOT authbridge-proxy: this process.
+	_ = os.WriteFile(pf, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600)
+	if got := runningPID(pf); got != 0 {
+		t.Errorf("pid of a foreign process -> %d, want 0 (it is not ours)", got)
+	}
+	// A pid that is not running at all.
+	_ = os.WriteFile(pf, []byte("999999\n"), 0o600)
+	if got := runningPID(pf); got != 0 {
+		t.Errorf("dead pid -> %d, want 0", got)
+	}
+}
+
+// TestDialableAddr covers the bind-vs-dial distinction the health probe depends
+// on: ":9091" is not something a client can connect to.
+func TestDialableAddr(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"127.0.0.1:47604", "127.0.0.1:47604"},
+		{":47604", "localhost:47604"},
+		{"0.0.0.0:47604", "localhost:47604"},
+		{"[::]:47604", "localhost:47604"},
+		{"[::1]:47604", "[::1]:47604"},
+	} {
+		if got := dialableAddr(tc.in); got != tc.want {
+			t.Errorf("dialableAddr(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestServiceStatus_NamesTheUnsupervisedCase is the diagnostic that matters most:
+// a hand-started proxy works until the next reboot, and nothing says so.
+func TestServiceStatus_NamesTheUnsupervisedCase(t *testing.T) {
+	p := servicePathsFixture(t)
+	var out bytes.Buffer
+	if code := serviceStatus(p, &out); code != 0 {
+		t.Errorf("exit = %d, want 0 when not installed", code)
+	}
+	if !strings.Contains(out.String(), "not installed") {
+		t.Errorf("status did not say it is uninstalled: %q", out.String())
+	}
+
+	// With a live proxy of ours in the pidfile it should say nothing restarts it.
+	cmd := exec.Command(p.binary) // the fixture's sleep script
+	if err := cmd.Start(); err != nil {
+		t.Skip("cannot start the fixture process")
+	}
+	defer func() { _ = cmd.Process.Kill() }()
+	_ = os.WriteFile(p.pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)
+	// The fixture is not named authbridge-prox, so runningPID rejects it — which is
+	// itself the property TestRunningPID covers. Assert the uninstalled branch only.
+	out.Reset()
+	_ = serviceStatus(p, &out)
+	if !strings.Contains(out.String(), "not installed") {
+		t.Errorf("unexpected status output: %q", out.String())
+	}
+}
+
+// TestWaitHealthy_TimesOut: install claims success only after the health endpoint
+// answers, because a supervisor reports "loaded" for a proxy that is crash-looping.
+func TestWaitHealthy_TimesOut(t *testing.T) {
+	start := time.Now()
+	if waitHealthy("http://127.0.0.1:1/healthz", 1200*time.Millisecond) {
+		t.Error("reported healthy against a closed port")
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
+		t.Errorf("returned after %s; it should have used the timeout", elapsed)
+	}
+}
+
+// TestLastLines_SurfacesTheReason: "installed but not answering" is useless
+// without the log tail that says why.
+func TestLastLines_SurfacesTheReason(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "proxy.log")
+	_ = os.WriteFile(p, []byte("one\ntwo\nthree\nfour\n"), 0o600)
+	got := lastLines(p, 2)
+	if len(got) != 2 || got[0] != "three" || got[1] != "four" {
+		t.Errorf("lastLines = %v, want [three four]", got)
+	}
+	if msg := lastLines(filepath.Join(dir, "nope.log"), 3); len(msg) != 1 || !strings.Contains(msg[0], "no log") {
+		t.Errorf("missing log should say so, got %v", msg)
+	}
+}

--- a/authbridge/cmd/abctl/cmd_service_test.go
+++ b/authbridge/cmd/abctl/cmd_service_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/xml"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,8 +97,10 @@ func TestRenderUnit_BothPlatforms(t *testing.T) {
 		if n := strings.Count(u, "ExecStart="); n != 1 {
 			t.Errorf("ExecStart appears %d times, want 1", n)
 		}
-		if !strings.Contains(u, p.binary+" --config "+p.configFile) {
-			t.Errorf("ExecStart does not invoke absolute paths:\n%s", u)
+		// Quoted: systemd splits ExecStart on whitespace, so a $HOME with a space in
+		// it would otherwise become two wrong arguments.
+		if !strings.Contains(u, "'"+p.binary+"' --config '"+p.configFile+"'") {
+			t.Errorf("ExecStart does not invoke quoted absolute paths:\n%s", u)
 		}
 	})
 
@@ -240,4 +243,64 @@ func TestLastLines_SurfacesTheReason(t *testing.T) {
 	if msg := lastLines(filepath.Join(dir, "nope.log"), 3); len(msg) != 1 || !strings.Contains(msg[0], "no log") {
 		t.Errorf("missing log should say so, got %v", msg)
 	}
+}
+
+// TestRenderUnit_HostilePaths covers what a real $HOME can contain. Both renderings
+// interpolate user-supplied paths: an unescaped "&" makes the plist malformed XML
+// that launchctl bootstrap rejects, and an unquoted space splits systemd's ExecStart
+// into the wrong arguments.
+func TestRenderUnit_HostilePaths(t *testing.T) {
+	p := servicePaths{
+		binary:     "/Users/a & b/.local/bin/authbridge-proxy",
+		configFile: "/Users/a & b/.cortex/my config.yaml",
+		logFile:    "/Users/a & b/.cortex/proxy.log",
+		home:       "/Users/a & b",
+	}
+
+	t.Run("plist stays well-formed XML", func(t *testing.T) {
+		u := renderUnitFor("darwin", p)
+		if strings.Contains(u, "a & b") {
+			t.Error("raw & left in the plist; launchctl bootstrap would reject it")
+		}
+		if !strings.Contains(u, "a &amp; b") {
+			t.Errorf("& not escaped:\n%s", u)
+		}
+		var v any
+		if err := xml.Unmarshal([]byte(u), &v); err != nil {
+			t.Errorf("rendered plist is not well-formed XML: %v", err)
+		}
+	})
+
+	t.Run("systemd ExecStart keeps the path as one argument", func(t *testing.T) {
+		u := renderUnitFor("linux", p)
+		var execLine string
+		for _, l := range strings.Split(u, "\n") {
+			if strings.HasPrefix(l, "ExecStart=") {
+				execLine = l
+			}
+		}
+		if execLine == "" {
+			t.Fatal("no ExecStart line")
+		}
+		// Both paths must be quoted, or the spaces split them.
+		if !strings.Contains(execLine, "'"+p.binary+"'") {
+			t.Errorf("binary not quoted: %s", execLine)
+		}
+		if !strings.Contains(execLine, "'"+p.configFile+"'") {
+			t.Errorf("config path not quoted: %s", execLine)
+		}
+	})
+
+	t.Run("a single quote in the path cannot break out", func(t *testing.T) {
+		q := servicePaths{
+			binary:     "/home/o'brien/bin/authbridge-proxy",
+			configFile: "/home/o'brien/.cortex/config.yaml",
+			logFile:    "/home/o'brien/.cortex/proxy.log",
+			home:       "/home/o'brien",
+		}
+		u := renderUnitFor("linux", q)
+		if strings.Contains(u, "ExecStart='/home/o'brien") {
+			t.Errorf("quote not neutralised, ExecStart is breakable:\n%s", u)
+		}
+	})
 }

--- a/authbridge/cmd/abctl/cmd_service_test.go
+++ b/authbridge/cmd/abctl/cmd_service_test.go
@@ -304,3 +304,28 @@ func TestRenderUnit_HostilePaths(t *testing.T) {
 		}
 	})
 }
+
+// TestSupervisionIsPlatformCorrect: launchd does not restart these agents, so the
+// plist must run the proxy under --supervise; systemd does, and nesting a supervisor
+// there would hide crashes from its StartLimit accounting.
+func TestSupervisionIsPlatformCorrect(t *testing.T) {
+	p := servicePaths{
+		binary: "/u/bin/authbridge-proxy", configFile: "/u/.cortex/config.yaml",
+		logFile: "/u/.cortex/proxy.log", home: "/u",
+	}
+	darwin := renderUnitFor("darwin", p)
+	if !strings.Contains(darwin, "<string>--supervise</string>") {
+		t.Error("the plist does not supervise; a crash would go unrecovered on macOS")
+	}
+	// The supervise flag must come before --config, as a flag not a config value.
+	if i, j := strings.Index(darwin, "--supervise"), strings.Index(darwin, "--config"); i < 0 || j < 0 || i > j {
+		t.Errorf("--supervise is not ordered before --config (%d vs %d)", i, j)
+	}
+	linux := renderUnitFor("linux", p)
+	if strings.Contains(linux, "--supervise") {
+		t.Error("systemd unit nests a supervisor; Restart=on-failure already does this")
+	}
+	if !strings.Contains(linux, "Restart=on-failure") {
+		t.Error("systemd unit lost its own restart policy")
+	}
+}

--- a/authbridge/cmd/abctl/cmd_service_test.go
+++ b/authbridge/cmd/abctl/cmd_service_test.go
@@ -36,15 +36,18 @@ func servicePathsFixture(t *testing.T) servicePaths {
 func TestRenderUnit_BothPlatforms(t *testing.T) {
 	p := servicePathsFixture(t)
 
-	t.Run("darwin restarts on failure only", func(t *testing.T) {
-		// KeepAlive=true respawns even after a clean exit, so `launchctl stop` could
-		// never stick.
+	t.Run("darwin restarts after a crash", func(t *testing.T) {
+		// Unconditional KeepAlive on purpose: it is the simpler guarantee for the
+		// requirement that matters — come back after a crash — and costs nothing,
+		// because stopping deliberately is what `service uninstall` is for.
+		// {SuccessfulExit:false} is documented in terms of exit STATUS, which leaves
+		// its behaviour on death by signal ambiguous.
 		u := renderUnitFor("darwin", p)
-		if !strings.Contains(u, "<key>SuccessfulExit</key>") {
-			t.Error("KeepAlive is not scoped to failures")
+		if !strings.Contains(u, "<key>KeepAlive</key><true/>") {
+			t.Error("KeepAlive is not unconditional; a kill -9 would not be restarted")
 		}
-		if strings.Contains(u, "<key>KeepAlive</key><true/>") {
-			t.Error("unconditional KeepAlive")
+		if strings.Contains(u, "SuccessfulExit") {
+			t.Error("KeepAlive is conditioned on exit status, which signal death does not satisfy")
 		}
 		if !strings.Contains(u, "ThrottleInterval") {
 			t.Error("no ThrottleInterval; a bad config would respawn tightly")

--- a/authbridge/cmd/abctl/edit/templates_test.go
+++ b/authbridge/cmd/abctl/edit/templates_test.go
@@ -40,7 +40,7 @@ func TestRenderTemplates_PluginWithFields(t *testing.T) {
 				{Name: "timeout_ms", Type: "int", Default: "5000",
 					Description: "Per-call timeout."},
 				{Name: "unclassified_policy", Type: "string", Default: "passthrough",
-					Enum: []string{"passthrough", "judge"},
+					Enum:        []string{"passthrough", "judge"},
 					Description: "Behavior when no parser claimed the request."},
 			},
 		},

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -83,7 +83,7 @@ func main() {
 			// someone who has never wanted a cluster.
 			if local != "" && !dialable(local) {
 				msg = "abctl: nothing is listening on " + local + " (from ~/.cortex/config.yaml).\n" +
-					"  Start it:  authbridge-proxy --config ~/.cortex/config.yaml &\n" +
+					"  Start it:  abctl service start   (or: abctl service install)\n" +
 					"  Or pass --endpoint http://... , or install kubectl to browse a cluster."
 			}
 			fmt.Fprintln(os.Stderr, msg)

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -43,6 +43,26 @@ func main() {
 		}
 	}
 
+	// Without this, `abctl --help` printed only -endpoint and -version, so the
+	// subcommands were invisible to anyone who asked the tool what it could do — the
+	// service commands most of all, since those are what you need when Cortex is down.
+	flag.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), `abctl — inspect and run Cortex
+
+Usage:
+  abctl                      open the traffic viewer (TUI)
+  abctl service <action>     run Cortex as a service: install, uninstall,
+                             status, stop, start, restart
+  abctl claude-code <action> point Claude Code at Cortex: enable, disable, status
+  abctl tools <action>       tool-definition costs: scan
+
+Run a subcommand with no action, or with --help, for its own usage.
+
+Flags:
+`)
+		flag.PrintDefaults()
+	}
+
 	endpoint := flag.String("endpoint", "",
 		"AuthBridge session API URL (e.g. http://localhost:9094). When omitted, abctl connects to the Cortex on this machine if one is running, otherwise it opens a Namespaces → Pods picker.")
 	showVersion := flag.Bool("version", false, "print version and exit")

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -35,8 +35,10 @@ func main() {
 			os.Exit(runTools(os.Args[2:], os.Stdout, os.Stderr))
 		case "claude-code":
 			os.Exit(runClaudeCode(os.Args[2:], os.Stdout, os.Stderr))
+		case "service":
+			os.Exit(runService(os.Args[2:], os.Stdout, os.Stderr))
 		default:
-			fmt.Fprintf(os.Stderr, "abctl: unknown subcommand %q (known: tools, claude-code)\n", os.Args[1])
+			fmt.Fprintf(os.Stderr, "abctl: unknown subcommand %q (known: tools, claude-code, service)\n", os.Args[1])
 			os.Exit(2)
 		}
 	}

--- a/authbridge/cmd/abctl/tui/json_colorize.go
+++ b/authbridge/cmd/abctl/tui/json_colorize.go
@@ -17,12 +17,12 @@ import (
 // another, numbers/booleans/null each distinct so the eye can scan a dense
 // payload quickly.
 var (
-	styleJSONKey     = lipgloss.NewStyle().Foreground(colorAccent)
-	styleJSONString  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#047857", Dark: "#6EE7B7"})
-	styleJSONNumber  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B45309", Dark: "#FCD34D"})
-	styleJSONBool    = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B91C1C", Dark: "#FCA5A5"})
-	styleJSONNull    = lipgloss.NewStyle().Foreground(colorMuted).Italic(true)
-	styleJSONPunct   = lipgloss.NewStyle().Foreground(colorMuted)
+	styleJSONKey    = lipgloss.NewStyle().Foreground(colorAccent)
+	styleJSONString = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#047857", Dark: "#6EE7B7"})
+	styleJSONNumber = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B45309", Dark: "#FCD34D"})
+	styleJSONBool   = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#B91C1C", Dark: "#FCA5A5"})
+	styleJSONNull   = lipgloss.NewStyle().Foreground(colorMuted).Italic(true)
+	styleJSONPunct  = lipgloss.NewStyle().Foreground(colorMuted)
 )
 
 // ColorizeJSON takes a Go value (typically something decoded from json) and

--- a/authbridge/cmd/abctl/tui/styles.go
+++ b/authbridge/cmd/abctl/tui/styles.go
@@ -10,13 +10,13 @@ import (
 // file edit. Colors are chosen to render legibly on both light and dark
 // terminals (Bubble Tea's ANSI adaptive palette) — avoid 24-bit colors here.
 var (
-	colorAccent    = lipgloss.AdaptiveColor{Light: "#4F46E5", Dark: "#A5B4FC"}
-	colorOK        = lipgloss.AdaptiveColor{Light: "#047857", Dark: "#6EE7B7"}
-	colorWarn      = lipgloss.AdaptiveColor{Light: "#92400E", Dark: "#FCD34D"}
-	colorError     = lipgloss.AdaptiveColor{Light: "#B91C1C", Dark: "#FCA5A5"}
-	colorMuted     = lipgloss.AdaptiveColor{Light: "#6B7280", Dark: "#9CA3AF"}
-	colorInbound   = lipgloss.AdaptiveColor{Light: "#1D4ED8", Dark: "#93C5FD"}
-	colorOutbound  = lipgloss.AdaptiveColor{Light: "#B45309", Dark: "#FCD34D"}
+	colorAccent   = lipgloss.AdaptiveColor{Light: "#4F46E5", Dark: "#A5B4FC"}
+	colorOK       = lipgloss.AdaptiveColor{Light: "#047857", Dark: "#6EE7B7"}
+	colorWarn     = lipgloss.AdaptiveColor{Light: "#92400E", Dark: "#FCD34D"}
+	colorError    = lipgloss.AdaptiveColor{Light: "#B91C1C", Dark: "#FCA5A5"}
+	colorMuted    = lipgloss.AdaptiveColor{Light: "#6B7280", Dark: "#9CA3AF"}
+	colorInbound  = lipgloss.AdaptiveColor{Light: "#1D4ED8", Dark: "#93C5FD"}
+	colorOutbound = lipgloss.AdaptiveColor{Light: "#B45309", Dark: "#FCD34D"}
 )
 
 var (

--- a/authbridge/cmd/authbridge-proxy/local.go
+++ b/authbridge/cmd/authbridge-proxy/local.go
@@ -79,6 +79,11 @@ func builtinConfigYAML(caDir string) string {
 mode: proxy-sidecar
 listener:
   roles: [forward]
+  # Every listener binds 127.0.0.1, including any this file does not name. The
+  # explicit ports below pick a non-colliding range; this line is what makes an
+  # unnamed or newly added listener safe on a laptop, where a wildcard bind means
+  # the Wi-Fi.
+  bind_loopback_only: true
   forward_proxy_addr: 127.0.0.1:47600
   session_api_addr: 127.0.0.1:47601
   # Without this the preset defaults health to ":9091" — every interface, and a
@@ -150,6 +155,18 @@ func writeBuiltinConfig(cortexDir, caDir string) (string, error) {
 	if err := os.Chmod(cortexDir, 0o700); err != nil {
 		return "", err
 	}
+	// Same reasoning one level down. tlsbridge creates caDir 0700, but MkdirAll does
+	// not tighten an existing directory, so a caDir left at 0755 by an earlier build
+	// stays 0755 while holding the CA's private key. The key file itself is 0600, so
+	// this is defence in depth rather than the only guard — but it should not be the
+	// parent's mode alone standing between a MITM CA key and every process on the
+	// machine. Only when it already exists: letting tlsbridge create it keeps the
+	// Kubernetes case (a mounted ca_dir, deliberately left alone) untouched.
+	if fi, err := os.Stat(caDir); err == nil && fi.IsDir() {
+		if err := os.Chmod(caDir, 0o700); err != nil {
+			return "", err
+		}
+	}
 	path := filepath.Join(cortexDir, localConfigName)
 	if _, err := os.Stat(path); err == nil {
 		slog.Info("local mode — keeping the existing config (edits and any prune list are preserved)",
@@ -158,7 +175,10 @@ func writeBuiltinConfig(cortexDir, caDir string) (string, error) {
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", err
 	}
-	if err := os.WriteFile(path, []byte(builtinConfigYAML(caDir)), 0o644); err != nil {
+	// 0600, not 0644: it names the CA's location and the whole listener layout, and
+	// abctl's migration already rewrites it 0600 — a fresh install should not be the
+	// looser of the two.
+	if err := os.WriteFile(path, []byte(builtinConfigYAML(caDir)), 0o600); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -129,6 +129,8 @@ func main() {
 	// listed as a deprecated alias rather than hidden: an empty usage string
 	// still prints the flag, just with a blank description that reads like a bug.
 	demoDeprecated := flag.Bool("demo", false, "deprecated alias for -local")
+	writeConfigOnly := flag.Bool("write-config", false,
+		"with -local: create the built-in config (and its directory) if absent, then exit")
 	caDir := flag.String("ca-dir", "",
 		"CA directory for --local (auto-generated); defaults to ~/"+cortexDirName+"/"+caDirName)
 	flag.Parse()
@@ -186,10 +188,22 @@ func main() {
 			log.Fatalf("--local: %v", werr)
 		}
 		*configPath = p
+		// install.sh needs the config materialised without starting anything: it hands
+		// the proxy to the OS supervisor, which then starts it. Writing the config was
+		// previously a side effect of starting --local, so removing that start removed
+		// the only thing that ever created the file — a fresh install then had nothing
+		// for `abctl service install` to load. Exiting here keeps one source of truth
+		// for the built-in config instead of teaching abctl to write it too.
+		if *writeConfigOnly {
+			slog.Info("wrote the built-in config; not starting", "config", p, "ca_dir", absCA)
+			return
+		}
 		slog.Info("local mode — using the built-in config; edit it to hot-reload",
 			"config", p, "ca_dir", absCA)
 	} else if *caDir != "" {
 		log.Fatal("--ca-dir only applies with --local")
+	} else if *writeConfigOnly {
+		log.Fatal("--write-config only applies with --local")
 	}
 
 	if *configPath == "" {

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -129,11 +129,20 @@ func main() {
 	// listed as a deprecated alias rather than hidden: an empty usage string
 	// still prints the flag, just with a blank description that reads like a bug.
 	demoDeprecated := flag.Bool("demo", false, "deprecated alias for -local")
+	supervise := flag.Bool("supervise", false,
+		"restart the proxy if it exits (launchd cannot be relied on for this; see supervise.go)")
 	writeConfigOnly := flag.Bool("write-config", false,
 		"with -local: create the built-in config (and its directory) if absent, then exit")
 	caDir := flag.String("ca-dir", "",
 		"CA directory for --local (auto-generated); defaults to ~/"+cortexDirName+"/"+caDirName)
 	flag.Parse()
+	if *supervise {
+		// Before anything binds: this process starts a child that does the real work.
+		if err := runSupervisor("supervise"); err != nil {
+			log.Fatalf("supervise: %v", err)
+		}
+		return
+	}
 
 	if *showVersion {
 		fmt.Println("authbridge-proxy", version)

--- a/authbridge/cmd/authbridge-proxy/supervise.go
+++ b/authbridge/cmd/authbridge-proxy/supervise.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"slices"
+	"syscall"
+	"time"
+)
+
+// Supervision exists because launchd cannot be relied on for it.
+//
+// Measured on macOS 26.5.2, in a gui/<uid> domain with an active Aqua session, for
+// an agent bootstrapped mid-session: launchd logs "pending spawn, domain in
+// on-demand-only mode" and then honours NOTHING that would restart the process —
+// KeepAlive=true, KeepAlive={SuccessfulExit:false}, StartInterval, and RunAtLoad all
+// fail to fire, via both `launchctl bootstrap` and legacy `launchctl load -w`, with
+// and without ProcessType, with the executable approved in Login Items. Bootstrapping
+// into user/<uid> instead is refused outright. Only an explicit `launchctl kickstart`
+// starts the job.
+//
+// So the process that restarts the proxy has to be one launchd already started. This
+// is that process: launchd starts the supervisor (at login, which does work, or via
+// kickstart at install), and the supervisor restarts the proxy for as long as it
+// lives. A crash of the proxy — the failure this feature is for — is then covered
+// without depending on launchd's autonomous spawn at all.
+//
+// What this does NOT cover: the supervisor itself being killed. Nothing restarts it
+// until the next login. That is a far narrower gap than every crash going unrecovered,
+// and it is stated rather than papered over.
+const (
+	// superviseRestartDelay is the pause after a child exits before starting another.
+	superviseRestartDelay = 2 * time.Second
+	// superviseMaxDelay caps the backoff when the child keeps dying immediately, so a
+	// config that cannot start does not spin.
+	superviseMaxDelay = 30 * time.Second
+	// superviseHealthyRun is how long a child must survive for its run to count as
+	// healthy, resetting the backoff.
+	superviseHealthyRun = 10 * time.Second
+)
+
+// runSupervisor re-executes this binary without the supervise flag and restarts it
+// whenever it exits, until the supervisor is asked to stop.
+func runSupervisor(flagName string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locating this binary: %w", err)
+	}
+	// Same arguments, minus the flag that got us here, so the child runs the proxy.
+	args := make([]string, 0, len(os.Args)-1)
+	for _, a := range os.Args[1:] {
+		if a == "-"+flagName || a == "--"+flagName {
+			continue
+		}
+		args = append(args, a)
+	}
+	if slices.Contains(args, "-"+flagName) || slices.Contains(args, "--"+flagName) {
+		return errors.New("internal: supervise flag survived argument filtering")
+	}
+
+	// Forward termination to the child so `launchctl bootout` / `systemctl stop`
+	// takes the whole tree down; otherwise the proxy is orphaned and keeps the ports,
+	// which would look exactly like the "stop that does not stop" this replaces.
+	stopping := make(chan os.Signal, 1)
+	signal.Notify(stopping, syscall.SIGTERM, syscall.SIGINT)
+
+	delay := superviseRestartDelay
+	for {
+		cmd := exec.Command(self, args...) //nolint:gosec // our own binary, filtered args
+		cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, nil
+		start := time.Now()
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("starting the proxy: %w", err)
+		}
+		slog.Info("supervisor: proxy started", "pid", cmd.Process.Pid)
+
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+
+		select {
+		case sig := <-stopping:
+			slog.Info("supervisor: stopping, forwarding signal to the proxy", "signal", sig.String())
+			_ = cmd.Process.Signal(syscall.SIGTERM) //nolint:errcheck
+			select {
+			case <-done:
+			case <-time.After(20 * time.Second):
+				// Longer than the proxy's own 15s shutdown deadline, then insist.
+				slog.Warn("supervisor: proxy did not exit in 20s; killing it")
+				_ = cmd.Process.Kill() //nolint:errcheck
+				<-done
+			}
+			return nil
+
+		case werr := <-done:
+			ran := time.Since(start)
+			if ran >= superviseHealthyRun {
+				delay = superviseRestartDelay // it was up long enough; forget the backoff
+			}
+			slog.Warn("supervisor: proxy exited; restarting",
+				"ran", ran.Round(time.Millisecond), "err", werr, "restart_in", delay)
+			select {
+			case sig := <-stopping:
+				slog.Info("supervisor: stopping instead of restarting", "signal", sig.String())
+				return nil
+			case <-time.After(delay):
+			}
+			if ran < superviseHealthyRun {
+				if delay *= 2; delay > superviseMaxDelay {
+					delay = superviseMaxDelay
+				}
+			}
+		}
+	}
+}

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -1,19 +1,58 @@
-# Turning Cortex off, and removing it
+# Running Cortex: start, stop, and remove it
 
-Two different things, so pick the one you want:
-
-- **Pause it** — stop Cortex, keep everything installed.
-- **Unwire Claude Code** — leave Cortex running, stop routing Claude Code through it.
-- **Remove it** — take it all off the machine.
-
-## Pause it
+Cortex runs as a service, so there is nothing to launch by hand and nothing to keep
+in a terminal. Everything below is `abctl service`; run it with no action to see the
+list.
 
 ```sh
-abctl service stop      # start / restart when you want it back
+abctl service status      # is it running, and is it answering?
+abctl service start       # start it
+abctl service stop        # stop it, and keep it stopped
+abctl service restart     # stop and start
+abctl service install     # set it up in the first place (the installer does this)
+abctl service uninstall   # stop it and remove the service
 ```
 
-The stop persists — Cortex stays down across logouts and reboots until you start it
-again.
+**Never use `kill` or `pkill`.** The proxy is supervised: killing it gets it restarted
+within a couple of seconds, which looks like a process refusing to die. `abctl service
+stop` is the stop that works.
+
+## Is it working?
+
+```sh
+abctl service status
+```
+
+`installed:` names the unit file, `healthy:` names the endpoint that answered. If it
+says `NOT answering`, the proxy is loaded but not serving — check `~/.cortex/proxy.log`.
+
+To see traffic rather than status, run `abctl` with no arguments.
+
+## Start and stop
+
+```sh
+abctl service start
+abctl service stop
+```
+
+A stop persists: Cortex stays down across logouts and reboots until you start it
+again. That is deliberate — a stop that quietly undoes itself at your next login is
+worse than none.
+
+`stop` also reports how many connections it cut, because a Claude Code session that is
+already running cannot recover on its own: `HTTPS_PROXY` is fixed in its environment
+when it starts, so it has no way to fall back to a direct connection. Restart any
+session that begins failing to connect.
+
+## Three ways to turn it off
+
+They are different, so pick deliberately:
+
+### Pause it
+
+```sh
+abctl service stop
+```
 
 Claude Code fails while Cortex is stopped, because its settings still point at the
 proxy. Either start Cortex again or unwire Claude Code (below).
@@ -27,7 +66,7 @@ connections it cut, for exactly this reason.
 Use `abctl service stop`, not `kill` or `pkill` — the supervisor restarts the
 process within seconds, which looks like it refusing to die.
 
-## Unwire Claude Code
+### Unwire Claude Code
 
 ```sh
 abctl claude-code disable
@@ -41,7 +80,7 @@ again. Restart `claude` to pick it up.
 Cortex keeps running; nothing sends traffic to it. `abctl claude-code enable` puts it
 back.
 
-## Remove it
+### Remove it
 
 ```sh
 abctl claude-code disable     # 1. unwire Claude Code
@@ -53,7 +92,7 @@ rm -f ~/.local/bin/abctl ~/.local/bin/authbridge-proxy
 Order matters for the first two: `claude-code disable` needs to read the config that
 step 3 deletes.
 
-### Check nothing is left
+#### Check nothing is left
 
 ```sh
 abctl claude-code status                    # should say "not enabled"
@@ -65,7 +104,7 @@ The CA that step 3 removes was only ever trusted through `NODE_EXTRA_CA_CERTS` i
 `~/.claude/settings.json` — Cortex never adds it to the system or login keychain, so
 there is nothing to clean up there.
 
-### If `abctl` is already gone
+#### If `abctl` is already gone
 
 The service can be removed by hand:
 

--- a/authbridge/docs/laptop-token-savings.md
+++ b/authbridge/docs/laptop-token-savings.md
@@ -130,6 +130,6 @@ client-side settings (`--allowedTools`, disabling unused MCP servers).
 
 ## Turning it off
 
-Empty the `remove:` list to stop pruning but keep watching traffic. To stop or
-remove Cortex entirely, see
-**[turning Cortex off, and removing it](./laptop-uninstall.md)**.
+Empty the `remove:` list to stop pruning but keep watching traffic. To start, stop
+or remove Cortex itself, see
+**[running Cortex](./laptop-service.md)**.

--- a/authbridge/docs/laptop-token-savings.md
+++ b/authbridge/docs/laptop-token-savings.md
@@ -126,4 +126,10 @@ client-side settings (`--allowedTools`, disabling unused MCP servers).
   transcript history for it to reason from yet.
 - **The proxy won't start** — read `~/.cortex/proxy.log`; a port conflict is logged
   at `ERROR`. Every listener is pinned to loopback on 47600–47604, so a clash
-  usually means Cortex is already running (`pkill -f authbridge-proxy`).
+  usually means Cortex is already running (`abctl service status`).
+
+## Turning it off
+
+Empty the `remove:` list to stop pruning but keep watching traffic. To stop or
+remove Cortex entirely, see
+**[turning Cortex off, and removing it](./laptop-uninstall.md)**.

--- a/authbridge/docs/laptop-uninstall.md
+++ b/authbridge/docs/laptop-uninstall.md
@@ -1,0 +1,74 @@
+# Turning Cortex off, and removing it
+
+Two different things, so pick the one you want:
+
+- **Pause it** — stop Cortex, keep everything installed.
+- **Unwire Claude Code** — leave Cortex running, stop routing Claude Code through it.
+- **Remove it** — take it all off the machine.
+
+## Pause it
+
+```sh
+abctl service stop      # start / restart when you want it back
+```
+
+Claude Code fails while Cortex is stopped, because its settings still point at the
+proxy. Either start Cortex again or unwire Claude Code (below).
+
+Use `abctl service stop`, not `kill` or `pkill` — the supervisor restarts the
+process within seconds, which looks like it refusing to die.
+
+## Unwire Claude Code
+
+```sh
+abctl claude-code disable
+```
+
+This removes only the three keys Cortex added to `~/.claude/settings.json`
+(`HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`)
+and leaves anything else in that file alone. Claude Code goes straight to the API
+again. Restart `claude` to pick it up.
+
+Cortex keeps running; nothing sends traffic to it. `abctl claude-code enable` puts it
+back.
+
+## Remove it
+
+```sh
+abctl claude-code disable     # 1. unwire Claude Code
+abctl service uninstall       # 2. stop it and remove the service
+rm -rf ~/.cortex              # 3. config, CA, logs
+rm -f ~/.local/bin/abctl ~/.local/bin/authbridge-proxy
+```
+
+Order matters for the first two: `claude-code disable` needs to read the config that
+step 3 deletes.
+
+### Check nothing is left
+
+```sh
+abctl claude-code status                    # should say "not enabled"
+pgrep -fl authbridge-prox                   # should print nothing
+ls ~/.cortex 2>/dev/null                    # should print nothing
+```
+
+The CA that step 3 removes was only ever trusted through `NODE_EXTRA_CA_CERTS` in
+`~/.claude/settings.json` — Cortex never adds it to the system or login keychain, so
+there is nothing to clean up there.
+
+### If `abctl` is already gone
+
+The service can be removed by hand:
+
+```sh
+# macOS
+launchctl bootout "gui/$(id -u)/io.rossoctl.cortex"
+rm -f ~/Library/LaunchAgents/io.rossoctl.cortex.plist
+
+# Linux
+systemctl --user disable --now cortex.service
+rm -f ~/.config/systemd/user/cortex.service
+```
+
+Then delete the three Cortex keys from the `env` block of
+`~/.claude/settings.json` yourself.

--- a/authbridge/docs/laptop-uninstall.md
+++ b/authbridge/docs/laptop-uninstall.md
@@ -12,8 +12,17 @@ Two different things, so pick the one you want:
 abctl service stop      # start / restart when you want it back
 ```
 
+The stop persists — Cortex stays down across logouts and reboots until you start it
+again.
+
 Claude Code fails while Cortex is stopped, because its settings still point at the
 proxy. Either start Cortex again or unwire Claude Code (below).
+
+**A Claude Code session that is already running cannot recover on its own.**
+`HTTPS_PROXY` is fixed in its environment when it starts, so it has no way to fall
+back to a direct connection, and `claude-code disable` cannot reach it. Restart any
+session that starts failing to connect. `service stop` tells you how many
+connections it cut, for exactly this reason.
 
 Use `abctl service stop`, not `kill` or `pkill` — the supervisor restarts the
 process within seconds, which looks like it refusing to die.

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -538,11 +538,39 @@ if [ -n "${WIRE_CLAUDE_CODE:-}" ]; then
 	set -e
 	case "${cc_status}" in
 		0)
+			# Claude Code now depends on this proxy being up, and nothing keeps it up:
+			# nohup survives neither a crash nor a logout. Offer supervision at the
+			# moment the dependency is created, not in a doc nobody rereads.
+			info ""
+			set +e
+			"${BIN_DIR}/abctl" service install
+			svc_status=$?
+			set -e
+			case "${svc_status}" in
+				0) ;; # supervised; it is already running under the supervisor
+				3)
+					info ""
+					info "  Not supervised. Cortex stops when it crashes or you log out, and"
+					info "  Claude Code stops with it. To set it up later:"
+					info "    \"${abctl_cmd}\" service install"
+					info ""
+					;;
+				*)
+					warn "could not install the service (exit ${svc_status}); Cortex is running"
+					warn "but will not come back after a crash or a logout."
+					;;
+			esac
 			info ""
 			info "  Run Claude Code:   claude"
 			info "  Watch traffic:     \"${abctl_cmd}\""
 			info "  Undo:              \"${abctl_cmd}\" claude-code disable"
-			info "  Stop Cortex:       pkill -f authbridge-proxy"
+			if [ "${svc_status}" = "0" ]; then
+				# Under a supervisor, pkill gets the process restarted immediately —
+				# baffling unless the right command is the one printed.
+				info "  Stop Cortex:       \"${abctl_cmd}\" service uninstall"
+			else
+				info "  Stop Cortex:       pkill -f authbridge-proxy"
+			fi
 			info ""
 			exit 0
 			;;

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -58,6 +58,10 @@ BIN_DIR="${HOME}/.local/bin"
 # Every file Cortex writes for this user lives here: config, CA, keys, logs,
 # pidfiles. One directory to inspect, back up, or delete.
 CORTEX_DIR="${HOME}/.cortex"
+case "$(uname -s)" in
+	Darwin) SUPERVISOR_NAME="launchd user agent" ;;
+	*) SUPERVISOR_NAME="systemd user unit" ;;
+esac
 
 info() { printf '%s\n' "$*"; }
 warn() { printf 'warning: %s\n' "$*" >&2; }
@@ -281,67 +285,19 @@ case "$arch" in
 	*) die "unsupported architecture: $arch (supported: amd64, arm64)" ;;
 esac
 
-# stop_previous_cortex stops a Cortex a previous run of this script started, if
-# one is still holding the ports the next one needs.
-#
-# Re-running the installer while Cortex is already up is ordinary — following the
-# README and then the token-cost guide does exactly that. Both use the same
-# loopback ports, so without this the second command dies on a bind conflict.
-#
-# Deliberately narrow. It only kills a pid from OUR pidfile whose process name is
-# still authbridge-proxy — a pidfile can outlive its process and the number can
-# be recycled onto something unrelated. Anything else holding the port is left
-# alone and reported by the preflight below.
-stop_previous_cortex() {
-	pidfile="${CORTEX_DIR}/proxy.pid"
-	[ -f "$pidfile" ] || return 0
-	pid=$(cat "$pidfile" 2>/dev/null) || return 0
-	case "$pid" in
-		'' | *[!0-9]*) return 0 ;;
-	esac
-	if ! kill -0 "$pid" 2>/dev/null; then
-		rm -f "$pidfile"
-		return 0
-	fi
-	# Match a 15-character prefix, not the full name. Linux caps comm at
-	# TASK_COMM_LEN-1 = 15 and "authbridge-proxy" is 16, so it reports
-	# "authbridge-prox" and a *authbridge-proxy* glob never matches — which made
-	# this whole function a no-op on Linux while passing on macOS, where comm is
-	# not truncated. Still narrow: the pid came from a pidfile we wrote.
-	name=$(ps -p "$pid" -o comm= 2>/dev/null || true)
-	case "$name" in
-		*authbridge-prox*) ;;
-		*) return 0 ;; # pid recycled onto something else — never touch it
-	esac
-	info "Stopping the Cortex started earlier (pid ${pid}); the new one replaces it."
-	kill "$pid" 2>/dev/null || true
-	# 90 * 0.2s = 18s, deliberately longer than the proxy's own 15s shutdown
-	# deadline (cmd/authbridge-proxy/main.go). Waiting only 5s could remove the
-	# pidfile while a draining request still held the listener, and the next port
-	# preflight would then fail with the previous instance invisible.
-	i=0
-	while [ "$i" -lt 90 ] && kill -0 "$pid" 2>/dev/null; do
-		sleep 0.2
-		i=$((i + 1))
-	done
-	if kill -0 "$pid" 2>/dev/null; then
-		# Keep the pidfile: it is the only handle on a process that is still there.
-		die "Cortex (pid ${pid}) did not exit within 18s. Stop it and re-run: kill -9 ${pid}"
-	fi
-	rm -f "$pidfile"
-}
-
 # --- preflight: fail early (before downloading) if a listener port is taken ---
 if [ "$MODE" = "local" ]; then
-	# Unconditionally, not gated on port_in_use: that probe reports "free" when
-	# neither lsof nor nc exists (see above), so on a minimal container the stop
-	# would be skipped, the new proxy would hit a bind conflict anyway, and the
-	# user would be left with a dead install. The function is already a no-op
-	# when nothing of ours is running, so it needs no probe to justify it.
-	stop_previous_cortex
+	# A Cortex of ours holding these ports is fine — `abctl service install` adopts
+	# it, and keeping a second copy of that narrow "is this pid really ours" check
+	# here would only let the two drift. This probe is for a FOREIGN listener, and
+	# it runs before the download so the failure is early and cheap.
 	for p in "$DEMO_FORWARD_PORT" "$DEMO_SESSION_PORT" "$DEMO_STATS_PORT" "$DEMO_HEALTH_PORT"; do
 		if port_in_use "$p"; then
-			die "port ${p} is already in use. Is Cortex already running (see ${CORTEX_DIR}/proxy.pid)? Otherwise free the port, or change the ports in the config, then re-run."
+			if [ -f "${CORTEX_DIR}/config.yaml" ]; then
+				# Ours, most likely: let abctl adopt it rather than refusing here.
+				continue
+			fi
+			die "port ${p} is already in use by something else. Free it, or change the ports in ${CORTEX_DIR}/config.yaml, then re-run."
 		fi
 	done
 fi
@@ -464,49 +420,27 @@ if [ "$MODE" = "install-only" ]; then
 	exit 0
 fi
 
-# --- start in the background, then wait until it's actually listening ---
+# --- run it as a service, not a background process ---
+#
+# There is no "start it with nohup" path any more. A backgrounded process survives
+# neither a crash nor a logout, and once Claude Code's settings point at the proxy
+# that means Claude Code silently stops working — most reliably right after a
+# reboot. Handing it to the OS supervisor removes that whole class of problem, and
+# removes any reason for anyone to reach for kill or pkill.
 info ""
-info "Starting Cortex in the background..."
-# 0700 on the Cortex directory: a CA private key is written beneath it.
-mkdir -p "$CORTEX_DIR" && chmod 700 "$CORTEX_DIR"
-# Deliberately NOT creating $ca_dir here. MkdirAll never tightens an existing
-# directory, so pre-creating it at the shell's umask defeated tlsbridge's 0700 —
-# the proxy creates it correctly on first start.
-log="${CORTEX_DIR}/proxy.log"
-pidfile="${CORTEX_DIR}/proxy.pid"
-nohup "$proxy" --local </dev/null >"$log" 2>&1 &
-proxy_pid=$!
-echo "$proxy_pid" >"$pidfile"
-
-# Confirm readiness from real signals, not the "listening" log line — that line is
-# emitted just *before* the socket is bound, so a bind failure could look ready.
-# A bind failure exits within ms (the proxy Fatalf's), so watch for early exit;
-# and probe the forward port for a true post-bind signal.
-ready=0
-i=0
-while [ "$i" -lt 50 ]; do
-	if ! kill -0 "$proxy_pid" 2>/dev/null; then
-		warn "Cortex exited during startup — last log lines:"
-		tail -n 15 "$log" >&2 || true
-		die "Cortex failed to start (full log: ${log})"
-	fi
-	if port_in_use "$DEMO_FORWARD_PORT"; then
-		ready=1
-		break
-	fi
-	sleep 0.2
-	i=$((i + 1))
-done
-
-info ""
-if [ "$ready" -eq 1 ]; then
-	info "Cortex is running (pid ${proxy_pid}).   Logs: ${log}"
-else
-	# It didn't exit during the startup window (a bind failure would have killed
-	# it), but no probe tool confirmed the port — most likely up. Say so honestly.
-	info "Cortex started (pid ${proxy_pid}); couldn't confirm it's listening (install lsof or nc to verify). Logs: ${log}"
+info "Setting Cortex up as a ${SUPERVISOR_NAME} so it restarts on failure and"
+info "comes back at login..."
+set +e
+"${BIN_DIR}/abctl" service install --yes
+svc_status=$?
+set -e
+if [ "${svc_status}" != "0" ]; then
+	die "could not set up the service (exit ${svc_status}).
+  Cortex is NOT running. Inspect the unit it would install with:
+    \"${abctl_cmd}\" service install --print-unit
+  or run the proxy in the foreground to see what it says:
+    \"${proxy_cmd}\" --local"
 fi
-info ""
 
 # tool-prune is in the config but INERT: its remove list is empty, so it does
 # nothing until a name is added. That is deliberate for an install.
@@ -538,39 +472,13 @@ if [ -n "${WIRE_CLAUDE_CODE:-}" ]; then
 	set -e
 	case "${cc_status}" in
 		0)
-			# Claude Code now depends on this proxy being up, and nothing keeps it up:
-			# nohup survives neither a crash nor a logout. Offer supervision at the
-			# moment the dependency is created, not in a doc nobody rereads.
-			info ""
-			set +e
-			"${BIN_DIR}/abctl" service install
-			svc_status=$?
-			set -e
-			case "${svc_status}" in
-				0) ;; # supervised; it is already running under the supervisor
-				3)
-					info ""
-					info "  Not supervised. Cortex stops when it crashes or you log out, and"
-					info "  Claude Code stops with it. To set it up later:"
-					info "    \"${abctl_cmd}\" service install"
-					info ""
-					;;
-				*)
-					warn "could not install the service (exit ${svc_status}); Cortex is running"
-					warn "but will not come back after a crash or a logout."
-					;;
-			esac
+			# The service is already installed above — it is how the proxy runs now,
+			# not an option — so there is nothing to offer here.
 			info ""
 			info "  Run Claude Code:   claude"
 			info "  Watch traffic:     \"${abctl_cmd}\""
 			info "  Undo:              \"${abctl_cmd}\" claude-code disable"
-			if [ "${svc_status}" = "0" ]; then
-				# Under a supervisor, pkill gets the process restarted immediately —
-				# baffling unless the right command is the one printed.
-				info "  Stop Cortex:       \"${abctl_cmd}\" service uninstall"
-			else
-				info "  Stop Cortex:       pkill -f authbridge-proxy"
-			fi
+			info "  Stop Cortex:       \"${abctl_cmd}\" service stop"
 			info ""
 			exit 0
 			;;
@@ -596,7 +504,5 @@ info "    HTTPS_PROXY=http://localhost:${DEMO_FORWARD_PORT} \\"
 info "      NODE_EXTRA_CA_CERTS=${ca_dir}/ca.crt \\"
 info "      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude"
 info ""
-# pkill -f, not `kill $(cat pidfile)`: a stale pidfile can name a recycled pid,
-# and nothing else on the machine is called authbridge-proxy.
-info "  Stop it:         kill ${proxy_pid}   (or: pkill -f authbridge-proxy)"
+info "  Stop it:         \"${abctl_cmd}\" service stop      (start / restart / status too)"
 info ""

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -455,6 +455,18 @@ if ! "${BIN_DIR}/abctl" service status >/dev/null 2>&1 &&
 	esac
 fi
 
+# Materialise the config before handing the proxy to the supervisor. This used to
+# happen as a side effect of starting `--local` in the background; with the service
+# doing the starting, nothing else creates the file, and `abctl service install`
+# refuses to run without it.
+if [ ! -f "${CORTEX_DIR}/config.yaml" ]; then
+	if ! "${BIN_DIR}/authbridge-proxy" --local --write-config; then
+		die "could not write ${CORTEX_DIR}/config.yaml.
+  Run this to see why:
+    \"${proxy_cmd}\" --local --write-config"
+	fi
+fi
+
 info ""
 info "Setting Cortex up as a ${SUPERVISOR_NAME} so it restarts on failure and"
 info "comes back at login..."

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -471,7 +471,11 @@ info ""
 info "Setting Cortex up as a ${SUPERVISOR_NAME} so it restarts on failure and"
 info "comes back at login..."
 set +e
-"${BIN_DIR}/abctl" service install --yes
+# --proxy: use the binary this script just installed, not whatever happens to be
+# earlier on PATH. An end-to-end run found the unit pointing at an older
+# authbridge-proxy from another directory, which rejected --supervise and exited, so
+# the service never came up.
+"${BIN_DIR}/abctl" service install --yes --proxy "${BIN_DIR}/authbridge-proxy"
 svc_status=$?
 set -e
 if [ "${svc_status}" != "0" ]; then

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -88,6 +88,7 @@ Options:
   --claude-code    after starting, offer to configure Claude Code to use it, so
                    it runs as plain `claude` with no environment variables
   --local          the default, spelled out
+  --yes, -y        do not prompt; answer yes to configuring Claude Code
   --ref=REF        take THIS SCRIPT from a git ref instead of the newest release
                    (e.g. --ref=main for unreleased changes, --ref=v0.7.0-alpha.4
                    to pin). Binaries come from the same release unless
@@ -108,10 +109,12 @@ USAGE
 # --- mode selection ---
 MODE=local
 WIRE_CLAUDE_CODE=""
+ASSUME_YES=""
 for arg in "$@"; do
 	case "$arg" in
 		--install-only) MODE=install-only ;;
 		--claude-code) WIRE_CLAUDE_CODE=1 ;;
+		--yes | -y) ASSUME_YES=1 ;;
 		--ref=*) AUTHBRIDGE_REF="${arg#*=}" ;;
 		# --local is the default; accepted so writing it out explicitly works, and
 		# so it mirrors the proxy flag of the same name.
@@ -120,7 +123,7 @@ for arg in "$@"; do
 			usage
 			exit 0
 			;;
-		*) die "unknown option: $arg (try --claude-code, --install-only, --local, --ref=REF, or no argument)" ;;
+		*) die "unknown option: $arg (try --claude-code, --install-only, --local, --ref=REF, --yes, or no argument)" ;;
 	esac
 done
 # Env form kept working; the flag wins if both are given.
@@ -427,6 +430,31 @@ fi
 # that means Claude Code silently stops working — most reliably right after a
 # reboot. Handing it to the OS supervisor removes that whole class of problem, and
 # removes any reason for anyone to reach for kill or pkill.
+# This script now starts the proxy ONLY through `abctl service`, so an abctl that
+# predates that command cannot be driven by it. Say which mismatch it is, rather
+# than letting `unknown subcommand "service"` surface as a bare non-zero exit after
+# the binaries are already installed.
+if ! "${BIN_DIR}/abctl" service status >/dev/null 2>&1 &&
+	"${BIN_DIR}/abctl" service 2>&1 | grep -q "unknown subcommand"; then
+	# Only offer the matching-release URL when $version really is a tag: under
+	# AUTHBRIDGE_SKIP_DOWNLOAD it reads "already installed", which would otherwise
+	# be spliced into a nonsense URL.
+	case "${version}" in
+		v*)
+			die "the ${version} abctl has no 'service' command, which this installer needs
+  in order to start Cortex. Either use the installer that shipped with it:
+    curl -fsSL https://raw.githubusercontent.com/${REPO}/${version}/authbridge/install.sh | sh
+  or install newer binaries with this script:
+    AUTHBRIDGE_VERSION=<newer tag>"
+			;;
+		*)
+			die "the abctl in ${BIN_DIR} has no 'service' command, which this installer
+  needs in order to start Cortex. Install a newer one — drop
+  AUTHBRIDGE_SKIP_DOWNLOAD, or point AUTHBRIDGE_VERSION at a release that has it."
+			;;
+	esac
+fi
+
 info ""
 info "Setting Cortex up as a ${SUPERVISOR_NAME} so it restarts on failure and"
 info "comes back at login..."
@@ -467,7 +495,11 @@ fi
 if [ -n "${WIRE_CLAUDE_CODE:-}" ]; then
 	info ""
 	set +e
-	"${BIN_DIR}/abctl" claude-code enable
+	if [ -n "${ASSUME_YES}" ]; then
+		"${BIN_DIR}/abctl" claude-code enable --yes
+	else
+		"${BIN_DIR}/abctl" claude-code enable
+	fi
 	cc_status=$?
 	set -e
 	case "${cc_status}" in


### PR DESCRIPTION
## Why

Once `abctl claude-code enable` has run, every Claude Code request goes to
`localhost:47600`. Verified what happens when the proxy is gone:

```
$ curl --proxy http://localhost:47999 https://api.anthropic.com/v1/messages
exit=7   (CURLE_COULDNT_CONNECT)
```

No fallback to direct — Claude Code simply stops working. And nothing kept the
proxy up: `install.sh` used `nohup … &`, which survives neither a crash nor a
logout. So "it worked yesterday" was the normal experience after a reboot, and the
only warning was a line printed at enable time that nobody rereads three weeks
later.

## What this adds

`abctl service install | uninstall | status | stop | start | restart` — a **launchd
user agent** on macOS, a **systemd user unit** on Linux. `install.sh` installs it
unconditionally: running supervised is now how Cortex runs, not a choice the user is
asked to make. The `nohup` path, the pidfile it wrote, and every `pkill` instruction
are gone.

**User-scoped only, never a system daemon.** This process holds the bridge CA's
private key; running it as root to gain robustness would be a bad trade.

## Adoption, not collision

The failure mode worth designing around. A second proxy **exits 1** on a bind
conflict:

```
level=ERROR msg="forward-proxy listen: bind: address already in use"
exit code: 1
```

So installing a unit while a hand-started proxy holds the ports leaves the
supervised copy crash-looping — and **Claude Code keeps working** off the old
process, hiding the break until the next reboot, when nothing comes back.

`install` stops the hand-started instance first (pidfile plus the same 15-character
process-name check `install.sh` uses, since Linux truncates `comm`), then
supervises a fresh one. It announces this before acting:

```
A Cortex you started by hand is running (pid 86682). It will be stopped
so the supervised one can take the ports.
```

## "Loaded" is not "serving"

A config error is fatal at startup, which a supervisor turns into a restart loop.
`install` probes the health endpoint — read from the config, so it cannot drift from
the running proxy — and on failure reports the log tail instead of claiming success.
`service status` names the two states that matter:

- a hand-started proxy that works until the next reboot with nothing to restart it
- installed-but-not-answering, which means Claude Code is failing *right now*

## Two unit-file details that would otherwise be quietly wrong

**launchd gets unconditional `KeepAlive`; systemd gets `Restart=on-failure`.** I
first argued the opposite here — that `KeepAlive=true` makes a deliberate stop
impossible, so it should be scoped to `SuccessfulExit=false`. That is now wrong in
two ways. Apple documents `SuccessfulExit` in terms of exit *status*, which leaves
its behaviour on death by signal ambiguous, and a deliberate stop is served by
`service uninstall` / `service stop` (a bootout), not by a `KeepAlive` condition.
`SuccessfulExit` no longer appears in the plist, and a test fails if it reappears.

systemd needs no such trade: `on-failure` already covers signal death, and a
`systemctl stop` is distinguishable from a crash.

**Restart-after-crash does NOT work in the session where you install it — measured,
not suspected.** On macOS 26.5.2, from a real GUI terminal, launchd defers an agent
bootstrapped into an already-running login domain: it logs `pending spawn, domain in
on-demand-only mode` and honours neither `RunAtLoad` nor `KeepAlive`. An explicit
`kickstart` works, which is why install succeeds.

Ruled out individually: `ProcessType=Background` vs none (both fail), modern
`bootstrap` vs legacy `load -w` (both fail), Login Items "Allow in the Background"
(enabled, still fails), `launchctl disable` (label absent from the disabled
database), and my own headless context (reproduced from the user's GUI terminal with
a throwaway agent and a trivial sleeper). The 454 agents loaded at login on that
machine all run normally, so the distinguishing factor is *when* the job entered the
domain — meaning a logout/login is expected to fix it. **That is untested.**

So the install output and the README now state the caveat and name the `kill -9`
check, rather than letting "Running under launchd user agent." read as "crash-restart
is active now". If the login test also fails, the real fix is launchd socket
activation — an on-demand trigger is spawned even in an on-demand-only domain —
which needs the proxy to accept a launchd-passed socket, and is out of scope here.

Everything else was observed working on a real machine: adoption of a hand-started
proxy, the job starting, serving on the configured ports, uninstall removing it, and
`stop` staying stopped.

**systemd `StartLimit*` belong in `[Unit]`.** I wrote them into `[Service]` first.
They moved to `[Unit]` in systemd v229 and are deprecated in `[Service]`, where they
can be ignored — **silently voiding the crash-loop throttle they exist to provide**.
Caught it reading the rendered unit. Also dropped `After=network-online.target`:
that target isn't part of a user manager, and every listener here is loopback.

## Testing, and its limits

I'm on macOS, so `renderUnitFor` takes the OS **explicitly** rather than reading
`runtime.GOOS` — otherwise the systemd unit would have shipped written but never
executed, which is the same shape as a bug that already cost this repo a day. Both
renderings are exercised from either host. The plist is validated with
`plutil -lint`; the systemd unit is checked for section placement and that every
line is a section, comment, or `key=value`.

**What is not exercised:** the actual `launchctl bootstrap` / `systemctl --user`
calls. Running them would register a real agent in the reviewer's session, so tests
use a `--unit-file` override and stop before the load step. `--print-unit` renders
the unit without installing so it can be inspected first. Worth one real
`abctl service install` before merge.

Covered: both renderings, plist validity, `runningPID` refusing a foreign or
recycled pid, bind-vs-dial address handling, the health probe timing out rather
than reporting success, the log tail, and the uninstalled/unsupervised status
branches.

## Supervision-aware messaging

Under a supervisor, `pkill -f authbridge-proxy` gets the process restarted instantly
— "I killed it and it came back." Every printed stop command becomes
`abctl service uninstall` when a unit is installed.

## Deliberately left for a follow-up

- **No log rotation.** The file only grows; under restarts it grows faster.
- **A foreign hand-rolled unit is not detected.** We only see a port held by a proxy
  we did not start, not someone else's launchd/systemd unit for the same binary.
- **Upgrade restart.** Reinstalling binaries replaces the file, but a running
  supervised process keeps the old one until restarted. `install.sh` should restart
  the service after an upgrade; it does not yet.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `abctl service` commands to install, uninstall, start, stop, restart, and check the Cortex proxy.
  - Supports user-level service supervision on macOS and Linux, including unit preview and customization options.
  - Added configuration migration, automatic health verification, and local configuration generation.

- **Improvements**
  - Installer now adopts existing proxy instances and provides clearer diagnostics.
  - Added an option to bind listeners to localhost for improved laptop security.
  - Updated setup, troubleshooting, and removal documentation with service-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Added after the first review

- **A fresh install could not start Cortex.** Removing `nohup --local` removed the
  only thing that created `~/.cortex/config.yaml`, which `service install` requires —
  so the README one-liner died on a clean machine. New
  `authbridge-proxy --local --write-config` materialises it; the circular
  "run the installer first" error now names the command that creates the file.
  My earlier "verified end to end" claim did not cover this path.
- **The health probe was skipped for migrated configs** — paths were resolved before
  the migration ran, so an older config gave no health URL and install reported
  success having probed nothing. Recomputed after migration, with `ApplyPreset`
  applied the way the binaries do.
- **A healthy probe did not prove the supervised copy was serving** — an unadopted
  proxy keeps the ports while the supervised one crash-loops. Install now checks
  supervisor state too.
- **Paths are escaped and quoted** — `&` in `$HOME` made the plist malformed XML;
  a space split systemd's `ExecStart`.
- **A failed load no longer leaves the unit file behind**, and lingering is undone on
  uninstall only when we were the ones who enabled it.
- **Laptop listeners bind loopback by rule**, not by enumeration:
  `listener.bind_loopback_only`. A real config was serving `*:9091` and `*:8082` on
  every interface. Off by default so kubelet probes still work.
- **File modes tightened**: `~/.cortex/ca` to 0700, `proxy.log` to 0600, and a fresh
  `config.yaml` to 0600.

**Not addressed, deliberately:** the session API on `:47601` is unauthenticated, and
loopback does not isolate by UID, so any local process can read session content.
That is a separate decision.

