### PR TITLE
fix: :technologist: Add check for go tidy on modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,9 +174,9 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v -x --ignore=tests/e2e
 
-  # Fails when any authbridge module's go.mod/go.sum would change under
-  # `go mod tidy` (GOWORK=off, so replace directives resolve as they do
-  # in build.yaml and release-binaries.yaml).
+  # `go mod tidy -diff` on every authbridge module. GOWORK=off so
+  # replace directives resolve as they do in build.yaml and
+  # release-binaries.yaml.
   go-tidy-check:
     name: Verify module graph is tidy
     runs-on: ubuntu-latest
@@ -193,12 +193,17 @@ jobs:
       - name: Run go mod tidy -diff in every module
         run: |
           set -euo pipefail
+          # Percent-encode %, CR, LF before inserting a path into a
+          # ::group:: or ::error workflow command.
+          esc() { printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e ':a' -e '$!N' -e 's/\n/%0A/g' -e 'ta'; }
           fail=0
           while IFS= read -r -d '' go_mod; do
             mod=$(dirname "$go_mod")
-            echo "::group::$mod"
+            mod_esc=$(esc "$mod")
+            go_mod_esc=$(esc "$go_mod")
+            echo "::group::${mod_esc}"
             if ! (cd "$mod" && go mod tidy -diff); then
-              echo "::error file=${go_mod}::go mod tidy would change ${go_mod}; run 'go mod tidy' in ${mod} and commit"
+              echo "::error file=${go_mod_esc}::go mod tidy would change ${go_mod_esc}; run 'go mod tidy' in ${mod_esc} and commit"
               fail=1
             fi
             echo "::endgroup::"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,10 @@ jobs:
       - name: Run go mod tidy -diff in every module
         run: |
           set -euo pipefail
-          # Percent-encode %, CR, LF for use in workflow-command metadata.
+          # Percent-encode %, CR, LF for use in workflow commands
+          # (both metadata and message halves — CR/LF in the message
+          # would end the command and let the next line be interpreted
+          # as a new one).
           esc() { printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e ':a' -e '$!N' -e 's/\n/%0A/g' -e 'ta'; }
           fail=0
           found=0
@@ -204,7 +207,7 @@ jobs:
             go_mod_esc=$(esc "$go_mod")
             echo "::group::${mod_esc}"
             if ! (cd "$mod" && go mod tidy -diff); then
-              echo "::error file=${go_mod_esc}::go mod tidy would change ${go_mod}; run 'go mod tidy' in ${mod} and commit"
+              echo "::error file=${go_mod_esc}::go mod tidy would change ${go_mod_esc}; run 'go mod tidy' in ${mod_esc} and commit"
               fail=1
             fi
             echo "::endgroup::"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,3 +173,34 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v -x --ignore=tests/e2e
+
+  # Fails when any authbridge module's go.mod/go.sum would change under
+  # `go mod tidy` (GOWORK=off, so replace directives resolve as they do
+  # in build.yaml and release-binaries.yaml).
+  go-tidy-check:
+    name: Verify module graph is tidy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GOWORK: "off"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: authbridge/authlib/go.mod
+
+      - name: Run go mod tidy -diff in every module
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r -d '' go_mod; do
+            mod=$(dirname "$go_mod")
+            echo "::group::$mod"
+            if ! (cd "$mod" && go mod tidy -diff); then
+              echo "::error file=${go_mod}::go mod tidy would change ${go_mod}; run 'go mod tidy' in ${mod} and commit"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done < <(find authbridge -name go.mod -not -path '*/demos/*' -print0 | sort -z)
+          exit $fail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,19 +193,24 @@ jobs:
       - name: Run go mod tidy -diff in every module
         run: |
           set -euo pipefail
-          # Percent-encode %, CR, LF before inserting a path into a
-          # ::group:: or ::error workflow command.
+          # Percent-encode %, CR, LF for use in workflow-command metadata.
           esc() { printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e ':a' -e '$!N' -e 's/\n/%0A/g' -e 'ta'; }
           fail=0
+          found=0
           while IFS= read -r -d '' go_mod; do
+            found=$((found + 1))
             mod=$(dirname "$go_mod")
             mod_esc=$(esc "$mod")
             go_mod_esc=$(esc "$go_mod")
             echo "::group::${mod_esc}"
             if ! (cd "$mod" && go mod tidy -diff); then
-              echo "::error file=${go_mod_esc}::go mod tidy would change ${go_mod_esc}; run 'go mod tidy' in ${mod_esc} and commit"
+              echo "::error file=${go_mod_esc}::go mod tidy would change ${go_mod}; run 'go mod tidy' in ${mod} and commit"
               fail=1
             fi
             echo "::endgroup::"
-          done < <(find authbridge -name go.mod -not -path '*/demos/*' -print0 | sort -z)
+          done < <(find authbridge -name go.mod -print0 | sort -z)
+          if [ "$found" -eq 0 ]; then
+            echo "::error::no go.mod found under authbridge/"
+            exit 1
+          fi
           exit $fail


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Adds a `go-tidy-check` job to CI build. We should know at PR time, not at merge or release, when a change breaks something CI didn't cover. This catches the type of patch needed in #862.

`go mod tidy -diff` catches this without compiling anything, so it needs no CGO and no linked FFI archive. That means it covers `cpex`, `praxis`, and any future cmd/* module the compile matrix doesn't reach. This 'costs' ~30-60s on the first run of a PR (cold module cache); ~5-10s on subsequent runs of the same branch (warm cache).

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

## Related issue(s)

Fixes #863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Expanded automated checks to verify that all Go modules, including demo modules, remain tidy.
  - Checks now continue reviewing other modules after detecting an issue and report module-specific failures.
  - The workflow now fails when any module requires updates or when no Go modules are found.
  - Improved handling of special characters in module paths for clearer workflow reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->