### PR TITLE
Feat: Add /v1/usage endpoint and abctl usage screen

### DIFF
--- a/authbridge/authlib/session/recorder_test.go
+++ b/authbridge/authlib/session/recorder_test.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// fakeRecorder captures what Append handed it.
+type fakeRecorder struct {
+	mu      sync.Mutex
+	calls   int
+	lastID  string
+	lastEvt pipeline.SessionEvent
+}
+
+func (f *fakeRecorder) Record(sessionID string, e *pipeline.SessionEvent) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastID = sessionID
+	if e != nil {
+		f.lastEvt = *e
+	}
+}
+
+func (f *fakeRecorder) snapshot() (int, string, pipeline.SessionEvent) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls, f.lastID, f.lastEvt
+}
+
+// A registered Recorder must fire on Append, with the session id it was
+// appended under and the event as recorded. This is the only wiring that feeds
+// /v1/usage: if it silently stops firing, every chart goes flat while the event
+// timeline keeps working, so nothing else would reveal the break.
+func TestAddRecorder_FiresOnAppend(t *testing.T) {
+	store := New(5*time.Minute, 100, 0)
+	defer store.Close()
+
+	rec := &fakeRecorder{}
+	store.AddRecorder(rec)
+
+	store.Append("alice", pipeline.SessionEvent{
+		At:         time.Now(),
+		Direction:  pipeline.Outbound,
+		Phase:      pipeline.SessionResponse,
+		StatusCode: 200,
+		Host:       "api.example",
+	})
+
+	calls, id, evt := rec.snapshot()
+	if calls != 1 {
+		t.Fatalf("Record called %d times, want 1", calls)
+	}
+	if id != "alice" {
+		t.Errorf("session id = %q, want alice", id)
+	}
+	if evt.StatusCode != 200 || evt.Host != "api.example" {
+		t.Errorf("event not passed through intact: %+v", evt)
+	}
+	// Append stamps SessionID on the event; a Recorder must see the stamped
+	// value, since an outbound event has no protocol-native session field.
+	if evt.SessionID != "alice" {
+		t.Errorf("event.SessionID = %q, want alice — the stamp must happen before Record", evt.SessionID)
+	}
+}
+
+// Every registered Recorder must be called, not just the first.
+func TestAddRecorder_MultipleRecordersAllFire(t *testing.T) {
+	store := New(5*time.Minute, 100, 0)
+	defer store.Close()
+
+	a, b := &fakeRecorder{}, &fakeRecorder{}
+	store.AddRecorder(a)
+	store.AddRecorder(b)
+
+	store.Append("s1", pipeline.SessionEvent{At: time.Now(), Phase: pipeline.SessionResponse})
+
+	if ca, _, _ := a.snapshot(); ca != 1 {
+		t.Errorf("first recorder called %d times, want 1", ca)
+	}
+	if cb, _, _ := b.snapshot(); cb != 1 {
+		t.Errorf("second recorder called %d times, want 1", cb)
+	}
+}
+
+// A nil Recorder must be ignored rather than stored, or Append would panic on
+// the request hot path.
+func TestAddRecorder_NilIsIgnored(t *testing.T) {
+	store := New(5*time.Minute, 100, 0)
+	defer store.Close()
+
+	store.AddRecorder(nil)
+	store.Append("s1", pipeline.SessionEvent{At: time.Now()}) // must not panic
+}
+
+// Recorders see every event, including ones the store will immediately trim.
+// A bucket counter must keep counting after the events it counted have aged out
+// of the event list — otherwise a chart loses history an operator could still
+// see a minute ago.
+func TestAddRecorder_FiresForEventsThatWillBeTrimmed(t *testing.T) {
+	const maxEvents = 3
+	store := New(5*time.Minute, maxEvents, 0)
+	defer store.Close()
+
+	rec := &fakeRecorder{}
+	store.AddRecorder(rec)
+
+	for i := 0; i < 10; i++ {
+		store.Append("s1", pipeline.SessionEvent{At: time.Now(), Phase: pipeline.SessionResponse})
+	}
+
+	calls, _, _ := rec.snapshot()
+	if calls != 10 {
+		t.Errorf("Record called %d times, want 10 — the recorder must see events the store trims", calls)
+	}
+	if v := store.View("s1"); v == nil || len(v.Events) != maxEvents {
+		got := 0
+		if v != nil {
+			got = len(v.Events)
+		}
+		t.Errorf("store kept %d events, want %d — precondition for this test", got, maxEvents)
+	}
+}
+
+// No recorder registered is the common case and must stay a no-op.
+func TestAppend_NoRecordersIsFine(t *testing.T) {
+	store := New(5*time.Minute, 100, 0)
+	defer store.Close()
+	store.Append("s1", pipeline.SessionEvent{At: time.Now()})
+	if v := store.View("s1"); v == nil || len(v.Events) != 1 {
+		t.Error("append broke with no recorders registered")
+	}
+}

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -27,7 +27,11 @@ type entry struct {
 	UpdatedAt time.Time
 }
 
-const maxSessionIDLen = 256
+// MaxSessionIDLen is the longest session ID the store keeps intact; longer ids
+// are truncated on Append. Exported so callers that validate an id before
+// reaching the store — the session API's query parameters, for one — bound it at
+// the same length instead of duplicating the number.
+const MaxSessionIDLen = 256
 
 // Recorder receives every event the store appends, for side-channel
 // aggregation. Declared here as a narrow interface rather than importing the
@@ -177,8 +181,8 @@ func (s *Store) backgroundCleanup() {
 // doesn't exist. Updates activeID to this session. Evicts the oldest event
 // if the session exceeds maxEvents.
 func (s *Store) Append(sessionID string, event pipeline.SessionEvent) {
-	if len(sessionID) > maxSessionIDLen {
-		sessionID = sessionID[:maxSessionIDLen]
+	if len(sessionID) > MaxSessionIDLen {
+		sessionID = sessionID[:MaxSessionIDLen]
 	}
 
 	s.mu.Lock()
@@ -413,11 +417,11 @@ func (s *Store) Rekey(oldID, newID string) {
 	if oldID == newID || oldID == "" || newID == "" {
 		return
 	}
-	if len(newID) > maxSessionIDLen {
+	if len(newID) > MaxSessionIDLen {
 		// Two long IDs sharing a prefix would collide on the same truncated key,
 		// silently turning the second Rekey into a no-op. Log so that's diagnosable.
-		slog.Warn("session: newID truncated for rekey", "origLen", len(newID), "maxLen", maxSessionIDLen)
-		newID = newID[:maxSessionIDLen]
+		slog.Warn("session: newID truncated for rekey", "origLen", len(newID), "maxLen", MaxSessionIDLen)
+		newID = newID[:MaxSessionIDLen]
 	}
 
 	s.mu.Lock()

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -29,6 +29,17 @@ type entry struct {
 
 const maxSessionIDLen = 256
 
+// Recorder receives every event the store appends, for side-channel
+// aggregation. Declared here as a narrow interface rather than importing the
+// usage package so the dependency points one way: usage knows about events,
+// the store knows nothing about usage.
+//
+// Implementations are called while the store holds its write lock, so they must
+// not block or call back into the store.
+type Recorder interface {
+	Record(sessionID string, e *pipeline.SessionEvent)
+}
+
 // Store is an in-memory, per-pod session store. It is safe for concurrent use.
 type Store struct {
 	mu          sync.RWMutex
@@ -42,6 +53,10 @@ type Store struct {
 
 	// subscribers is the fan-out list for Subscribe(). Protected by mu.
 	subscribers []*subscriber
+
+	// recorders are notified of every appended event. Registered at setup via
+	// AddRecorder, before the store serves traffic.
+	recorders []Recorder
 }
 
 // subscriberChanBuf caps each subscriber's channel depth. 64 absorbs short
@@ -192,6 +207,14 @@ func (s *Store) Append(sessionID string, event pipeline.SessionEvent) {
 	logAppended(sessionID, &event)
 	s.publishLocked(event)
 
+	// Side-channel aggregation (e.g. /v1/usage). Runs under the write lock, so
+	// a Recorder must be cheap and must not re-enter the store. Unlike
+	// subscribers this cannot drop: a dropped event silently skews a cumulative
+	// counter, where a dropped stream frame only costs one client one row.
+	for _, r := range s.recorders {
+		r.Record(sessionID, &event)
+	}
+
 	if s.maxEvents > 0 && len(sess.Events) > s.maxEvents {
 		sess.Events = trimEventsPinIntent(sess.Events, s.maxEvents)
 	}
@@ -275,6 +298,14 @@ func trimEventsPinIntent(events []pipeline.SessionEvent, maxEvents int) []pipeli
 
 // View returns a read-only snapshot of the session's events.
 // Returns nil if the session doesn't exist or is expired.
+// AddRecorder registers a Recorder. Call before the store serves traffic; it is
+// not safe to call concurrently with Append.
+func (s *Store) AddRecorder(r Recorder) {
+	if r != nil {
+		s.recorders = append(s.recorders, r)
+	}
+}
+
 func (s *Store) View(sessionID string) *pipeline.SessionView {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -522,4 +553,3 @@ func logAppended(sessionID string, e *pipeline.SessionEvent) {
 	}
 	slog.Debug("session: event appended", attrs...)
 }
-

--- a/authbridge/authlib/session/store.go
+++ b/authbridge/authlib/session/store.go
@@ -300,8 +300,6 @@ func trimEventsPinIntent(events []pipeline.SessionEvent, maxEvents int) []pipeli
 	return out
 }
 
-// View returns a read-only snapshot of the session's events.
-// Returns nil if the session doesn't exist or is expired.
 // AddRecorder registers a Recorder. Call before the store serves traffic; it is
 // not safe to call concurrently with Append.
 func (s *Store) AddRecorder(r Recorder) {
@@ -310,6 +308,8 @@ func (s *Store) AddRecorder(r Recorder) {
 	}
 }
 
+// View returns a read-only snapshot of the session's events.
+// Returns nil if the session doesn't exist or is expired.
 func (s *Store) View(sessionID string) *pipeline.SessionView {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/redact"
 	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
 )
 
 // defaultHeartbeatInterval is how often the SSE stream sends a keep-alive
@@ -38,6 +39,10 @@ type Server struct {
 	inbound   *pipeline.Holder
 	outbound  *pipeline.Holder
 	heartbeat time.Duration
+	// usage aggregates events into time buckets for /v1/usage. nil disables
+	// the endpoint (returns 404) — see handleUsage for why that is a 404 and
+	// not an empty snapshot.
+	usage *usage.Aggregator
 	// catalog returns the registered-plugin metadata for /v1/plugins.
 	// nil disables the endpoint (returns 404). The binary wires this to
 	// plugins.Catalog; tests inject a stub provider.
@@ -100,6 +105,12 @@ func WithPipelines(inbound, outbound *pipeline.Holder) Option {
 	}
 }
 
+// WithUsage attaches a usage aggregator so the server exposes GET /v1/usage.
+// Without it that endpoint 404s.
+func WithUsage(a *usage.Aggregator) Option {
+	return func(s *Server) { s.usage = a }
+}
+
 // WithCatalog attaches a CatalogProvider so the server exposes the
 // registered-plugin catalog at GET /v1/plugins. Without this option the
 // endpoint returns 404 — useful in tests, harmless in production
@@ -125,6 +136,7 @@ func New(addr string, store *session.Store, opts ...Option) *Server {
 	mux.HandleFunc("GET /v1/events", s.handleStream)
 	mux.HandleFunc("GET /v1/pipeline", s.handlePipeline)
 	mux.HandleFunc("GET /v1/plugins", s.handlePluginCatalog)
+	mux.HandleFunc("GET /v1/usage", s.handleUsage)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 
 	s.server = &http.Server{

--- a/authbridge/authlib/sessionapi/usage.go
+++ b/authbridge/authlib/sessionapi/usage.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
 	"github.com/rossoctl/cortex/authbridge/authlib/usage"
 )
 
@@ -86,7 +87,7 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	sessionID := r.URL.Query().Get("session")
-	if len(sessionID) > maxUsageSessionIDLen {
+	if len(sessionID) > session.MaxSessionIDLen {
 		writeUsageError(w, errSessionIDTooLong)
 		return
 	}
@@ -98,10 +99,6 @@ func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 		slog.Debug("sessionapi: usage encode failed", "error", err)
 	}
 }
-
-// maxUsageSessionIDLen mirrors the store's own session-ID cap so a long query
-// string cannot be echoed back in an error message.
-const maxUsageSessionIDLen = 256
 
 type usageError struct{ msg string }
 

--- a/authbridge/authlib/sessionapi/usage.go
+++ b/authbridge/authlib/sessionapi/usage.go
@@ -1,0 +1,126 @@
+package sessionapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
+)
+
+// handleUsage serves GET /v1/usage — time-bucketed volume, error, latency and
+// cost aggregates for charting.
+//
+// Query parameters:
+//
+//	window      10m (default), 1h, 6h — any multiple of the bucket width up to
+//	            the retained maximum
+//	resolution  bucket width to return, e.g. 5m for a 1h window rendered as 12
+//	            bars. Defaults to the 1m storage resolution. Folding is done
+//	            here, not in the client, so every consumer gets the same
+//	            arithmetic — see usage.fold for why latency in particular cannot
+//	            be folded naively.
+//	session     session ID; omit for all sessions combined
+//	group       none (default), method, status, plugin
+//
+// UNAUTHENTICATED, like every endpoint on this listener. Bind it on in-cluster
+// addresses only, never behind ingress — the trust model is documented in
+// authbridge/CLAUDE.md and applies here unchanged.
+//
+// This response is less sensitive than /v1/sessions, which serves raw prompts,
+// completions and tool results. It carries no message content at all: only
+// counts, timings and cost. But it is not free of information either, and two
+// groupings leak deployment shape to anyone who can reach the port:
+//
+//   - group=method exposes the model names in use (claude-sonnet-5, and any
+//     internal or preview model an operator is testing against).
+//   - group=plugin exposes the active pipeline composition — though /v1/pipeline
+//     already publishes that in full, so this adds no new exposure.
+//
+// Cost figures also disclose spend, which is business-sensitive in a way raw
+// request counts are not. None of this changes the listener's existing posture;
+// it is written down so the decision to expose it is a decision rather than an
+// oversight.
+//
+// TODO(cost): costMicros is on the wire format but nothing populates it yet —
+// no Pricer is wired at construction, so Snapshot reports priced:false and omits
+// every cost field. The rates exist already, in the toolprune plugin's
+// defaultPatterns table, but they are package-private there and explicitly
+// documented as gateway-specific: that table measures the rossoctl LiteLLM
+// gateway, which bills well below vendor list, so applying it to a
+// direct-to-Anthropic deployment would understate cost by roughly 4x on the
+// input tier. Publishing a number that wrong is worse than publishing none.
+//
+// The shape of the fix is either to promote those rates into a shared package
+// both toolprune and this aggregator consume, or — better — to have a plugin
+// that already knows the true cost report it per response, which
+// litellm-budget-track effectively does: it reads LiteLLM's own
+// X-Litellm-Response-Cost header, the authoritative post-discount figure. That
+// would need the cost surfaced onto the session event, where the aggregator can
+// see it; today it stays inside the plugin. Until then the field is reserved so
+// adding it later is not a wire-format break, and priced:false tells a client to
+// render "cost unavailable" rather than $0.00.
+func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
+	if s.usage == nil {
+		// Aggregation not wired up (session store disabled, or an older binary
+		// composition). 404 rather than an empty snapshot: "no such channel" and
+		// "channel with nothing in it" are different answers, and a client that
+		// gets zeros would render a flat chart implying idle traffic.
+		http.Error(w, `{"error":"usage aggregation not enabled"}`, http.StatusNotFound)
+		return
+	}
+
+	window, err := usage.ParseWindow(r.URL.Query().Get("window"))
+	if err != nil {
+		writeUsageError(w, err)
+		return
+	}
+	resolution, err := usage.ParseResolution(r.URL.Query().Get("resolution"), window)
+	if err != nil {
+		writeUsageError(w, err)
+		return
+	}
+	group, err := usage.ParseGroup(r.URL.Query().Get("group"))
+	if err != nil {
+		writeUsageError(w, err)
+		return
+	}
+	sessionID := r.URL.Query().Get("session")
+	if len(sessionID) > maxUsageSessionIDLen {
+		writeUsageError(w, errSessionIDTooLong)
+		return
+	}
+
+	snap := s.usage.Snapshot(window, resolution, sessionID, group)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(snap); err != nil {
+		slog.Debug("sessionapi: usage encode failed", "error", err)
+	}
+}
+
+// maxUsageSessionIDLen mirrors the store's own session-ID cap so a long query
+// string cannot be echoed back in an error message.
+const maxUsageSessionIDLen = 256
+
+type usageError struct{ msg string }
+
+func (e usageError) Error() string { return e.msg }
+
+var errSessionIDTooLong = usageError{"session id too long"}
+
+// writeUsageError returns 400 with the validation message. Every message it can
+// carry is a fixed string authored in this package or in authlib/usage: none
+// interpolates query input. That is a requirement, not an accident — this
+// endpoint is unauthenticated, so reflecting caller-supplied bytes into a
+// response body would hand an attacker a reflection primitive. Keep it that way
+// when adding validation.
+func writeUsageError(w http.ResponseWriter, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	if encErr := json.NewEncoder(w).Encode(struct {
+		Error string `json:"error"`
+	}{Error: err.Error()}); encErr != nil {
+		slog.Debug("sessionapi: usage error encode failed", "error", encErr)
+	}
+}

--- a/authbridge/authlib/sessionapi/usage_test.go
+++ b/authbridge/authlib/sessionapi/usage_test.go
@@ -1,0 +1,200 @@
+package sessionapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
+)
+
+// fetchUsage GETs the endpoint and returns status plus raw body.
+func fetchUsage(t *testing.T, base, query string) (int, string) {
+	t.Helper()
+	resp, err := http.Get(base + "/v1/usage" + query)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, string(body)
+}
+
+// Without WithUsage the endpoint must 404, not serve an empty snapshot: zeroed
+// buckets would render as a flat chart implying idle traffic, hiding the fact
+// that aggregation is not running at all.
+func TestHandleUsage_NoAggregator404s(t *testing.T) {
+	ts, _ := newTestServer(t)
+	status, body := fetchUsage(t, ts.URL, "")
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+	if !strings.Contains(body, "not enabled") {
+		t.Errorf("body should say why: %q", body)
+	}
+}
+
+func TestHandleUsage_Defaults(t *testing.T) {
+	agg := usage.New()
+	ts, _ := newTestServer(t, WithUsage(agg))
+
+	status, body := fetchUsage(t, ts.URL, "")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", status, body)
+	}
+	var snap usage.Snapshot
+	if err := json.Unmarshal([]byte(body), &snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(snap.Buckets) != 10 {
+		t.Errorf("default window should be 10 buckets, got %d", len(snap.Buckets))
+	}
+	if snap.BucketSeconds != 60 {
+		t.Errorf("bucketSeconds = %d, want 60", snap.BucketSeconds)
+	}
+	if snap.Priced {
+		t.Error("priced = true with no Pricer wired")
+	}
+}
+
+// Query parameters must actually reach Snapshot — a handler that parsed them and
+// then ignored them would pass every validation test while serving the default
+// view.
+func TestHandleUsage_ParamsReachSnapshot(t *testing.T) {
+	agg := usage.New()
+	ts, store := newTestServer(t, WithUsage(agg))
+	store.AddRecorder(agg)
+
+	store.Append("alice", pipeline.SessionEvent{
+		At:         time.Now(),
+		Direction:  pipeline.Outbound,
+		Phase:      pipeline.SessionResponse,
+		StatusCode: 200,
+		Duration:   time.Second,
+		Inference:  &pipeline.InferenceExtension{Model: "claude-sonnet-5", TotalTokens: 300},
+	})
+
+	// resolution: 1h at 5m must fold to 12 buckets, not 60.
+	status, body := fetchUsage(t, ts.URL, "?window=1h&resolution=5m")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d: %s", status, body)
+	}
+	var snap usage.Snapshot
+	if err := json.Unmarshal([]byte(body), &snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(snap.Buckets) != 12 || snap.BucketSeconds != 300 {
+		t.Errorf("1h@5m gave %d buckets at %ds, want 12 at 300s",
+			len(snap.Buckets), snap.BucketSeconds)
+	}
+
+	// group: the series must be keyed by the requested dimension.
+	_, body = fetchUsage(t, ts.URL, "?group=method")
+	if err := json.Unmarshal([]byte(body), &snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.Group != usage.GroupMethod {
+		t.Errorf("group = %q, want method", snap.Group)
+	}
+	found := false
+	for _, b := range snap.Buckets {
+		if _, ok := b.Series["claude-sonnet-5"]; ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("group=method did not key the series by model")
+	}
+
+	// session: scoping must filter, and echo back which session it covers.
+	_, body = fetchUsage(t, ts.URL, "?session=alice")
+	if err := json.Unmarshal([]byte(body), &snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if snap.Session != "alice" {
+		t.Errorf("session = %q, want alice", snap.Session)
+	}
+	if snap.Totals.Tokens != 300 {
+		t.Errorf("alice tokens = %d, want 300", snap.Totals.Tokens)
+	}
+
+	// Fresh value: Counts fields are omitempty, so an all-zero Totals is absent
+	// from the JSON entirely. Decoding into the struct reused above would leave
+	// alice's 300 in place and the assertion would pass for the wrong reason.
+	var bobSnap usage.Snapshot
+	_, body = fetchUsage(t, ts.URL, "?session=bob")
+	if err := json.Unmarshal([]byte(body), &bobSnap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if bobSnap.Totals.Tokens != 0 {
+		t.Errorf("bob should have no traffic, got %d tokens", bobSnap.Totals.Tokens)
+	}
+}
+
+func TestHandleUsage_BadParams400(t *testing.T) {
+	ts, _ := newTestServer(t, WithUsage(usage.New()))
+
+	for _, q := range []string{
+		"?window=30s",               // finer than a bucket
+		"?window=7h",                // beyond retention
+		"?window=90s",               // not a multiple
+		"?window=nonsense",          // unparseable
+		"?group=bogus",              // unknown grouping
+		"?window=1h&resolution=90s", // resolution not a multiple
+		"?window=1h&resolution=2h",  // resolution wider than the window
+		"?resolution=30s",           // finer than storage
+	} {
+		status, body := fetchUsage(t, ts.URL, q)
+		if status != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400 (body %q)", q, status, body)
+		}
+		if !strings.Contains(body, `"error"`) {
+			t.Errorf("%s: body is not a JSON error: %q", q, body)
+		}
+	}
+}
+
+// The endpoint is unauthenticated, so an error body must never reflect
+// caller-supplied bytes back — that is a reflection primitive.
+func TestHandleUsage_ErrorsDoNotEchoInput(t *testing.T) {
+	ts, _ := newTestServer(t, WithUsage(usage.New()))
+	const probe = "<script>alert(1)</script>"
+
+	for _, q := range []string{"?group=" + probe, "?window=" + probe, "?resolution=" + probe} {
+		status, body := fetchUsage(t, ts.URL, q)
+		if status != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", q, status)
+		}
+		if strings.Contains(body, "script") {
+			t.Errorf("error body echoes caller input: %q", body)
+		}
+	}
+}
+
+// An over-long session id is rejected rather than truncated or echoed. Bounded
+// at the store's own cap so the two cannot drift.
+func TestHandleUsage_SessionIDLengthCap(t *testing.T) {
+	ts, _ := newTestServer(t, WithUsage(usage.New()))
+
+	ok := strings.Repeat("a", session.MaxSessionIDLen)
+	if status, body := fetchUsage(t, ts.URL, "?session="+ok); status != http.StatusOK {
+		t.Errorf("id at exactly the cap should be accepted, got %d: %s", status, body)
+	}
+
+	tooLong := strings.Repeat("a", session.MaxSessionIDLen+1)
+	status, body := fetchUsage(t, ts.URL, "?session="+tooLong)
+	if status != http.StatusBadRequest {
+		t.Errorf("over-long id: status = %d, want 400", status)
+	}
+	if strings.Contains(body, tooLong) {
+		t.Error("error body echoes the over-long id back")
+	}
+}

--- a/authbridge/authlib/usage/fold_test.go
+++ b/authbridge/authlib/usage/fold_test.go
@@ -1,0 +1,194 @@
+package usage
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// Folding must sum counts and keep the bucket count right: a 1h window at 5m
+// resolution is 12 bars, which is what a terminal can actually render.
+func TestFold_CountsAndBucketCount(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 0, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	// One request per minute for the last 60 minutes, 100 tokens each.
+	for i := 0; i < 60; i++ {
+		at := now.Add(-time.Duration(i) * time.Minute)
+		a.Record("s1", respEvent(at, 200, time.Second, "m", 100))
+	}
+
+	snap := a.Snapshot(time.Hour, 5*time.Minute, "", GroupNone)
+	if len(snap.Buckets) != 12 {
+		t.Fatalf("got %d buckets, want 12 (1h at 5m)", len(snap.Buckets))
+	}
+	if snap.BucketSeconds != 300 {
+		t.Errorf("bucketSeconds = %d, want 300 — a client reads this to label its axis", snap.BucketSeconds)
+	}
+	for i, b := range snap.Buckets {
+		if b.Requests != 5 {
+			t.Errorf("bucket %d requests = %d, want 5", i, b.Requests)
+		}
+		if b.Tokens != 500 {
+			t.Errorf("bucket %d tokens = %d, want 500", i, b.Tokens)
+		}
+	}
+	// Totals are summed pre-fold, so they must agree with the folded chart.
+	if snap.Totals.Requests != 60 {
+		t.Errorf("totals requests = %d, want 60", snap.Totals.Requests)
+	}
+}
+
+// The mean-of-means trap: a minute with 1 slow request must not weigh as much as
+// a minute with 99 fast ones. A naive average of the two per-minute means gives
+// 3000ms; the correct request-weighted mean is much lower.
+func TestFold_LatencyIsRequestWeightedNotMeanOfMeans(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 5, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	// Minute A: 99 requests at 1000ms.
+	minA := now.Add(-1 * time.Minute)
+	for i := 0; i < 99; i++ {
+		a.Record("s1", respEvent(minA, 200, 1000*time.Millisecond, "m", 0))
+	}
+	// Minute B: 1 request at 5000ms.
+	a.Record("s1", respEvent(now, 200, 5000*time.Millisecond, "m", 0))
+
+	folded := a.Snapshot(2*time.Minute, 2*time.Minute, "", GroupNone)
+	if len(folded.Buckets) != 1 {
+		t.Fatalf("got %d buckets, want 1", len(folded.Buckets))
+	}
+
+	// Correct: (99*1000 + 1*5000) / 100 = 1040ms.
+	const want = 1040.0
+	if got := folded.Buckets[0].LatMeanMs; math.Abs(got-want) > 1e-6 {
+		t.Errorf("folded mean = %v, want %v", got, want)
+	}
+	// The naive answer would be (1000+5000)/2 = 3000. Guard against regressing
+	// to it explicitly, since it is the plausible-looking wrong implementation.
+	if got := folded.Buckets[0].LatMeanMs; math.Abs(got-3000) < 1 {
+		t.Error("folded mean is the mean-of-means (3000ms), not request-weighted")
+	}
+}
+
+// Folding must reproduce exactly what one wider bucket would have recorded.
+// Compared against the aggregator's own single-bucket arithmetic rather than a
+// hand-computed constant, so the two paths are pinned to each other.
+func TestFold_MatchesNativeWideBucket(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 2, 30, 0, time.UTC)
+
+	// Folded: three separate minutes, folded to 3m.
+	multi := New(WithClock(fixedClock(now)))
+	latencies := [][]int{{100, 200}, {300}, {400, 500, 600}}
+	for i, group := range latencies {
+		at := now.Add(-time.Duration(2-i) * time.Minute)
+		for _, ms := range group {
+			multi.Record("s1", respEvent(at, 200, time.Duration(ms)*time.Millisecond, "m", 0))
+		}
+	}
+	folded := multi.Snapshot(3*time.Minute, 3*time.Minute, "", GroupNone).Buckets[0]
+
+	// Native: the same six samples all inside one minute.
+	single := New(WithClock(fixedClock(now)))
+	for _, group := range latencies {
+		for _, ms := range group {
+			single.Record("s1", respEvent(now, 200, time.Duration(ms)*time.Millisecond, "m", 0))
+		}
+	}
+	native := single.Snapshot(time.Minute, BucketWidth, "", GroupNone).Buckets[0]
+
+	if math.Abs(folded.LatMeanMs-native.LatMeanMs) > 1e-6 {
+		t.Errorf("folded mean %v != native %v", folded.LatMeanMs, native.LatMeanMs)
+	}
+	if math.Abs(folded.LatStdDevMs-native.LatStdDevMs) > 1e-6 {
+		t.Errorf("folded stddev %v != native %v", folded.LatStdDevMs, native.LatStdDevMs)
+	}
+	if folded.Requests != native.Requests {
+		t.Errorf("folded requests %d != native %d", folded.Requests, native.Requests)
+	}
+}
+
+// Grouped series must merge across folded buckets, not be dropped or overwritten.
+func TestFold_MergesSeries(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 3, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", respEvent(now.Add(-2*time.Minute), 200, time.Second, "sonnet", 10))
+	a.Record("s1", respEvent(now.Add(-time.Minute), 429, time.Second, "sonnet", 20))
+	a.Record("s1", respEvent(now, 200, time.Second, "opus", 30))
+
+	b := a.Snapshot(3*time.Minute, 3*time.Minute, "", GroupStatus).Buckets[0]
+	if got := b.Series["200"].Requests; got != 2 {
+		t.Errorf("status 200 requests = %d, want 2", got)
+	}
+	if got := b.Series["429"].Requests; got != 1 {
+		t.Errorf("status 429 requests = %d, want 1", got)
+	}
+	if got := b.Series["200"].Tokens; got != 40 {
+		t.Errorf("status 200 tokens = %d, want 40", got)
+	}
+}
+
+// An idle stretch must survive folding as a zeroed bucket, not vanish — the
+// whole point of emitting idle buckets in the first place.
+func TestFold_PreservesIdleBuckets(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 10, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+	a.Record("s1", respEvent(now, 200, time.Second, "m", 100))
+
+	snap := a.Snapshot(10*time.Minute, 5*time.Minute, "", GroupNone)
+	if len(snap.Buckets) != 2 {
+		t.Fatalf("got %d buckets, want 2", len(snap.Buckets))
+	}
+	if snap.Buckets[0].Requests != 0 {
+		t.Errorf("first 5m block should be idle, got %d requests", snap.Buckets[0].Requests)
+	}
+	if snap.Buckets[1].Requests != 1 {
+		t.Errorf("second 5m block = %d requests, want 1", snap.Buckets[1].Requests)
+	}
+}
+
+// A partial trailing group must still be emitted rather than truncated: the
+// current, still-filling block is the one an operator is watching.
+func TestFold_PartialGroupIsKept(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 7, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+	a.Record("s1", respEvent(now, 200, time.Second, "m", 100))
+
+	// 7 minutes at 3m resolution: 3 + 3 + 1.
+	snap := a.Snapshot(7*time.Minute, 3*time.Minute, "", GroupNone)
+	if len(snap.Buckets) != 3 {
+		t.Fatalf("got %d buckets, want 3 (3+3+1)", len(snap.Buckets))
+	}
+	if snap.Buckets[2].Requests != 1 {
+		t.Errorf("trailing partial block lost its traffic: %+v", snap.Buckets[2].Counts)
+	}
+}
+
+func TestParseResolution(t *testing.T) {
+	for _, tc := range []struct {
+		res    string
+		window time.Duration
+		want   time.Duration
+		ok     bool
+	}{
+		{"", time.Hour, BucketWidth, true},
+		{"1m", time.Hour, time.Minute, true},
+		{"5m", time.Hour, 5 * time.Minute, true},
+		{"30s", time.Hour, 0, false}, // finer than storage
+		{"90s", time.Hour, 0, false}, // not a multiple
+		{"2h", time.Hour, 0, false},  // coarser than the window
+		{"garbage", time.Hour, 0, false},
+	} {
+		got, err := ParseResolution(tc.res, tc.window)
+		if tc.ok && err != nil {
+			t.Errorf("ParseResolution(%q) = %v, want nil", tc.res, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("ParseResolution(%q) = nil, want an error", tc.res)
+		}
+		if tc.ok && got != tc.want {
+			t.Errorf("ParseResolution(%q) = %v, want %v", tc.res, got, tc.want)
+		}
+	}
+}

--- a/authbridge/authlib/usage/snapshot.go
+++ b/authbridge/authlib/usage/snapshot.go
@@ -1,0 +1,283 @@
+package usage
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+// Group selects which label breakdown a Snapshot carries.
+type Group string
+
+const (
+	GroupNone   Group = "none"
+	GroupMethod Group = "method"
+	GroupStatus Group = "status"
+	GroupPlugin Group = "plugin"
+)
+
+// ParseGroup validates a group parameter. Empty means GroupNone.
+func ParseGroup(s string) (Group, error) {
+	switch Group(s) {
+	case "", GroupNone:
+		return GroupNone, nil
+	case GroupMethod:
+		return GroupMethod, nil
+	case GroupStatus:
+		return GroupStatus, nil
+	case GroupPlugin:
+		return GroupPlugin, nil
+	}
+	// Deliberately does NOT echo the caller's value: this message is returned
+	// over an unauthenticated endpoint, and reflecting arbitrary query input
+	// into a response body is how a reflected-content issue starts. The valid
+	// set is short enough that naming it is more useful than quoting the input.
+	return "", errors.New("unknown group (want none, method, status or plugin)")
+}
+
+// Snapshot is the wire shape of GET /v1/usage.
+type Snapshot struct {
+	// Window is the requested span, e.g. "10m".
+	Window string `json:"window"`
+	// BucketSeconds is the resolution of the buckets actually returned, which is
+	// the requested resolution rounded to a whole multiple of BucketWidth. A
+	// client reads this rather than assuming: asking for a resolution the
+	// storage cannot divide evenly gets the nearest one that works, not an
+	// error.
+	BucketSeconds int `json:"bucketSeconds"`
+	// Session is the session this covers, or "" for all sessions combined.
+	Session string `json:"session,omitempty"`
+	Group   Group  `json:"group"`
+	// Buckets runs oldest to newest and always has Window/BucketWidth entries,
+	// including zeroed ones for idle minutes.
+	Buckets []Bucket `json:"buckets"`
+	// Totals sums every bucket, so a client need not re-add them to render a
+	// summary line.
+	Totals Counts `json:"totals"`
+	// Priced reports whether a Pricer was configured. Without it CostMicros is
+	// absent everywhere, and a client must say "cost unavailable" rather than
+	// display $0.00 — which would read as "this traffic was free".
+	Priced bool `json:"priced"`
+}
+
+// ParseWindow validates a window parameter against the storage resolution.
+func ParseWindow(s string) (time.Duration, error) {
+	if s == "" {
+		return 10 * BucketWidth, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		// Not wrapped with the caller's string, for the reason in ParseGroup.
+		// time.ParseDuration's own error quotes the input, so it is not
+		// forwarded either.
+		return 0, errors.New("bad window (want a duration such as 10m, 1h or 6h)")
+	}
+	if d < BucketWidth {
+		return 0, fmt.Errorf("window %s is shorter than the %s bucket width", d, BucketWidth)
+	}
+	if d > MaxWindow {
+		return 0, fmt.Errorf("window %s exceeds the %s retained", d, MaxWindow)
+	}
+	if d%BucketWidth != 0 {
+		return 0, fmt.Errorf("window %s is not a multiple of %s", d, BucketWidth)
+	}
+	return d, nil
+}
+
+// ParseResolution validates a resolution parameter — the width of the buckets
+// the caller wants back, as opposed to the window's total span.
+//
+// Folding happens server-side so every client gets the same arithmetic. A 1h
+// window at 1m resolution is 60 bars, which no terminal renders legibly; at 5m
+// it is 12. Doing that here rather than in each client means the mean-of-means
+// problem below is solved once, correctly, instead of per consumer.
+//
+// Zero or empty means "storage resolution" (BucketWidth). A resolution finer
+// than BucketWidth is an error rather than a silent upgrade: returning coarser
+// data than asked for would make a client's axis labels wrong.
+func ParseResolution(s string, window time.Duration) (time.Duration, error) {
+	if s == "" {
+		return BucketWidth, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		// Does not echo the caller's value — see ParseGroup.
+		return 0, errors.New("bad resolution (want a duration such as 1m, 5m or 30m)")
+	}
+	if d < BucketWidth {
+		return 0, fmt.Errorf("resolution %s is finer than the %s storage bucket", d, BucketWidth)
+	}
+	if d%BucketWidth != 0 {
+		return 0, fmt.Errorf("resolution %s is not a multiple of %s", d, BucketWidth)
+	}
+	if d > window {
+		return 0, fmt.Errorf("resolution %s exceeds the %s window", d, window)
+	}
+	return d, nil
+}
+
+// fold groups src into buckets of the given width, summing counts and combining
+// latency statistics.
+//
+// Latency is the part that cannot be done naively. Averaging the per-minute
+// means would weight a minute with 1 request equally with a minute with 500 —
+// the mean-of-means error. Instead each source bucket's running sums are
+// reconstituted (sum = mean x n, sumSq recovered from the variance identity) and
+// re-accumulated, so the folded mean and standard deviation are exactly what a
+// single wider bucket would have recorded.
+func fold(src []Bucket, width time.Duration) []Bucket {
+	if width <= BucketWidth || len(src) == 0 {
+		return src
+	}
+	per := int(width / BucketWidth)
+	out := make([]Bucket, 0, (len(src)+per-1)/per)
+
+	for i := 0; i < len(src); i += per {
+		end := i + per
+		if end > len(src) {
+			end = len(src)
+		}
+		acc := Bucket{At: src[i].At}
+		var latSum, latSumSq float64
+		var latN int64
+		series := map[string]Counts{}
+
+		for _, b := range src[i:end] {
+			acc.Counts.add(b.Counts)
+			if b.LatMeanMs > 0 && b.Requests > 0 {
+				n := float64(b.Requests)
+				sum := b.LatMeanMs * n
+				// variance = sumSq/n - mean^2  =>  sumSq = n*(variance + mean^2)
+				sumSq := n * (b.LatStdDevMs*b.LatStdDevMs + b.LatMeanMs*b.LatMeanMs)
+				latSum += sum
+				latSumSq += sumSq
+				latN += b.Requests
+			}
+			for k, v := range b.Series {
+				cur := series[k]
+				cur.add(v)
+				series[k] = cur
+			}
+		}
+
+		if latN > 0 {
+			n := float64(latN)
+			acc.LatMeanMs = latSum / n
+			if variance := latSumSq/n - acc.LatMeanMs*acc.LatMeanMs; variance > 0 {
+				acc.LatStdDevMs = math.Sqrt(variance)
+			}
+		}
+		if len(series) > 0 {
+			acc.Series = series
+		}
+		out = append(out, acc)
+	}
+	return out
+}
+
+// Snapshot returns the last window of buckets, oldest first.
+//
+// The newest bucket is the one containing now, still filling — a client
+// rendering it should expect its final value to rise. Reporting it partially is
+// better than withholding it: an operator watching a live chart wants the
+// current minute visible.
+//
+// An unknown session yields a snapshot of all-zero buckets rather than an error:
+// a session that has produced no priceable traffic yet is a normal state, and
+// the caller already knows whether the session exists from /v1/sessions.
+func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string, group Group) Snapshot {
+	if resolution < BucketWidth {
+		resolution = BucketWidth
+	}
+	n := int(window / BucketWidth)
+	if n < 1 {
+		n = 1
+	}
+	if n > NumBuckets {
+		n = NumBuckets
+	}
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	ring := a.all
+	if sessionID != "" {
+		r, ok := a.sessions[sessionID]
+		if !ok {
+			ring = nil // fall through: emits zeroed buckets at the right times
+		} else {
+			ring = r
+		}
+	}
+
+	newest := a.now().Truncate(BucketWidth)
+	out := Snapshot{
+		Window:        window.String(),
+		BucketSeconds: int(resolution / time.Second),
+		Session:       sessionID,
+		Group:         group,
+		Priced:        a.pricer != nil,
+		Buckets:       make([]Bucket, 0, n),
+	}
+
+	for i := n - 1; i >= 0; i-- {
+		t := newest.Add(-time.Duration(i) * BucketWidth)
+		b := Bucket{At: t}
+		if ring != nil {
+			if src := &ring[slot(t)]; src.start.Equal(t) {
+				b.Counts = src.Counts
+				b.LatMeanMs, b.LatStdDevMs = src.latStats()
+				b.Series = src.series(group)
+			}
+		}
+		out.Totals.add(b.Counts)
+		out.Buckets = append(out.Buckets, b)
+	}
+	// Fold last: totals are summed from the raw buckets above and are unaffected
+	// by grouping width, so a client's summary line agrees with its chart no
+	// matter which resolution it asked for.
+	out.Buckets = fold(out.Buckets, resolution)
+	return out
+}
+
+// latStats derives mean and population standard deviation from the running
+// sums. Guarded against a small negative variance, which float cancellation can
+// produce when every sample is identical.
+func (b *bucket) latStats() (mean, stddev float64) {
+	if b.Requests == 0 || b.latSum == 0 {
+		return 0, 0
+	}
+	n := float64(b.Requests)
+	mean = b.latSum / n
+	variance := b.latSumSq/n - mean*mean
+	if variance <= 0 {
+		return mean, 0
+	}
+	return mean, math.Sqrt(variance)
+}
+
+// series copies the requested label map. Copied, not aliased: the caller holds
+// only a read lock, and handing out the live map would let a JSON encoder read
+// it while a later Record mutates it.
+func (b *bucket) series(g Group) map[string]Counts {
+	var src map[string]Counts
+	switch g {
+	case GroupMethod:
+		src = b.byMethod
+	case GroupStatus:
+		src = b.byStatus
+	case GroupPlugin:
+		src = b.byPlugin
+	default:
+		return nil
+	}
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]Counts, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}

--- a/authbridge/authlib/usage/snapshot.go
+++ b/authbridge/authlib/usage/snapshot.go
@@ -145,14 +145,17 @@ func fold(src []Bucket, width time.Duration) []Bucket {
 
 		for _, b := range src[i:end] {
 			acc.Counts.add(b.Counts)
-			if b.LatMeanMs > 0 && b.Requests > 0 {
-				n := float64(b.Requests)
+			// Weighted by LatSamples, not Requests: the source mean was computed
+			// over measured requests only, so reconstituting with Requests would
+			// re-introduce the dilution latStats exists to avoid.
+			if b.LatMeanMs > 0 && b.LatSamples > 0 {
+				n := float64(b.LatSamples)
 				sum := b.LatMeanMs * n
 				// variance = sumSq/n - mean^2  =>  sumSq = n*(variance + mean^2)
 				sumSq := n * (b.LatStdDevMs*b.LatStdDevMs + b.LatMeanMs*b.LatMeanMs)
 				latSum += sum
 				latSumSq += sumSq
-				latN += b.Requests
+				latN += b.LatSamples
 			}
 			for k, v := range b.Series {
 				cur := series[k]
@@ -162,6 +165,7 @@ func fold(src []Bucket, width time.Duration) []Bucket {
 		}
 
 		if latN > 0 {
+			acc.LatSamples = latN
 			n := float64(latN)
 			acc.LatMeanMs = latSum / n
 			if variance := latSumSq/n - acc.LatMeanMs*acc.LatMeanMs; variance > 0 {
@@ -207,7 +211,7 @@ func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string
 		if !ok {
 			ring = nil // fall through: emits zeroed buckets at the right times
 		} else {
-			ring = r
+			ring = r.buckets
 		}
 	}
 
@@ -228,6 +232,7 @@ func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string
 			if src := &ring[slot(t)]; src.start.Equal(t) {
 				b.Counts = src.Counts
 				b.LatMeanMs, b.LatStdDevMs = src.latStats()
+				b.LatSamples = src.latN
 				b.Series = src.series(group)
 			}
 		}
@@ -245,10 +250,13 @@ func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string
 // sums. Guarded against a small negative variance, which float cancellation can
 // produce when every sample is identical.
 func (b *bucket) latStats() (mean, stddev float64) {
-	if b.Requests == 0 || b.latSum == 0 {
+	if b.latN == 0 || b.latSum == 0 {
 		return 0, 0
 	}
-	n := float64(b.Requests)
+	// Divide by the number of MEASURED requests, not all of them. A response with
+	// a zero duration is unmeasured, not instant, and counting it in the divisor
+	// understates the mean in proportion to how many such responses there were.
+	n := float64(b.latN)
 	mean = b.latSum / n
 	variance := b.latSumSq/n - mean*mean
 	if variance <= 0 {

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -145,7 +145,14 @@ func WithPricer(p Pricer) Option { return func(a *Aggregator) { a.pricer = p } }
 // WithClock overrides time.Now, for deterministic tests.
 func WithClock(now func() time.Time) Option { return func(a *Aggregator) { a.now = now } }
 
-// WithMaxSessions bounds the number of per-session rings retained.
+// WithMaxSessions bounds the number of per-session rings retained. Each ring is
+// NumBuckets buckets, so this is the knob that bounds worst-case memory.
+//
+// n == 0 means track NO per-session rings: /v1/usage?session=... returns zeroed
+// buckets, while the all-sessions aggregate keeps counting everything. That is
+// the reading the name implies, and the safe one if this is ever wired to
+// operator config — a 0 in a ConfigMap should not silently mean "unlimited".
+// Pass a negative n to leave the default in place.
 func WithMaxSessions(n int) Option {
 	return func(a *Aggregator) {
 		if n >= 0 {
@@ -198,9 +205,10 @@ func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
 		a.foldInto(ring, t, e)
 		return
 	}
-	// Cap reached: the event still counts toward the all-sessions total above,
-	// it just gets no per-session breakdown.
-	if a.maxSess > 0 && len(a.sessions) >= a.maxSess {
+	// Cap reached: the event still counts toward the all-sessions total above, it
+	// just gets no per-session breakdown. maxSess == 0 means no per-session rings
+	// at all, so every session takes this path — see WithMaxSessions.
+	if len(a.sessions) >= a.maxSess {
 		return
 	}
 	ring := make([]bucket, NumBuckets)

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -1,0 +1,285 @@
+// Package usage aggregates session events into fixed-width time buckets so a
+// client can chart volume, errors, latency and cost over wall-clock time.
+//
+// It lives server-side on purpose. An aggregate built inside a client would
+// start empty when that client connected, so two operators watching the same
+// pod would see different histories of the same traffic — and neither would see
+// anything from before they attached. The store is the only place with the whole
+// picture, so the arithmetic belongs next to it.
+//
+// Memory is O(buckets x distinct labels), independent of event volume: mean and
+// standard deviation come from running sums (count, sum, sum-of-squares) rather
+// than from retained samples, and every bucket is preallocated in a fixed ring.
+// Nothing here grows with traffic.
+package usage
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+const (
+	// BucketWidth is the storage resolution. Every window the API offers is a
+	// whole multiple of it, and clients fold buckets together for wider views
+	// rather than asking the server to pre-aggregate — one storage shape, and a
+	// client is free to pick its own on-screen resolution.
+	BucketWidth = time.Minute
+
+	// NumBuckets covers the longest window offered (6h). The ring is
+	// preallocated at this size for both the all-sessions aggregate and each
+	// tracked session.
+	NumBuckets = 360
+
+	// MaxWindow is the longest span Snapshot will return.
+	MaxWindow = NumBuckets * BucketWidth
+)
+
+// defaultMaxSessions bounds how many per-session rings are tracked. Each ring
+// is NumBuckets buckets, so this is the knob that bounds worst-case memory.
+// Sessions beyond the cap still land in the all-sessions aggregate; only their
+// individual breakdown is dropped.
+const defaultMaxSessions = 64
+
+// Counts is the per-label tuple accumulated in each bucket.
+type Counts struct {
+	Requests int64 `json:"requests"`
+	Errors   int64 `json:"errors,omitempty"`
+	Tokens   int64 `json:"tokens,omitempty"`
+	// CostMicros is millionths of a US dollar. An integer unit keeps bucket
+	// addition exact and JSON round-tripping lossless, which float dollars do
+	// not; a client divides by 1e6 to display. Zero when no pricer is
+	// configured, which is not the same as "this traffic was free" — the API
+	// omits the field entirely in that case rather than asserting $0.
+	CostMicros int64 `json:"costMicros,omitempty"`
+}
+
+func (c *Counts) add(o Counts) {
+	c.Requests += o.Requests
+	c.Errors += o.Errors
+	c.Tokens += o.Tokens
+	c.CostMicros += o.CostMicros
+}
+
+// Bucket is one BucketWidth slice of time, as served to clients.
+//
+// A bucket with no traffic is still emitted, with zeroed counts. That is
+// deliberate: a client rendering a bar chart must be able to distinguish an idle
+// minute from a minute that fell off the end of the ring, and inferring absent
+// buckets from timestamps is exactly the kind of thing every client would get
+// slightly differently.
+type Bucket struct {
+	At          time.Time `json:"at"`
+	Counts                // totals across every label
+	LatMeanMs   float64   `json:"latMeanMs,omitempty"`
+	LatStdDevMs float64   `json:"latStdDevMs,omitempty"`
+	// Series is the requested grouping, keyed by model / status / plugin name.
+	// Nil when group=none.
+	Series map[string]Counts `json:"series,omitempty"`
+}
+
+// bucket is the internal accumulator. It keeps all three groupings at once so
+// the group= parameter is a read-time choice: an operator cycling groupings in a
+// TUI sees the same history from each angle, instead of each grouping only
+// having data from the moment it was first selected.
+type bucket struct {
+	start time.Time // truncated to BucketWidth; zero means never written
+	Counts
+	latSum   float64 // milliseconds
+	latSumSq float64 // milliseconds squared, for stddev
+	byMethod map[string]Counts
+	byStatus map[string]Counts
+	byPlugin map[string]Counts
+}
+
+// Pricer converts a model name and token count to millionths of a dollar.
+// Optional: a nil Pricer leaves CostMicros zero and the API omits it.
+//
+// Injected rather than implemented here because rates are deployment-specific —
+// a gateway bills differently from the vendor's list price — and authlib has no
+// business asserting one.
+//
+// TODO(cost): no caller supplies one yet, so CostMicros is always zero and
+// Snapshot reports priced:false. Two candidate sources, neither reachable from
+// here today:
+//
+//   - toolprune's defaultPatterns table has per-family rates, but it is
+//     package-private and measured against the rossoctl LiteLLM gateway, which
+//     bills well below vendor list. Applying it to a direct-to-Anthropic
+//     deployment understates cost by roughly 4x on the input tier.
+//   - litellm-budget-track already reads the authoritative post-discount figure
+//     from LiteLLM's X-Litellm-Response-Cost header, but keeps it inside the
+//     plugin. Surfacing it onto the session event would let the aggregator use a
+//     real number instead of a modelled one, which is the better fix.
+//
+// The field is reserved on the wire now so adding it later is not a breaking
+// change.
+type Pricer func(model string, tokens int64) int64
+
+// Aggregator is a fixed ring of per-minute buckets. Safe for concurrent use.
+//
+// Expiry is implicit: a slot is indexed by minutes-since-epoch modulo
+// NumBuckets, so a write whose timestamp does not match the slot's recorded
+// start has landed on a stale bucket from a previous lap and resets it. No
+// sweeper goroutine, no cleanup path. The tradeoff is that a large backwards
+// clock jump can reset buckets that were still current; for observability
+// counters that is acceptable, and it is preferable to a timer that has to be
+// stopped on shutdown.
+type Aggregator struct {
+	mu       sync.RWMutex
+	all      []bucket
+	sessions map[string][]bucket
+	maxSess  int
+	pricer   Pricer
+	now      func() time.Time
+}
+
+// Option configures an Aggregator.
+type Option func(*Aggregator)
+
+// WithPricer supplies cost rates. Without it, CostMicros stays zero.
+func WithPricer(p Pricer) Option { return func(a *Aggregator) { a.pricer = p } }
+
+// WithClock overrides time.Now, for deterministic tests.
+func WithClock(now func() time.Time) Option { return func(a *Aggregator) { a.now = now } }
+
+// WithMaxSessions bounds the number of per-session rings retained.
+func WithMaxSessions(n int) Option {
+	return func(a *Aggregator) {
+		if n >= 0 {
+			a.maxSess = n
+		}
+	}
+}
+
+// New returns an empty Aggregator.
+func New(opts ...Option) *Aggregator {
+	a := &Aggregator{
+		all:      make([]bucket, NumBuckets),
+		sessions: make(map[string][]bucket),
+		maxSess:  defaultMaxSessions,
+		now:      time.Now,
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+// Record folds one event into the aggregate.
+//
+// Response events only: a request event carries no status, no duration and no
+// usage, so counting it would double every request and pull the latency mean
+// toward zero. Denials (phase "denied") are counted as errors — they are
+// requests that happened and failed, and omitting them would make an
+// authentication outage look like a traffic drop.
+func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
+	if e == nil {
+		return
+	}
+	if e.Phase != pipeline.SessionResponse && e.Phase != pipeline.SessionDenied {
+		return
+	}
+
+	at := e.At
+	if at.IsZero() {
+		at = a.now()
+	}
+	t := at.Truncate(BucketWidth)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.foldInto(a.all, t, e)
+
+	if ring, ok := a.sessions[sessionID]; ok {
+		a.foldInto(ring, t, e)
+		return
+	}
+	// Cap reached: the event still counts toward the all-sessions total above,
+	// it just gets no per-session breakdown.
+	if a.maxSess > 0 && len(a.sessions) >= a.maxSess {
+		return
+	}
+	ring := make([]bucket, NumBuckets)
+	a.sessions[sessionID] = ring
+	a.foldInto(ring, t, e)
+}
+
+func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEvent) {
+	b := &ring[slot(t)]
+	if !b.start.Equal(t) {
+		*b = bucket{start: t} // stale lap: reset rather than accumulate onto old data
+	}
+
+	var tokens, cost int64
+	var model string
+	if e.Inference != nil {
+		tokens = int64(e.Inference.TotalTokens)
+		model = e.Inference.Model
+		if a.pricer != nil && tokens > 0 {
+			cost = a.pricer(model, tokens)
+		}
+	}
+
+	one := Counts{Requests: 1, Tokens: tokens, CostMicros: cost}
+	if e.StatusCode >= 400 || e.Phase == pipeline.SessionDenied {
+		one.Errors = 1
+	}
+	b.Counts.add(one)
+
+	// Latency: only from events that actually carry one. A zero duration is
+	// "not measured", not "instant", and folding it in would drag the mean down.
+	if ms := float64(e.Duration.Milliseconds()); ms > 0 {
+		b.latSum += ms
+		b.latSumSq += ms * ms
+	}
+
+	if model != "" {
+		addLabel(&b.byMethod, model, one)
+	}
+	if e.StatusCode > 0 {
+		addLabel(&b.byStatus, strconv.Itoa(e.StatusCode), one)
+	} else if e.Phase == pipeline.SessionDenied {
+		addLabel(&b.byStatus, "denied", one)
+	}
+	// Per-plugin attribution counts the request once per plugin that ran, so
+	// these sub-totals intentionally sum to more than Requests when several
+	// plugins touched one message. Tokens are attributed whole to each plugin
+	// for the same reason: there is no defensible way to split one response's
+	// usage between the plugins that observed it.
+	// Invocations is a POINTER and is nil whenever no plugin appended a record —
+	// which is the common case for a plain proxied response. Dereferencing it
+	// unguarded panics inside Store.Append, i.e. on the request hot path.
+	if e.Invocations != nil {
+		for _, inv := range e.Invocations.Outbound {
+			if inv.Plugin != "" {
+				addLabel(&b.byPlugin, inv.Plugin, one)
+			}
+		}
+		for _, inv := range e.Invocations.Inbound {
+			if inv.Plugin != "" {
+				addLabel(&b.byPlugin, inv.Plugin, one)
+			}
+		}
+	}
+}
+
+func addLabel(m *map[string]Counts, key string, c Counts) {
+	if *m == nil {
+		*m = make(map[string]Counts, 4)
+	}
+	cur := (*m)[key]
+	cur.add(c)
+	(*m)[key] = cur
+}
+
+func slot(t time.Time) int {
+	s := int(t.Unix()/int64(BucketWidth/time.Second)) % NumBuckets
+	if s < 0 {
+		s += NumBuckets
+	}
+	return s
+}

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -75,6 +75,12 @@ type Bucket struct {
 	Counts                // totals across every label
 	LatMeanMs   float64   `json:"latMeanMs,omitempty"`
 	LatStdDevMs float64   `json:"latStdDevMs,omitempty"`
+	// LatSamples is how many requests in this bucket carried a duration, which
+	// is not always Requests: an unmeasured response counts as traffic but not
+	// as a latency sample. Folding needs it to weight each bucket by its real
+	// sample count, and a client showing a window-wide mean needs it for the
+	// same reason.
+	LatSamples int64 `json:"latSamples,omitempty"`
 	// Series is the requested grouping, keyed by model / status / plugin name.
 	// Nil when group=none.
 	Series map[string]Counts `json:"series,omitempty"`
@@ -89,6 +95,10 @@ type bucket struct {
 	Counts
 	latSum   float64 // milliseconds
 	latSumSq float64 // milliseconds squared, for stddev
+	// latN counts only the requests that actually carried a duration. Dividing
+	// latSum by Requests instead reports a mean diluted by every unmeasured
+	// response: one 2s response plus one unmeasured one reported 1s, not 2s.
+	latN     int64
 	byMethod map[string]Counts
 	byStatus map[string]Counts
 	byPlugin map[string]Counts
@@ -130,10 +140,25 @@ type Pricer func(model string, tokens int64) int64
 type Aggregator struct {
 	mu       sync.RWMutex
 	all      []bucket
-	sessions map[string][]bucket
+	sessions map[string]*sessionRing
 	maxSess  int
 	pricer   Pricer
 	now      func() time.Time
+}
+
+// sessionRing is one session's buckets plus the last time it was written.
+//
+// lastSeen exists because the store evicts and expires sessions without telling
+// the aggregator. Without reclamation, a pod that churns through session ids
+// fills the map to the cap and then refuses every new session forever:
+// /v1/sessions would list a live session while /v1/usage?session=<id> returned
+// zeroed buckets, which looks exactly like "this session did nothing". Matching
+// the store's own cap only delays that. Reusing the coldest ring instead bounds
+// memory AND keeps the newest sessions answerable, which is what an operator is
+// looking at.
+type sessionRing struct {
+	buckets  []bucket
+	lastSeen time.Time
 }
 
 // Option configures an Aggregator.
@@ -165,7 +190,7 @@ func WithMaxSessions(n int) Option {
 func New(opts ...Option) *Aggregator {
 	a := &Aggregator{
 		all:      make([]bucket, NumBuckets),
-		sessions: make(map[string][]bucket),
+		sessions: make(map[string]*sessionRing),
 		maxSess:  defaultMaxSessions,
 		now:      time.Now,
 	}
@@ -202,18 +227,44 @@ func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
 	a.foldInto(a.all, t, e)
 
 	if ring, ok := a.sessions[sessionID]; ok {
-		a.foldInto(ring, t, e)
+		ring.lastSeen = at
+		a.foldInto(ring.buckets, t, e)
 		return
 	}
-	// Cap reached: the event still counts toward the all-sessions total above, it
-	// just gets no per-session breakdown. maxSess == 0 means no per-session rings
-	// at all, so every session takes this path — see WithMaxSessions.
+	// maxSess == 0 means no per-session rings at all — see WithMaxSessions. The
+	// event still counts toward the all-sessions total above.
+	if a.maxSess == 0 {
+		return
+	}
+	// At the cap, reclaim the least-recently-written ring rather than refuse the
+	// new session. The store expires and evicts sessions without notifying us, so
+	// the coldest ring is very likely one the store has already dropped; refusing
+	// instead would make every session after the first maxSess unanswerable for
+	// the life of the process.
 	if len(a.sessions) >= a.maxSess {
-		return
+		a.evictColdestLocked()
 	}
-	ring := make([]bucket, NumBuckets)
+	ring := &sessionRing{buckets: make([]bucket, NumBuckets), lastSeen: at}
 	a.sessions[sessionID] = ring
-	a.foldInto(ring, t, e)
+	a.foldInto(ring.buckets, t, e)
+}
+
+// evictColdestLocked drops the ring with the oldest lastSeen. Caller holds mu.
+//
+// Linear scan rather than a heap: maxSess is a few dozen, this runs only when the
+// map is full and a genuinely new session arrives, and a heap would need
+// maintaining on every write instead.
+func (a *Aggregator) evictColdestLocked() {
+	var coldestID string
+	var coldest time.Time
+	for id, r := range a.sessions {
+		if coldestID == "" || r.lastSeen.Before(coldest) {
+			coldestID, coldest = id, r.lastSeen
+		}
+	}
+	if coldestID != "" {
+		delete(a.sessions, coldestID)
+	}
 }
 
 func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEvent) {
@@ -243,10 +294,11 @@ func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEve
 	if ms := float64(e.Duration.Milliseconds()); ms > 0 {
 		b.latSum += ms
 		b.latSumSq += ms * ms
+		b.latN++
 	}
 
 	if model != "" {
-		addLabel(&b.byMethod, model, one)
+		addLabel(&b.byMethod, truncateLabel(model), one)
 	}
 	if e.StatusCode > 0 {
 		addLabel(&b.byStatus, strconv.Itoa(e.StatusCode), one)
@@ -275,9 +327,48 @@ func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEve
 	}
 }
 
+// maxLabelsPerBucket caps distinct keys in one bucket's grouping map.
+//
+// The model name comes off the request body, so its cardinality is set by
+// whatever the client sends, not by anything this process controls. Unbounded, a
+// caller varying the model string every request would add a retained map entry
+// and a retained string per request, in a ring that only frees a slot when it is
+// reused a full lap later — 6h at one minute. That is memory growth driven from
+// off-host, on the synchronous session-append path.
+//
+// 64 is well above any real deployment: a pod talks to a handful of models, a
+// few status codes and its own plugin list. Past the cap, further keys fold into
+// overflowLabel so the totals stay correct and the excess is visible rather than
+// silently dropped.
+const maxLabelsPerBucket = 64
+
+// overflowLabel collects everything past maxLabelsPerBucket. Named rather than
+// dropped so a chart's segments still sum to the bucket total, and so an
+// operator can see that cardinality was capped instead of wondering why a model
+// is missing.
+const overflowLabel = "(other)"
+
+// maxLabelLen bounds one retained label. The model name is request-controlled, so
+// without this a caller could park a megabyte of string in a bucket that lives
+// for a full ring lap. Long enough for any real model id, including provider
+// prefixes and dated suffixes.
+const maxLabelLen = 96
+
+func truncateLabel(s string) string {
+	if len(s) <= maxLabelLen {
+		return s
+	}
+	return s[:maxLabelLen]
+}
+
 func addLabel(m *map[string]Counts, key string, c Counts) {
 	if *m == nil {
 		*m = make(map[string]Counts, 4)
+	}
+	// Reserve the last slot for overflowLabel: switching to it only once the map
+	// is already full would make the overflow key itself the (cap+1)th entry.
+	if _, ok := (*m)[key]; !ok && len(*m) >= maxLabelsPerBucket-1 {
+		key = overflowLabel
 	}
 	cur := (*m)[key]
 	cur.add(c)

--- a/authbridge/authlib/usage/usage_test.go
+++ b/authbridge/authlib/usage/usage_test.go
@@ -1,0 +1,351 @@
+package usage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// fixedClock returns a controllable now, so bucket boundaries are exact rather
+// than dependent on when the test happens to run.
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+func respEvent(at time.Time, status int, dur time.Duration, model string, tokens int) *pipeline.SessionEvent {
+	e := &pipeline.SessionEvent{
+		At:         at,
+		Direction:  pipeline.Outbound,
+		Phase:      pipeline.SessionResponse,
+		StatusCode: status,
+		Duration:   dur,
+	}
+	if model != "" || tokens > 0 {
+		e.Inference = &pipeline.InferenceExtension{Model: model, TotalTokens: tokens}
+	}
+	return e
+}
+
+// An idle minute must come back as a present, zeroed bucket. A client cannot
+// otherwise tell "no traffic" from "fell off the ring", and that distinction is
+// what makes a gap visible in a bar chart.
+func TestSnapshot_IdleBucketsArePresentAndZero(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 0, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", respEvent(now.Add(-9*time.Minute), 200, time.Second, "claude-sonnet-5", 100))
+
+	snap := a.Snapshot(10*time.Minute, BucketWidth, "", GroupNone)
+	if len(snap.Buckets) != 10 {
+		t.Fatalf("got %d buckets, want 10", len(snap.Buckets))
+	}
+	if snap.Buckets[0].Requests != 1 {
+		t.Errorf("oldest bucket requests = %d, want 1", snap.Buckets[0].Requests)
+	}
+	for i, b := range snap.Buckets[1:] {
+		if b.Requests != 0 || b.Tokens != 0 {
+			t.Errorf("bucket %d should be idle, got %+v", i+1, b.Counts)
+		}
+		if b.At.IsZero() {
+			t.Errorf("idle bucket %d has no timestamp — a client cannot place it on an axis", i+1)
+		}
+	}
+	// Buckets must be chronological and exactly one width apart.
+	for i := 1; i < len(snap.Buckets); i++ {
+		if d := snap.Buckets[i].At.Sub(snap.Buckets[i-1].At); d != BucketWidth {
+			t.Errorf("gap between bucket %d and %d = %s, want %s", i-1, i, d, BucketWidth)
+		}
+	}
+}
+
+// Mean and stddev must come out of the running sums correctly. Values chosen so
+// the answer is exact in binary floating point.
+func TestSnapshot_LatencyMeanAndStdDev(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	// 1000ms, 2000ms, 3000ms -> mean 2000, population stddev sqrt(2/3)*1000.
+	for _, ms := range []int{1000, 2000, 3000} {
+		a.Record("s1", respEvent(now, 200, time.Duration(ms)*time.Millisecond, "m", 0))
+	}
+
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Buckets[0]
+	if b.LatMeanMs != 2000 {
+		t.Errorf("mean = %v, want 2000", b.LatMeanMs)
+	}
+	want := math.Sqrt(2.0/3.0) * 1000
+	if math.Abs(b.LatStdDevMs-want) > 1e-6 {
+		t.Errorf("stddev = %v, want %v", b.LatStdDevMs, want)
+	}
+}
+
+// Identical samples have zero variance; float cancellation can make the
+// intermediate negative, which would NaN the sqrt.
+func TestSnapshot_IdenticalLatenciesGiveZeroStdDev(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+	for i := 0; i < 5; i++ {
+		a.Record("s1", respEvent(now, 200, 1234*time.Millisecond, "m", 0))
+	}
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Buckets[0]
+	if b.LatStdDevMs != 0 {
+		t.Errorf("stddev = %v, want exactly 0", b.LatStdDevMs)
+	}
+	if math.IsNaN(b.LatStdDevMs) {
+		t.Error("stddev is NaN — negative variance was not guarded")
+	}
+}
+
+// A zero duration means "not measured", not "instant": folding it in would drag
+// the mean toward zero and misreport latency.
+func TestSnapshot_ZeroDurationExcludedFromMean(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+	a.Record("s1", respEvent(now, 200, 2*time.Second, "m", 0))
+	a.Record("s1", respEvent(now, 200, 0, "m", 0)) // unmeasured
+
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Buckets[0]
+	if b.Requests != 2 {
+		t.Errorf("requests = %d, want 2 (both count as traffic)", b.Requests)
+	}
+	// Mean divides by Requests, so an unmeasured event still halves it. Document
+	// the actual behavior rather than assert an aspiration.
+	if b.LatMeanMs != 1000 {
+		t.Errorf("mean = %v, want 1000 (2000ms over 2 requests)", b.LatMeanMs)
+	}
+}
+
+// >=400 counts as an error, and a denial counts too: an auth outage must not
+// look like a traffic drop.
+func TestRecord_ErrorsAndDenials(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", respEvent(now, 200, time.Second, "m", 10))
+	a.Record("s1", respEvent(now, 429, time.Second, "m", 0))
+	a.Record("s1", respEvent(now, 500, time.Second, "m", 0))
+	denied := respEvent(now, 0, time.Second, "", 0)
+	denied.Phase = pipeline.SessionDenied
+	a.Record("s1", denied)
+
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupStatus).Buckets[0]
+	if b.Requests != 4 {
+		t.Errorf("requests = %d, want 4", b.Requests)
+	}
+	if b.Errors != 3 {
+		t.Errorf("errors = %d, want 3 (429, 500, denied)", b.Errors)
+	}
+	if _, ok := b.Series["denied"]; !ok {
+		t.Errorf("denied events need their own status key; got keys %v", keys(b.Series))
+	}
+}
+
+// Request events carry no status, duration or usage. Counting them would double
+// every request.
+func TestRecord_IgnoresRequestPhase(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+	req := respEvent(now, 0, 0, "m", 0)
+	req.Phase = pipeline.SessionRequest
+	a.Record("s1", req)
+
+	if got := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Totals.Requests; got != 0 {
+		t.Errorf("requests = %d, want 0 — request-phase events must not count", got)
+	}
+}
+
+// All three groupings accumulate simultaneously, so an operator cycling the
+// group parameter sees the same history from each angle rather than each
+// grouping starting empty when first selected.
+func TestSnapshot_AllGroupingsPopulatedFromOnePass(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	e := respEvent(now, 200, time.Second, "claude-sonnet-5", 500)
+	e.Invocations = &pipeline.Invocations{Outbound: []pipeline.Invocation{{Plugin: "inference-parser"}}}
+	a.Record("s1", e)
+
+	for _, tc := range []struct {
+		group Group
+		key   string
+	}{
+		{GroupMethod, "claude-sonnet-5"},
+		{GroupStatus, "200"},
+		{GroupPlugin, "inference-parser"},
+	} {
+		b := a.Snapshot(time.Minute, BucketWidth, "", tc.group).Buckets[0]
+		if _, ok := b.Series[tc.key]; !ok {
+			t.Errorf("group=%s missing key %q; got %v", tc.group, tc.key, keys(b.Series))
+		}
+	}
+	if b := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Buckets[0]; b.Series != nil {
+		t.Error("group=none must omit series entirely")
+	}
+}
+
+// Cost is opt-in. Without a Pricer, CostMicros stays zero AND Priced is false,
+// so a client can say "unavailable" instead of rendering $0.00.
+func TestSnapshot_CostRequiresPricer(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+
+	unpriced := New(WithClock(fixedClock(now)))
+	unpriced.Record("s1", respEvent(now, 200, time.Second, "claude-sonnet-5", 1000))
+	snap := unpriced.Snapshot(time.Minute, BucketWidth, "", GroupNone)
+	if snap.Priced {
+		t.Error("Priced = true with no pricer configured")
+	}
+	if snap.Totals.CostMicros != 0 {
+		t.Errorf("costMicros = %d, want 0", snap.Totals.CostMicros)
+	}
+
+	// 1520 micros per 1000 tokens (roughly sonnet input at $1.52/Mtok).
+	priced := New(WithClock(fixedClock(now)),
+		WithPricer(func(_ string, tokens int64) int64 { return tokens * 1520 / 1000 }))
+	priced.Record("s1", respEvent(now, 200, time.Second, "claude-sonnet-5", 1000))
+	snap = priced.Snapshot(time.Minute, BucketWidth, "", GroupNone)
+	if !snap.Priced {
+		t.Error("Priced = false with a pricer configured")
+	}
+	if snap.Totals.CostMicros != 1520 {
+		t.Errorf("costMicros = %d, want 1520", snap.Totals.CostMicros)
+	}
+}
+
+// Per-session rings must isolate: one session's traffic cannot appear in
+// another's chart, while both land in the all-sessions total.
+func TestSnapshot_SessionIsolation(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("alice", respEvent(now, 200, time.Second, "m", 100))
+	a.Record("bob", respEvent(now, 200, time.Second, "m", 700))
+
+	if got := a.Snapshot(time.Minute, BucketWidth, "alice", GroupNone).Totals.Tokens; got != 100 {
+		t.Errorf("alice tokens = %d, want 100", got)
+	}
+	if got := a.Snapshot(time.Minute, BucketWidth, "bob", GroupNone).Totals.Tokens; got != 700 {
+		t.Errorf("bob tokens = %d, want 700", got)
+	}
+	if got := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Totals.Tokens; got != 800 {
+		t.Errorf("all-sessions tokens = %d, want 800", got)
+	}
+}
+
+// An unknown session yields zeroed buckets, not an error: a live session that
+// has produced no response events yet is a normal state.
+func TestSnapshot_UnknownSessionIsZeroedNotError(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+	snap := a.Snapshot(10*time.Minute, BucketWidth, "nope", GroupNone)
+	if len(snap.Buckets) != 10 {
+		t.Fatalf("got %d buckets, want 10", len(snap.Buckets))
+	}
+	if snap.Totals.Requests != 0 {
+		t.Errorf("totals = %+v, want zero", snap.Totals)
+	}
+}
+
+// Beyond the session cap, traffic still counts toward the all-sessions total —
+// only the per-session breakdown is dropped. Silently losing it from both would
+// make the aggregate disagree with reality.
+func TestRecord_SessionCapKeepsAllSessionsTotal(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)), WithMaxSessions(2))
+
+	for _, id := range []string{"s1", "s2", "s3"} {
+		a.Record(id, respEvent(now, 200, time.Second, "m", 100))
+	}
+	if got := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Totals.Requests; got != 3 {
+		t.Errorf("all-sessions requests = %d, want 3", got)
+	}
+	if got := a.Snapshot(time.Minute, BucketWidth, "s3", GroupNone).Totals.Requests; got != 0 {
+		t.Errorf("s3 was past the cap, want no per-session data, got %d", got)
+	}
+}
+
+// A slot reused on a later lap must reset, not accumulate onto stale data —
+// this is what makes the ring self-expiring with no sweeper.
+func TestRecord_StaleSlotResetsOnReuse(t *testing.T) {
+	base := time.Date(2026, 9, 4, 20, 0, 30, 0, time.UTC)
+	now := base
+	a := New(WithClock(func() time.Time { return now }))
+
+	a.Record("s1", respEvent(base, 200, time.Second, "m", 999))
+
+	// Exactly one full lap later: same slot, different minute.
+	later := base.Add(NumBuckets * BucketWidth)
+	now = later
+	a.Record("s1", respEvent(later, 200, time.Second, "m", 5))
+
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Buckets[0]
+	if b.Tokens != 5 {
+		t.Errorf("tokens = %d, want 5 — stale lap data was not reset", b.Tokens)
+	}
+}
+
+// Invocations is nil on any event no plugin recorded against — the common case.
+// This panicked inside Store.Append (the request hot path) before the nil guard.
+func TestRecord_NilInvocationsDoesNotPanic(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	e := respEvent(now, 200, time.Second, "m", 10)
+	if e.Invocations != nil {
+		t.Fatal("precondition: helper should leave Invocations nil")
+	}
+	a.Record("s1", e) // must not panic
+
+	if got := a.Snapshot(time.Minute, BucketWidth, "", GroupPlugin).Buckets[0]; got.Requests != 1 {
+		t.Errorf("requests = %d, want 1", got.Requests)
+	}
+}
+
+func TestParseWindow(t *testing.T) {
+	if d, err := ParseWindow(""); err != nil || d != 10*time.Minute {
+		t.Errorf("default = %v, %v; want 10m, nil", d, err)
+	}
+	for _, s := range []string{"10m", "1h", "6h"} {
+		if _, err := ParseWindow(s); err != nil {
+			t.Errorf("ParseWindow(%q) = %v, want nil", s, err)
+		}
+	}
+	for _, s := range []string{"30s", "7h", "90s", "garbage"} {
+		if _, err := ParseWindow(s); err == nil {
+			t.Errorf("ParseWindow(%q) = nil, want an error", s)
+		}
+	}
+}
+
+// Validation errors must not echo caller input: this is served unauthenticated,
+// so reflecting query bytes into a response body would be a reflection
+// primitive.
+func TestParseErrors_DoNotEchoInput(t *testing.T) {
+	const probe = "<script>alert(1)</script>"
+	if _, err := ParseGroup(probe); err == nil {
+		t.Fatal("expected an error")
+	} else if contains(err.Error(), probe) {
+		t.Errorf("group error echoes caller input: %q", err)
+	}
+	if _, err := ParseWindow(probe); err == nil {
+		t.Fatal("expected an error")
+	} else if contains(err.Error(), probe) {
+		t.Errorf("window error echoes caller input: %q", err)
+	}
+}
+
+func contains(hay, needle string) bool {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func keys(m map[string]Counts) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/authbridge/authlib/usage/usage_test.go
+++ b/authbridge/authlib/usage/usage_test.go
@@ -1,7 +1,9 @@
 package usage
 
 import (
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,10 +110,43 @@ func TestSnapshot_ZeroDurationExcludedFromMean(t *testing.T) {
 	if b.Requests != 2 {
 		t.Errorf("requests = %d, want 2 (both count as traffic)", b.Requests)
 	}
-	// Mean divides by Requests, so an unmeasured event still halves it. Document
-	// the actual behavior rather than assert an aspiration.
-	if b.LatMeanMs != 1000 {
-		t.Errorf("mean = %v, want 1000 (2000ms over 2 requests)", b.LatMeanMs)
+	// The mean is over MEASURED requests only. Dividing by Requests would report
+	// 1000ms for a single 2000ms response, understating latency in proportion to
+	// how many responses arrived unmeasured.
+	if b.LatMeanMs != 2000 {
+		t.Errorf("mean = %v, want 2000 (one measured 2000ms response)", b.LatMeanMs)
+	}
+	if b.LatSamples != 1 {
+		t.Errorf("latSamples = %d, want 1 — only one response carried a duration", b.LatSamples)
+	}
+}
+
+// The same dilution must not reappear when buckets are folded: a wider bucket's
+// mean has to weight each source bucket by its measured-sample count, not by its
+// request count.
+func TestFold_LatencyExcludesUnmeasuredRequests(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 2, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	// Minute A: one measured 2000ms response plus 9 unmeasured ones.
+	minA := now.Add(-time.Minute)
+	a.Record("s1", respEvent(minA, 200, 2000*time.Millisecond, "m", 0))
+	for i := 0; i < 9; i++ {
+		a.Record("s1", respEvent(minA, 200, 0, "m", 0))
+	}
+	// Minute B: one measured 4000ms response.
+	a.Record("s1", respEvent(now, 200, 4000*time.Millisecond, "m", 0))
+
+	folded := a.Snapshot(2*time.Minute, 2*time.Minute, "", GroupNone).Buckets[0]
+	if folded.Requests != 11 {
+		t.Fatalf("requests = %d, want 11", folded.Requests)
+	}
+	// Two measured samples: (2000 + 4000) / 2 = 3000.
+	if folded.LatMeanMs != 3000 {
+		t.Errorf("folded mean = %v, want 3000 (two measured samples)", folded.LatMeanMs)
+	}
+	if folded.LatSamples != 2 {
+		t.Errorf("folded latSamples = %d, want 2", folded.LatSamples)
 	}
 }
 
@@ -245,21 +280,54 @@ func TestSnapshot_UnknownSessionIsZeroedNotError(t *testing.T) {
 	}
 }
 
-// Beyond the session cap, traffic still counts toward the all-sessions total —
-// only the per-session breakdown is dropped. Silently losing it from both would
-// make the aggregate disagree with reality.
-func TestRecord_SessionCapKeepsAllSessionsTotal(t *testing.T) {
-	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
-	a := New(WithClock(fixedClock(now)), WithMaxSessions(2))
+// At the cap, the NEWEST session must be answerable and the coldest ring
+// reclaimed. Refusing new sessions instead would leave /v1/sessions listing a
+// live session while /v1/usage?session=<id> returned zeros — indistinguishable
+// from "that session did nothing" — and would stay that way for the life of the
+// process, since the store expires sessions without telling the aggregator.
+func TestRecord_SessionCapReclaimsColdestRing(t *testing.T) {
+	base := time.Date(2026, 9, 4, 23, 0, 0, 0, time.UTC)
+	now := base
+	a := New(WithClock(func() time.Time { return now }), WithMaxSessions(2))
 
-	for _, id := range []string{"s1", "s2", "s3"} {
-		a.Record(id, respEvent(now, 200, time.Second, "m", 100))
+	// s1 at 23:00, s2 at 23:01 — both tracked, s1 is now the coldest.
+	a.Record("s1", respEvent(base, 200, time.Second, "m", 100))
+	a.Record("s2", respEvent(base.Add(time.Minute), 200, time.Second, "m", 100))
+
+	// s3 arrives: the cap is reached, so s1's ring is reclaimed.
+	now = base.Add(2 * time.Minute)
+	a.Record("s3", respEvent(now, 200, time.Second, "m", 100))
+
+	if got := a.Snapshot(10*time.Minute, BucketWidth, "s3", GroupNone).Totals.Requests; got != 1 {
+		t.Errorf("newest session s3 must be answerable, got %d requests", got)
 	}
-	if got := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Totals.Requests; got != 3 {
+	if got := a.Snapshot(10*time.Minute, BucketWidth, "s1", GroupNone).Totals.Requests; got != 0 {
+		t.Errorf("coldest session s1 should have been reclaimed, got %d requests", got)
+	}
+	if got := a.Snapshot(10*time.Minute, BucketWidth, "s2", GroupNone).Totals.Requests; got != 1 {
+		t.Errorf("s2 was warmer than s1 and should survive, got %d requests", got)
+	}
+	// Every event still counts in the all-sessions aggregate regardless.
+	if got := a.Snapshot(10*time.Minute, BucketWidth, "", GroupNone).Totals.Requests; got != 3 {
 		t.Errorf("all-sessions requests = %d, want 3", got)
 	}
-	if got := a.Snapshot(time.Minute, BucketWidth, "s3", GroupNone).Totals.Requests; got != 0 {
-		t.Errorf("s3 was past the cap, want no per-session data, got %d", got)
+}
+
+// Memory must stay bounded no matter how many distinct session ids arrive.
+func TestRecord_SessionRingsStayBounded(t *testing.T) {
+	base := time.Date(2026, 9, 4, 23, 0, 0, 0, time.UTC)
+	now := base
+	a := New(WithClock(func() time.Time { return now }), WithMaxSessions(4))
+
+	for i := 0; i < 200; i++ {
+		now = base.Add(time.Duration(i) * time.Second)
+		a.Record(fmt.Sprintf("session-%d", i), respEvent(now, 200, time.Second, "m", 1))
+	}
+	a.mu.RLock()
+	n := len(a.sessions)
+	a.mu.RUnlock()
+	if n > 4 {
+		t.Errorf("retained %d rings, cap is 4", n)
 	}
 }
 
@@ -367,4 +435,53 @@ func keys(m map[string]Counts) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// The model name is request-controlled, so label cardinality is set off-host. A
+// caller varying it every request must not be able to grow a bucket's map
+// without bound — that is memory growth driven from outside the process, on the
+// synchronous session-append path.
+func TestRecord_LabelCardinalityIsCapped(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	const attempts = maxLabelsPerBucket * 4
+	for i := 0; i < attempts; i++ {
+		a.Record("s1", respEvent(now, 200, time.Second, fmt.Sprintf("model-%d", i), 10))
+	}
+
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupMethod).Buckets[0]
+	if len(b.Series) > maxLabelsPerBucket {
+		t.Errorf("byMethod holds %d labels, want at most %d", len(b.Series), maxLabelsPerBucket)
+	}
+	if _, ok := b.Series[overflowLabel]; !ok {
+		t.Errorf("excess labels should fold into %q; got keys %v", overflowLabel, keys(b.Series))
+	}
+	// Totals must survive the capping: the point is to bound keys, not lose data.
+	if b.Requests != attempts {
+		t.Errorf("requests = %d, want %d — capping must not drop traffic", b.Requests, attempts)
+	}
+	var seriesTotal int64
+	for _, c := range b.Series {
+		seriesTotal += c.Requests
+	}
+	if seriesTotal != attempts {
+		t.Errorf("series sums to %d, want %d — segments must still sum to the bucket", seriesTotal, attempts)
+	}
+}
+
+// A pathologically long model name must not be retained whole.
+func TestRecord_LabelLengthIsCapped(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	huge := strings.Repeat("m", 100_000)
+	a.Record("s1", respEvent(now, 200, time.Second, huge, 10))
+
+	b := a.Snapshot(time.Minute, BucketWidth, "", GroupMethod).Buckets[0]
+	for k := range b.Series {
+		if len(k) > maxLabelLen {
+			t.Errorf("retained a %d-byte label, cap is %d", len(k), maxLabelLen)
+		}
+	}
 }

--- a/authbridge/authlib/usage/usage_test.go
+++ b/authbridge/authlib/usage/usage_test.go
@@ -300,6 +300,25 @@ func TestRecord_NilInvocationsDoesNotPanic(t *testing.T) {
 	}
 }
 
+// WithMaxSessions(0) means track NO per-session rings — the reading the name
+// implies. It previously fell through a `> 0` guard and disabled the cap
+// entirely, so a 0 from config would have meant "unlimited".
+func TestWithMaxSessions_ZeroTracksNoSessions(t *testing.T) {
+	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)), WithMaxSessions(0))
+
+	a.Record("s1", respEvent(now, 200, time.Second, "m", 100))
+
+	// The all-sessions aggregate still counts everything.
+	if got := a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Totals.Tokens; got != 100 {
+		t.Errorf("all-sessions tokens = %d, want 100", got)
+	}
+	// But no per-session breakdown exists.
+	if got := a.Snapshot(time.Minute, BucketWidth, "s1", GroupNone).Totals.Tokens; got != 0 {
+		t.Errorf("per-session tokens = %d, want 0 with maxSessions=0", got)
+	}
+}
+
 func TestParseWindow(t *testing.T) {
 	if d, err := ParseWindow(""); err != nil || d != 10*time.Minute {
 		t.Errorf("default = %v, %v; want 10m, nil", d, err)

--- a/authbridge/cmd/abctl/apiclient/client.go
+++ b/authbridge/cmd/abctl/apiclient/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
 )
 
 // Client is a handle to a session API endpoint. Safe for concurrent use.
@@ -184,4 +185,31 @@ func trimSlash(s string) string {
 		s = s[:len(s)-1]
 	}
 	return s
+}
+
+// GetUsage fetches time-bucketed usage aggregates from GET /v1/usage.
+//
+// sessionID empty means all sessions combined. resolution is the width of the
+// buckets returned — the server folds, so a 1h window at 5m arrives as 12
+// buckets rather than 60. Read the returned Snapshot.BucketSeconds rather than
+// assuming the requested resolution was honored.
+//
+// Returns ErrNotFound when the proxy has no usage aggregator wired (older
+// binary, or session tracking disabled), which callers should render as
+// "unavailable" rather than as an empty chart.
+func (c *Client) GetUsage(ctx context.Context, window, resolution time.Duration, sessionID string, group usage.Group) (*usage.Snapshot, error) {
+	q := url.Values{}
+	q.Set("window", window.String())
+	q.Set("resolution", resolution.String())
+	if sessionID != "" {
+		q.Set("session", sessionID)
+	}
+	if group != "" && group != usage.GroupNone {
+		q.Set("group", string(group))
+	}
+	var snap usage.Snapshot
+	if err := c.getJSON(ctx, "/v1/usage?"+q.Encode(), &snap); err != nil {
+		return nil, err
+	}
+	return &snap, nil
 }

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -618,9 +618,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case usageLoadedMsg:
-		// Discard a reply for a scope the user has since left, so a slow response
-		// cannot repaint the chart under the wrong heading.
-		if msg.session != m.usage.session {
+		// Discard anything but the newest request's reply. Two rapid `w` presses
+		// leave two requests in flight; without this an out-of-order response
+		// repaints a stale window under the current heading. Comparing an id
+		// rather than the view fields means a future option cannot silently
+		// escape the check.
+		if msg.req != m.usage.reqSeq {
 			return m, nil
 		}
 		m.usage.loading = false

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -416,6 +416,10 @@ func (m *model) backToPodsPane() {
 	m.usage.snap = nil
 	m.usage.err = nil
 	m.usage.lastFetch = time.Time{}
+	// Invalidate anything in flight against the old pod: its reply must not land
+	// as if it described the new one.
+	m.usage.reqSeq++
+	m.usage.tickGen++
 	m.eventCt = 0
 	m.lastCt = 0
 	m.rate = 0
@@ -641,12 +645,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case usageTickMsg:
-		// Only keep polling while the pane is focused: a ticker left running
-		// behind another pane would fetch forever for nothing.
-		if m.pane != paneUsage {
+		// Stop when the pane loses focus, and drop ticks from a previous visit:
+		// a quick exit and re-entry would otherwise leave two chains alive, each
+		// rescheduling its own successor.
+		if m.pane != paneUsage || msg.gen != m.usage.tickGen {
 			return m, nil
 		}
-		return m, tea.Batch(m.fetchUsage(), usageTick())
+		return m, tea.Batch(m.fetchUsage(), usageTick(m.usage.tickGen))
 
 	case refreshTickMsg:
 		// In picker mode, skip the fetch — m.client may be nil after a

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -41,6 +41,12 @@ const (
 	paneUsage
 )
 
+// lastPaneID is the highest valid paneID. Kept adjacent to the iota block so
+// adding a pane means updating one line here, and TestPaneKeysCoverAllPanes then
+// fails until that pane is documented in paneKeys — which is how paneUsage
+// shipped reachable by `u` but named in no footer and no help overlay.
+const lastPaneID = paneUsage
+
 // paneNone is the explicit "no previous pane recorded" sentinel for
 // model.previousPane. Using paneNamespaces (the zero value) as a
 // sentinel would conflict with a future feature that wanted to open

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -37,6 +38,7 @@ const (
 	panePipeline
 	panePluginDetail
 	paneCatalog
+	paneUsage
 )
 
 // paneNone is the explicit "no previous pane recorded" sentinel for
@@ -218,7 +220,9 @@ type model struct {
 	connState connStateInfo
 
 	// UI state.
-	pane         paneID
+	pane paneID
+	// usage is the Usage pane's view state (metric, window, scope, snapshot).
+	usage        usageState
 	selectedSess string
 	filter       string
 	filtering    bool
@@ -401,6 +405,11 @@ func (m *model) backToPodsPane() {
 	m.streamCh = nil
 	m.sessions = nil
 	m.events = make(map[string][]pipeline.SessionEvent)
+	// A different pod is a different aggregator: keep the view options the
+	// operator chose, drop the data they described.
+	m.usage.snap = nil
+	m.usage.err = nil
+	m.usage.lastFetch = time.Time{}
 	m.eventCt = 0
 	m.lastCt = 0
 	m.rate = 0
@@ -601,6 +610,34 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.rebuildEventsTable()
 		}
 		return m, nil
+
+	case usageLoadedMsg:
+		// Discard a reply for a scope the user has since left, so a slow response
+		// cannot repaint the chart under the wrong heading.
+		if msg.session != m.usage.session {
+			return m, nil
+		}
+		m.usage.loading = false
+		if msg.err != nil {
+			if errors.Is(msg.err, apiclient.ErrNotFound) {
+				m.usage.err = errUsageUnsupported
+			} else {
+				m.usage.err = msg.err
+			}
+			return m, nil
+		}
+		m.usage.err = nil
+		m.usage.snap = msg.snap
+		m.usage.lastFetch = time.Now()
+		return m, nil
+
+	case usageTickMsg:
+		// Only keep polling while the pane is focused: a ticker left running
+		// behind another pane would fetch forever for nothing.
+		if m.pane != paneUsage {
+			return m, nil
+		}
+		return m, tea.Batch(m.fetchUsage(), usageTick())
 
 	case refreshTickMsg:
 		// In picker mode, skip the fetch — m.client may be nil after a
@@ -1118,6 +1155,13 @@ func (m *model) paneView() string {
 		}
 		title = fmt.Sprintf("abctl · pipeline · %s", name)
 		body = m.detailVp.View()
+	case paneUsage:
+		scope := "all"
+		if m.usage.session != "" {
+			scope = m.usage.session
+		}
+		title = fmt.Sprintf("abctl · %s · usage · %s", m.endpoint, scope)
+		body = m.renderUsage(m.width, m.bodyHeight)
 	case paneCatalog:
 		title = fmt.Sprintf("abctl · %s · catalog", m.endpoint)
 		if m.catalog == nil {

--- a/authbridge/cmd/abctl/tui/help_overlay.go
+++ b/authbridge/cmd/abctl/tui/help_overlay.go
@@ -68,6 +68,7 @@ var paneKeys = map[paneID]keyGroup{
 			{"↑↓ / jk", "navigate"},
 			{"↵ / → / l", "drill into session"},
 			{"tab", "switch to pipeline"},
+			{"u", "usage charts (all sessions)"},
 			{"/", "filter"},
 			{"esc", "back to pods picker"},
 		},
@@ -79,6 +80,7 @@ var paneKeys = map[paneID]keyGroup{
 			{"↵ / → / l", "event detail"},
 			{"/", "filter"},
 			{"s", "toggle passthru/skip rows"},
+			{"u", "usage charts (this session)"},
 			{"esc / ← / h", "back to sessions"},
 		},
 	},
@@ -87,6 +89,7 @@ var paneKeys = map[paneID]keyGroup{
 		bindings: []keyBinding{
 			{"↑↓", "scroll"},
 			{"y", "yank event JSON to /tmp"},
+			{"u", "usage charts (this session)"},
 			{"esc / ← / h", "back to events"},
 		},
 	},
@@ -107,6 +110,16 @@ var paneKeys = map[paneID]keyGroup{
 			{"esc / ← / h", "back"},
 		},
 	},
+	paneUsage: {
+		title: "USAGE (this pane)",
+		bindings: []keyBinding{
+			{"t", "cycle metric (tokens/requests/errors)"},
+			{"w", "cycle window (10m/1h/6h)"},
+			{"s", "toggle session / all sessions"},
+			{"r", "refresh now"},
+			{"esc", "back"},
+		},
+	},
 	paneCatalog: {
 		title: "PLUGIN CATALOG (this pane)",
 		bindings: []keyBinding{
@@ -122,7 +135,7 @@ var paneKeys = map[paneID]keyGroup{
 // the overlay is stable across openings (Go map iteration is random).
 var otherPaneOrder = []paneID{
 	paneNamespaces, panePods, paneSessions, paneEvents,
-	paneDetail, panePipeline, panePluginDetail, paneCatalog,
+	paneDetail, paneUsage, panePipeline, panePluginDetail, paneCatalog,
 }
 
 // helpKeyColWidth is the fixed width of the key column so descriptions

--- a/authbridge/cmd/abctl/tui/help_overlay_test.go
+++ b/authbridge/cmd/abctl/tui/help_overlay_test.go
@@ -238,6 +238,46 @@ func TestPaneKeysCoverAllPanes(t *testing.T) {
 		t.Errorf("paneKeys has %d entries, otherPaneOrder %d — keep them in sync",
 			len(paneKeys), len(otherPaneOrder))
 	}
+
+	// Both lists agreeing is not enough: a new pane absent from BOTH satisfies
+	// the checks above while being undocumented everywhere. paneUsage shipped
+	// exactly that way — reachable with `u`, named in no footer and no overlay.
+	// Enumerate against the real pane range so a new paneID has to be
+	// documented or fail here.
+	for p := paneNamespaces; p <= lastPaneID; p++ {
+		if _, ok := paneKeys[p]; !ok {
+			t.Errorf("pane %v has no paneKeys entry — it would be undiscoverable in the [?] overlay", p)
+		}
+	}
+}
+
+// Every pane must name its keys in the footer, and any pane reachable by a
+// binding from elsewhere must have that binding advertised where it is pressed.
+// A key nobody can discover is a key nobody uses.
+func TestFooterHintsMentionUsageKey(t *testing.T) {
+	m := &model{}
+	for _, tc := range []struct {
+		pane paneID
+		want string
+	}{
+		{paneSessions, "[u] usage"},
+		{paneEvents, "[u] usage"},
+		{paneDetail, "[u] usage"},
+	} {
+		m.pane = tc.pane
+		if got := m.helpView(); !strings.Contains(got, tc.want) {
+			t.Errorf("pane %v footer omits %q:\n  %s", tc.pane, tc.want, got)
+		}
+	}
+
+	// The usage pane's own footer must not fall through to the bare default.
+	m.pane = paneUsage
+	got := m.helpView()
+	for _, want := range []string{"[t] metric", "[w] window", "[r] refresh"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("usage footer omits %q:\n  %s", want, got)
+		}
+	}
 }
 
 // The overlay must stay inside the terminal, and must never push the

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -271,6 +271,15 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			} else {
 				m.pane = panePipeline
 			}
+			// Returning INTO Usage has to restart its polling chain. The tick
+			// that was in flight when the catalog opened was dropped by the
+			// `m.pane != paneUsage` guard, so without this nothing reschedules
+			// and the 20s auto-refresh is silently dead until the user backs all
+			// the way out and re-enters with `u` — `r` refetches once but starts
+			// no chain.
+			if m.pane == paneUsage {
+				return m.resumeUsagePolling()
+			}
 		case paneUsage:
 			// Return to whichever pane opened it, from usageState's own field —
 			// model.previousPane is shared with the catalog overlay and gets

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -76,11 +76,9 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			return nil
 		case "w":
 			m.usage.cycleWindow()
-			m.usage.loading = true
-			return m.fetchUsage()
+			return m.beginFetch()
 		case "r":
-			m.usage.loading = true
-			return m.fetchUsage()
+			return m.beginFetch()
 		case "s":
 			// Toggle scope between this session and all sessions. Only offered
 			// when a session is selected; otherwise there is nothing to toggle to.
@@ -89,8 +87,7 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			} else if m.selectedSess != "" {
 				m.usage.session = m.selectedSess
 			}
-			m.usage.loading = true
-			return m.fetchUsage()
+			return m.beginFetch()
 		}
 	}
 

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -272,14 +272,17 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 				m.pane = panePipeline
 			}
 		case paneUsage:
-			// Return to whichever pane opened it — events (session-scoped) or
-			// sessions (all-sessions). Falls back to sessions if unrecorded.
-			if m.previousPane != paneNone {
-				m.pane = m.previousPane
-				m.previousPane = paneNone
+			// Return to whichever pane opened it, from usageState's own field —
+			// model.previousPane is shared with the catalog overlay and gets
+			// clobbered when the catalog is opened from here.
+			if m.usage.returnPane != paneNone {
+				m.pane = m.usage.returnPane
+				m.usage.returnPane = paneNone
 			} else {
 				m.pane = paneSessions
 			}
+			// End the polling chain on the way out.
+			m.usage.tickGen++
 		case paneDetail:
 			m.pane = paneEvents
 		case paneEvents:

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -559,15 +559,15 @@ func (m *model) helpView() string {
 		return "[↑↓/jk] nav  [↵] connect  [Esc] back  [r] reload  [?] keys  [q] quit"
 	case paneSessions:
 		if m.parentCtx != nil {
-			return "[↑↓] nav  [↵] drill  [tab] pipeline  [/] filter  [esc] pods  [p] pause  [?] keys  [q] quit"
+			return "[↑↓] nav  [↵] drill  [tab] pipeline  [u] usage  [/] filter  [esc] pods  [p] pause  [?] keys  [q] quit"
 		}
-		return "[↑↓] nav  [↵] drill  [tab] pipeline  [/] filter  [p] pause  [?] keys  [q] quit"
+		return "[↑↓] nav  [↵] drill  [tab] pipeline  [u] usage  [/] filter  [p] pause  [?] keys  [q] quit"
 	case paneEvents:
 		skipHint := "[s] hide passthru/skip"
 		if m.hideInactive {
 			skipHint = "[s] show all"
 		}
-		base := "[↑↓] nav  [b/f] page  [↵] detail  [esc] back  [/] filter  " + skipHint + "  [p] pause  [?] keys  [q] quit"
+		base := "[↑↓] nav  [b/f] page  [↵] detail  [u] usage  [esc] back  [/] filter  " + skipHint + "  [p] pause  [?] keys  [q] quit"
 		// Surface the hidden-message count so a filtered timeline doesn't
 		// look like data loss. Only annotate when hiding is on AND at
 		// least one message was hidden.
@@ -577,7 +577,7 @@ func (m *model) helpView() string {
 		}
 		return base
 	case paneDetail:
-		return "[↑↓] scroll  [y] yank  [esc] back  [?] keys  [q] quit"
+		return "[↑↓] scroll  [y] yank  [u] usage  [esc] back  [?] keys  [q] quit"
 	case panePipeline:
 		var base string
 		if m.parentCtx != nil {
@@ -594,6 +594,17 @@ func (m *model) helpView() string {
 		return base
 	case panePluginDetail:
 		return "[↑↓] scroll  [esc] back  [?] keys  [q] quit"
+	case paneUsage:
+		// [s] only appears when there is a session to scope to, so the footer
+		// never advertises a key that would do nothing.
+		scopeHint := ""
+		if m.usage.session != "" {
+			scopeHint = "  [s] all sessions"
+		} else if m.selectedSess != "" {
+			scopeHint = "  [s] this session"
+		}
+		return "[t] metric  [w] window" + scopeHint +
+			"  [r] refresh  [esc] back  [?] keys  [q] quit"
 	case paneCatalog:
 		if m.catalog == nil {
 			return "loading catalog…  [esc] back  [?] keys  [q] quit"

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -67,6 +67,48 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 	}
 
+	// The Usage pane owns the keyboard while it is up, except for esc/q which
+	// the shared handling above already routed.
+	if m.pane == paneUsage && !m.filtering {
+		switch msg.String() {
+		case "t":
+			m.usage.cycleMetric()
+			return nil
+		case "w":
+			m.usage.cycleWindow()
+			m.usage.loading = true
+			return m.fetchUsage()
+		case "r":
+			m.usage.loading = true
+			return m.fetchUsage()
+		case "s":
+			// Toggle scope between this session and all sessions. Only offered
+			// when a session is selected; otherwise there is nothing to toggle to.
+			if m.usage.session != "" {
+				m.usage.session = ""
+			} else if m.selectedSess != "" {
+				m.usage.session = m.selectedSess
+			}
+			m.usage.loading = true
+			return m.fetchUsage()
+		}
+	}
+
+	// `u` opens the Usage pane. Scope depends on where it was pressed: from the
+	// events timeline it charts the session being read, from the session picker
+	// it charts everything. Suppressed while filtering, where `u` is a character
+	// the user is typing — the same reasoning as the `?` overlay above.
+	if msg.String() == "u" && !m.filtering && m.editState.phase == editPhaseDone {
+		switch m.pane {
+		case paneEvents, paneDetail:
+			if m.selectedSess != "" {
+				return m.openUsage(m.selectedSess)
+			}
+		case paneSessions:
+			return m.openUsage("")
+		}
+	}
+
 	// Picker panes handle their own keys before session-view logic.
 	if m.pane == paneNamespaces {
 		switch msg.String() {
@@ -231,6 +273,15 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 				m.previousPane = paneNone
 			} else {
 				m.pane = panePipeline
+			}
+		case paneUsage:
+			// Return to whichever pane opened it — events (session-scoped) or
+			// sessions (all-sessions). Falls back to sessions if unrecorded.
+			if m.previousPane != paneNone {
+				m.pane = m.previousPane
+				m.previousPane = paneNone
+			} else {
+				m.pane = paneSessions
 			}
 		case paneDetail:
 			m.pane = paneEvents

--- a/authbridge/cmd/abctl/tui/usage_pane.go
+++ b/authbridge/cmd/abctl/tui/usage_pane.go
@@ -1,0 +1,144 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
+)
+
+// usagePollInterval is how often the pane refetches while it is open.
+//
+// 20s is a deliberate compromise: the server buckets at one minute, so polling
+// faster cannot reveal anything new except the current bucket filling, while
+// polling slower makes the newest bar look stale to someone watching a live
+// agent. The ticker is armed only while the pane is focused, so a background
+// pane costs nothing.
+const usagePollInterval = 20 * time.Second
+
+// errUsageUnsupported marks a proxy with no usage aggregator wired — an older
+// binary, or session tracking disabled. Distinguished from a transport error so
+// the pane can explain the cause instead of showing a bare failure.
+var errUsageUnsupported = errors.New("usage endpoint not available")
+
+// usageLoadedMsg carries a fetched snapshot back to Update.
+type usageLoadedMsg struct {
+	snap *usage.Snapshot
+	// session the request was made for, so a reply that arrives after the user
+	// switched scope can be discarded rather than rendered under the wrong
+	// heading.
+	session string
+	err     error
+}
+
+// usageTickMsg fires the periodic refetch.
+type usageTickMsg time.Time
+
+// usageState is the pane's view state: which metric, window and scope.
+type usageState struct {
+	metric    usageMetric
+	windowIdx int    // index into usageWindows
+	session   string // "" means all sessions
+	snap      *usage.Snapshot
+	err       error
+	loading   bool
+	lastFetch time.Time
+}
+
+func (u *usageState) window() (window, resolution time.Duration) {
+	w := usageWindows[u.windowIdx%len(usageWindows)]
+	return w.window, w.resolution
+}
+
+// cycleMetric advances [t]. Only the three count metrics are cycled here;
+// latency gets its own renderer (mean-with-whiskers), which is a follow-up.
+func (u *usageState) cycleMetric() {
+	u.metric = (u.metric + 1) % 3
+}
+
+func (u *usageState) cycleWindow() {
+	u.windowIdx = (u.windowIdx + 1) % len(usageWindows)
+}
+
+// fetchUsage requests a snapshot. Returns a tea.Cmd so the HTTP call happens off
+// the render loop.
+func (m *model) fetchUsage() tea.Cmd {
+	if m.client == nil {
+		return nil
+	}
+	client := m.client
+	window, resolution := m.usage.window()
+	session := m.usage.session
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		snap, err := client.GetUsage(ctx, window, resolution, session, usage.GroupNone)
+		return usageLoadedMsg{snap: snap, session: session, err: err}
+	}
+}
+
+// usageTick schedules the next poll.
+func usageTick() tea.Cmd {
+	return tea.Tick(usagePollInterval, func(t time.Time) tea.Msg { return usageTickMsg(t) })
+}
+
+// openUsage enters the pane, remembering where to return to.
+//
+// session is the scope: the events pane passes its selected session so the chart
+// matches the timeline the operator was just reading; the sessions pane passes ""
+// for an all-sessions view.
+func (m *model) openUsage(session string) tea.Cmd {
+	m.previousPane = m.pane
+	m.pane = paneUsage
+	m.usage.session = session
+	m.usage.loading = true
+	return tea.Batch(m.fetchUsage(), usageTick())
+}
+
+// renderUsage draws the pane.
+func (m *model) renderUsage(width, height int) string {
+	var b strings.Builder
+
+	scope := "all sessions"
+	if m.usage.session != "" {
+		scope = "session: " + m.usage.session
+	}
+	window, resolution := m.usage.window()
+	b.WriteString(fmt.Sprintf("  USAGE — %s — %s @ %s — %s\n\n",
+		scope, window, resolution, m.usage.metric))
+
+	switch {
+	case m.usage.err != nil && errors.Is(m.usage.err, errUsageUnsupported):
+		// The proxy has no aggregator: an older binary, or session tracking
+		// disabled. Say which, rather than showing an empty chart that would
+		// read as "no traffic".
+		b.WriteString("  Usage aggregation is not available on this proxy.\n")
+		b.WriteString("  It requires session tracking enabled and a build that serves /v1/usage.\n")
+	case m.usage.err != nil:
+		b.WriteString(fmt.Sprintf("  Error: %v\n", m.usage.err))
+	case m.usage.snap == nil && m.usage.loading:
+		b.WriteString("  Loading…\n")
+	case m.usage.snap == nil:
+		b.WriteString("  (no data)\n")
+	default:
+		for _, line := range renderBars(m.usage.snap.Buckets, m.usage.metric, width) {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString(renderUsageSummary(m.usage.snap))
+		b.WriteString("\n")
+		if !m.usage.lastFetch.IsZero() {
+			b.WriteString(fmt.Sprintf("\n  updated %s ago (every %s)\n",
+				time.Since(m.usage.lastFetch).Truncate(time.Second), usagePollInterval))
+		}
+	}
+
+	b.WriteString("\n  [t] metric  [w] window  [r] refresh  [esc] back\n")
+	return b.String()
+}

--- a/authbridge/cmd/abctl/tui/usage_pane.go
+++ b/authbridge/cmd/abctl/tui/usage_pane.go
@@ -139,6 +139,9 @@ func (m *model) renderUsage(width, height int) string {
 		}
 	}
 
-	b.WriteString("\n  [t] metric  [w] window  [r] refresh  [esc] back\n")
+	// No key hints here: helpView renders the footer for every pane, and a
+	// second copy inside the body would drift from it the first time a binding
+	// changed. The pane's keys live in helpView and in paneKeys (the [?]
+	// overlay), which the coverage test holds to the real pane list.
 	return b.String()
 }

--- a/authbridge/cmd/abctl/tui/usage_pane.go
+++ b/authbridge/cmd/abctl/tui/usage_pane.go
@@ -141,8 +141,18 @@ func (m *model) openUsage(session string) tea.Cmd {
 	m.usage.returnPane = m.pane
 	m.pane = paneUsage
 	m.usage.session = session
-	// New generation: any tick still in flight from a previous visit becomes
-	// stale and will not reschedule itself.
+	// Shares resumeUsagePolling so the two entry points cannot drift on how a
+	// chain is started or how the previous one is invalidated.
+	return m.resumeUsagePolling()
+}
+
+// resumeUsagePolling restarts the poll chain when the pane regains focus without
+// going through openUsage — returning from the catalog overlay, for instance.
+//
+// It bumps tickGen so any tick still in flight from the previous chain is stale,
+// then starts exactly one new chain. Refetching immediately as well means the
+// chart is current on arrival rather than showing data up to 20s old.
+func (m *model) resumeUsagePolling() tea.Cmd {
 	m.usage.tickGen++
 	return tea.Batch(m.beginFetch(), usageTick(m.usage.tickGen))
 }

--- a/authbridge/cmd/abctl/tui/usage_pane.go
+++ b/authbridge/cmd/abctl/tui/usage_pane.go
@@ -29,11 +29,17 @@ var errUsageUnsupported = errors.New("usage endpoint not available")
 // usageLoadedMsg carries a fetched snapshot back to Update.
 type usageLoadedMsg struct {
 	snap *usage.Snapshot
-	// session the request was made for, so a reply that arrives after the user
-	// switched scope can be discarded rather than rendered under the wrong
-	// heading.
-	session string
-	err     error
+	// req is the monotonic id of the request this answers. Update discards any
+	// reply whose id is not the newest one issued.
+	//
+	// A single id rather than a tuple of (session, window, resolution): comparing
+	// fields means every future view option has to be added to the comparison or
+	// it silently stops being covered, and two rapid presses of `w` produce two
+	// in-flight requests that agree on session but differ on window — so an
+	// out-of-order reply could repaint a stale window under the current heading.
+	// An id cannot be partially right.
+	req uint64
+	err error
 }
 
 // usageTickMsg fires the periodic refetch.
@@ -48,6 +54,26 @@ type usageState struct {
 	err       error
 	loading   bool
 	lastFetch time.Time
+
+	// reqSeq is the id of the most recently ISSUED request. Any reply carrying a
+	// smaller id is stale and dropped.
+	reqSeq uint64
+}
+
+// beginFetch invalidates what is on screen and returns the command for a fresh
+// request. Every view-option change goes through it.
+//
+// Clearing snap matters as much as bumping the sequence: leaving the old
+// snapshot in place means renderUsage keeps drawing the previous scope's or
+// window's bars under the NEW heading until the reply lands — the same
+// wrong-heading failure the discard guard prevents, arriving from the other
+// direction.
+func (m *model) beginFetch() tea.Cmd {
+	m.usage.reqSeq++
+	m.usage.snap = nil
+	m.usage.err = nil
+	m.usage.loading = true
+	return m.fetchUsage()
 }
 
 func (u *usageState) window() (window, resolution time.Duration) {
@@ -74,11 +100,12 @@ func (m *model) fetchUsage() tea.Cmd {
 	client := m.client
 	window, resolution := m.usage.window()
 	session := m.usage.session
+	req := m.usage.reqSeq
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		snap, err := client.GetUsage(ctx, window, resolution, session, usage.GroupNone)
-		return usageLoadedMsg{snap: snap, session: session, err: err}
+		return usageLoadedMsg{snap: snap, req: req, err: err}
 	}
 }
 
@@ -96,8 +123,7 @@ func (m *model) openUsage(session string) tea.Cmd {
 	m.previousPane = m.pane
 	m.pane = paneUsage
 	m.usage.session = session
-	m.usage.loading = true
-	return tea.Batch(m.fetchUsage(), usageTick())
+	return tea.Batch(m.beginFetch(), usageTick())
 }
 
 // renderUsage draws the pane.

--- a/authbridge/cmd/abctl/tui/usage_pane.go
+++ b/authbridge/cmd/abctl/tui/usage_pane.go
@@ -42,8 +42,11 @@ type usageLoadedMsg struct {
 	err error
 }
 
-// usageTickMsg fires the periodic refetch.
-type usageTickMsg time.Time
+// usageTickMsg fires the periodic refetch. gen ties it to the polling chain that
+// scheduled it, so ticks from a previous visit to the pane are ignored.
+type usageTickMsg struct {
+	gen uint64
+}
 
 // usageState is the pane's view state: which metric, window and scope.
 type usageState struct {
@@ -58,6 +61,19 @@ type usageState struct {
 	// reqSeq is the id of the most recently ISSUED request. Any reply carrying a
 	// smaller id is stale and dropped.
 	reqSeq uint64
+
+	// returnPane is where esc goes back to, kept here rather than in
+	// model.previousPane because that field is shared with the catalog overlay:
+	// opening the catalog from Usage overwrites it with paneUsage and the
+	// catalog's own esc then clears it, so esc from Usage landed on Sessions
+	// instead of the Events pane it was opened from.
+	returnPane paneID
+
+	// tickGen identifies the current polling chain. openUsage bumps it, and a
+	// tick from an earlier visit is dropped — otherwise a quick exit and
+	// re-entry leaves two chains alive, each rescheduling the other's successor
+	// and doubling the request rate for the life of the session.
+	tickGen uint64
 }
 
 // beginFetch invalidates what is on screen and returns the command for a fresh
@@ -109,9 +125,11 @@ func (m *model) fetchUsage() tea.Cmd {
 	}
 }
 
-// usageTick schedules the next poll.
-func usageTick() tea.Cmd {
-	return tea.Tick(usagePollInterval, func(t time.Time) tea.Msg { return usageTickMsg(t) })
+// usageTick schedules the next poll for the given generation.
+func usageTick(gen uint64) tea.Cmd {
+	return tea.Tick(usagePollInterval, func(time.Time) tea.Msg {
+		return usageTickMsg{gen: gen}
+	})
 }
 
 // openUsage enters the pane, remembering where to return to.
@@ -120,10 +138,13 @@ func usageTick() tea.Cmd {
 // matches the timeline the operator was just reading; the sessions pane passes ""
 // for an all-sessions view.
 func (m *model) openUsage(session string) tea.Cmd {
-	m.previousPane = m.pane
+	m.usage.returnPane = m.pane
 	m.pane = paneUsage
 	m.usage.session = session
-	return tea.Batch(m.beginFetch(), usageTick())
+	// New generation: any tick still in flight from a previous visit becomes
+	// stale and will not reschedule itself.
+	m.usage.tickGen++
+	return tea.Batch(m.beginFetch(), usageTick(m.usage.tickGen))
 }
 
 // renderUsage draws the pane.

--- a/authbridge/cmd/abctl/tui/usage_render.go
+++ b/authbridge/cmd/abctl/tui/usage_render.go
@@ -154,9 +154,14 @@ func barCell(v, peak int64, row int) string {
 	}
 }
 
+// renderAxis draws the baseline. The corner glyph sits in the LAST gutter column
+// so the dashes after it start at axisLabel — the column the bars start at.
+// Writing axisLabel-2 spaces then "0 ┼" placed the corner AT axisLabel and
+// shifted every tick one column right of the bar it underlines.
 func renderAxis(n int) string {
 	var sb strings.Builder
-	sb.WriteString(strings.Repeat(" ", axisLabel-2))
+	// Right-align "0" in the gutter, leaving the final cell for the corner.
+	sb.WriteString(strings.Repeat(" ", axisLabel-3))
 	sb.WriteString("0 ┼")
 	for i := 0; i < n; i++ {
 		sb.WriteString(strings.Repeat("─", barWidth))

--- a/authbridge/cmd/abctl/tui/usage_render.go
+++ b/authbridge/cmd/abctl/tui/usage_render.go
@@ -221,20 +221,44 @@ func renderValues(buckets []usage.Bucket, m usageMetric) string {
 	return strings.TrimRight(string(row), " ")
 }
 
-// humanizeCount renders a count in at most 5 characters so it fits the axis
-// gutter and the value row.
+// maxCountLabelLen is the width humanizeCount promises. renderBars lays out the
+// axis gutter and value row against it, so exceeding it pushes lines past the
+// terminal width and wraps the chart.
+const maxCountLabelLen = 5
+
+// humanizeCount renders a count in at most maxCountLabelLen characters.
+//
+// Every magnitude has to be covered, not just the plausible ones: the previous
+// version fell through to "%.1fM" above a million, so a billion tokens rendered
+// as "1000.0M" — seven characters — and a large enough total silently broke the
+// layout. Token counts over a 6h window are exactly the figure that grows without
+// anyone revisiting this function.
 func humanizeCount(v int64) string {
 	switch {
 	case v < 0:
 		return "0"
 	case v < 1000:
-		return fmt.Sprintf("%d", v)
+		return fmt.Sprintf("%d", v) // 0..999
 	case v < 10_000:
-		return fmt.Sprintf("%.1fk", float64(v)/1000)
+		return fmt.Sprintf("%.1fk", float64(v)/1000) // 1.0k..9.9k
 	case v < 1_000_000:
-		return fmt.Sprintf("%dk", v/1000)
+		return fmt.Sprintf("%dk", v/1000) // 10k..999k
+	case v < 10_000_000:
+		return fmt.Sprintf("%.1fM", float64(v)/1e6) // 1.0M..9.9M
+	case v < 1_000_000_000:
+		return fmt.Sprintf("%dM", v/1e6) // 10M..999M
+	case v < 10_000_000_000:
+		return fmt.Sprintf("%.1fG", float64(v)/1e9) // 1.0G..9.9G
+	case v < 1_000_000_000_000:
+		return fmt.Sprintf("%dG", v/1e9) // 10G..999G
+	case v < 10_000_000_000_000:
+		return fmt.Sprintf("%.1fT", float64(v)/1e12) // 1.0T..9.9T
+	case v < 1_000_000_000_000_000:
+		return fmt.Sprintf("%dT", v/1e12) // 10T..999T
 	default:
-		return fmt.Sprintf("%.1fM", float64(v)/1_000_000)
+		// Past 999T an int64 has about four decades left; clamp rather than
+		// widen, since a chart is unreadable long before this.
+		return ">999T"
 	}
 }
 
@@ -256,9 +280,12 @@ func renderUsageSummary(snap *usage.Snapshot) string {
 	var latSum float64
 	var latN int64
 	for _, b := range snap.Buckets {
-		if b.LatMeanMs > 0 {
-			latSum += b.LatMeanMs * float64(b.Requests)
-			latN += b.Requests
+		// Weight by LatSamples (requests that carried a duration), not Requests:
+		// an unmeasured response is traffic but not a latency sample, and using
+		// Requests understates the mean in proportion to how many there were.
+		if b.LatMeanMs > 0 && b.LatSamples > 0 {
+			latSum += b.LatMeanMs * float64(b.LatSamples)
+			latN += b.LatSamples
 		}
 	}
 	if latN > 0 {

--- a/authbridge/cmd/abctl/tui/usage_render.go
+++ b/authbridge/cmd/abctl/tui/usage_render.go
@@ -1,0 +1,286 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
+)
+
+// Bar geometry. Four columns wide with a one-column gap, so ten bars occupy 49
+// columns and fit an 80-column terminal alongside the axis gutter.
+//
+// The gap earns its column twice over: adjacent bars blur into one mass at the
+// tall end, and in a stacked view a boundary BETWEEN bars would otherwise be
+// indistinguishable from a boundary WITHIN one. Four is also the practical floor
+// for stacked segments — narrower and the block glyphs stop reading as distinct
+// textures, which is what carries the encoding when color is unavailable.
+const (
+	barWidth  = 4
+	barGap    = 1
+	barStride = barWidth + barGap
+	plotRows  = 10 // vertical resolution before partial blocks
+	axisLabel = 6  // "  50k " gutter
+)
+
+// eighths are the vertical partial blocks, 1/8 through 8/8. They give the
+// ungrouped view 8x the vertical resolution of whole cells for free: a bar's top
+// cell renders its fractional row rather than rounding away up to a full row of
+// value.
+var eighths = [...]rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
+
+// usageMetric selects which series the bar chart plots.
+type usageMetric int
+
+const (
+	metricTokens usageMetric = iota
+	metricRequests
+	metricErrors
+)
+
+func (m usageMetric) String() string {
+	switch m {
+	case metricRequests:
+		return "requests"
+	case metricErrors:
+		return "errors"
+	default:
+		return "tokens"
+	}
+}
+
+// value extracts this metric from a bucket.
+func (m usageMetric) value(b usage.Bucket) int64 {
+	switch m {
+	case metricRequests:
+		return b.Requests
+	case metricErrors:
+		return b.Errors
+	default:
+		return b.Tokens
+	}
+}
+
+// renderBars draws the ungrouped bar chart: a y-axis with humanized labels, one
+// bar per bucket using partial blocks for sub-row precision, a time axis, and a
+// value row.
+//
+// Pure by design — buckets in, lines out, no terminal and no model state — so
+// the exact glyph output is table-testable. Terminal rendering bugs are
+// otherwise only visible by eye, and the two cases that matter most (an idle
+// bucket versus a very small one; a fractional top cell) are precisely the ones
+// eyes skip over.
+func renderBars(buckets []usage.Bucket, m usageMetric, width int) []string {
+	if len(buckets) == 0 {
+		return []string{"  (no data)"}
+	}
+	// Fit as many bars as the terminal allows, keeping the newest: an operator
+	// watching live traffic cares about now, not about the start of the window.
+	maxBars := (width - axisLabel) / barStride
+	if maxBars < 1 {
+		maxBars = 1
+	}
+	if len(buckets) > maxBars {
+		buckets = buckets[len(buckets)-maxBars:]
+	}
+
+	var peak int64
+	for _, b := range buckets {
+		if v := m.value(b); v > peak {
+			peak = v
+		}
+	}
+
+	out := make([]string, 0, plotRows+3)
+
+	// Plot rows, top down. Each row is a threshold; a bar fills the row when its
+	// value reaches the row's ceiling, and renders a partial block when it lands
+	// inside the row.
+	for row := plotRows; row >= 1; row-- {
+		var sb strings.Builder
+		// Label every other row, matching the axis tick density below.
+		if row%2 == 0 && peak > 0 {
+			sb.WriteString(fmt.Sprintf("%5s ", humanizeCount(peak*int64(row)/int64(plotRows))))
+		} else {
+			sb.WriteString(strings.Repeat(" ", axisLabel))
+		}
+		sb.WriteString(barCellsForRow(buckets, m, peak, row))
+		out = append(out, strings.TrimRight(sb.String(), " "))
+	}
+
+	out = append(out, renderAxis(len(buckets)))
+	out = append(out, renderTimeLabels(buckets))
+	out = append(out, renderValues(buckets, m))
+	return out
+}
+
+// barCellsForRow renders one horizontal slice of every bar.
+func barCellsForRow(buckets []usage.Bucket, m usageMetric, peak int64, row int) string {
+	var sb strings.Builder
+	for _, b := range buckets {
+		v := m.value(b)
+		sb.WriteString(barCell(v, peak, row))
+		sb.WriteString(strings.Repeat(" ", barGap))
+	}
+	return sb.String()
+}
+
+// barCell renders one bar's glyphs for one row: full blocks below the value, a
+// partial block at the fractional boundary, spaces above.
+func barCell(v, peak int64, row int) string {
+	if v <= 0 || peak <= 0 {
+		return strings.Repeat(" ", barWidth)
+	}
+	// Height in eighths of a row, so a bar shorter than one row still shows.
+	totalEighths := v * int64(plotRows) * 8 / peak
+	// Floor at one eighth: integer division truncates a small-but-nonzero value
+	// to nothing (50 against a 50k peak is 0.08 eighths), which would render
+	// real traffic as an empty column — indistinguishable from the idle bucket
+	// the value row deliberately marks "0". A visible sliver is the honest
+	// answer; invisibility is not.
+	if totalEighths == 0 {
+		totalEighths = 1
+	}
+	rowFloor := int64(row-1) * 8
+	inThisRow := totalEighths - rowFloor
+	switch {
+	case inThisRow >= 8:
+		return strings.Repeat("█", barWidth)
+	case inThisRow <= 0:
+		return strings.Repeat(" ", barWidth)
+	default:
+		return strings.Repeat(string(eighths[inThisRow-1]), barWidth)
+	}
+}
+
+func renderAxis(n int) string {
+	var sb strings.Builder
+	sb.WriteString(strings.Repeat(" ", axisLabel-2))
+	sb.WriteString("0 ┼")
+	for i := 0; i < n; i++ {
+		sb.WriteString(strings.Repeat("─", barWidth))
+		if i < n-1 {
+			sb.WriteString("┴")
+		}
+	}
+	return sb.String()
+}
+
+// renderTimeLabels labels every other bucket. A full HH:MM does not fit under a
+// 4-column bar, so the first label carries the hour and the rest are minutes
+// only — enough to place a spike once the reader has the hour.
+func renderTimeLabels(buckets []usage.Bucket) string {
+	// Painted into a column-indexed buffer rather than appended: a label is
+	// wider than the 4-column bar it belongs to, so consecutive labels would
+	// otherwise push each other rightward and drift out of alignment with the
+	// bars they name. Placing by absolute column keeps every label under its own
+	// bar no matter how wide the previous one was.
+	row := make([]byte, axisLabel+len(buckets)*barStride+8)
+	for i := range row {
+		row[i] = ' '
+	}
+	for i, b := range buckets {
+		if i%2 != 0 {
+			continue
+		}
+		label := b.At.Format(":04")
+		if i == 0 {
+			label = b.At.Format("15:04")
+		}
+		at := axisLabel + i*barStride
+		if at+len(label) <= len(row) {
+			copy(row[at:], label)
+		}
+	}
+	return strings.TrimRight(string(row), " ")
+}
+
+// renderValues prints each bucket's value under its bar. An idle bucket prints
+// "0" rather than blank: a chart with a missing bar cannot otherwise distinguish
+// no traffic from traffic too small to plot, and that is exactly the gap an
+// operator is hunting when usage looks wrong.
+func renderValues(buckets []usage.Bucket, m usageMetric) string {
+	// Column-painted for the same reason as renderTimeLabels: a 5-character
+	// value under a 4-column bar would otherwise shove its neighbours right.
+	row := make([]byte, axisLabel+len(buckets)*barStride+8)
+	for i := range row {
+		row[i] = ' '
+	}
+	for i, b := range buckets {
+		v := m.value(b)
+		label := "0" // an idle bucket is stated, never blank
+		if v != 0 {
+			label = humanizeCount(v)
+		}
+		at := axisLabel - 1 + i*barStride
+		if at+len(label) <= len(row) {
+			copy(row[at:], label)
+		}
+	}
+	return strings.TrimRight(string(row), " ")
+}
+
+// humanizeCount renders a count in at most 5 characters so it fits the axis
+// gutter and the value row.
+func humanizeCount(v int64) string {
+	switch {
+	case v < 0:
+		return "0"
+	case v < 1000:
+		return fmt.Sprintf("%d", v)
+	case v < 10_000:
+		return fmt.Sprintf("%.1fk", float64(v)/1000)
+	case v < 1_000_000:
+		return fmt.Sprintf("%dk", v/1000)
+	default:
+		return fmt.Sprintf("%.1fM", float64(v)/1_000_000)
+	}
+}
+
+// renderUsageSummary is the footer line: totals plus latency and cost.
+func renderUsageSummary(snap *usage.Snapshot) string {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("REQUESTS %d", snap.Totals.Requests))
+
+	errPct := ""
+	if snap.Totals.Requests > 0 {
+		errPct = fmt.Sprintf(" (%.1f%%)", 100*float64(snap.Totals.Errors)/float64(snap.Totals.Requests))
+	}
+	parts = append(parts, fmt.Sprintf("ERRORS %d%s", snap.Totals.Errors, errPct))
+	parts = append(parts, fmt.Sprintf("TOKENS %s", humanizeCount(snap.Totals.Tokens)))
+
+	// Latency across the window, weighted by request count so a quiet minute
+	// does not count as much as a busy one (the same mean-of-means trap the
+	// server avoids when folding).
+	var latSum float64
+	var latN int64
+	for _, b := range snap.Buckets {
+		if b.LatMeanMs > 0 {
+			latSum += b.LatMeanMs * float64(b.Requests)
+			latN += b.Requests
+		}
+	}
+	if latN > 0 {
+		parts = append(parts, fmt.Sprintf("LATENCY %.2fs", latSum/float64(latN)/1000))
+	}
+
+	// Cost is reserved on the wire but nothing populates it yet. Say so rather
+	// than render $0.00, which reads as "this traffic was free".
+	if snap.Priced {
+		parts = append(parts, fmt.Sprintf("COST $%.4f", float64(snap.Totals.CostMicros)/1e6))
+	} else {
+		parts = append(parts, "COST unavailable")
+	}
+	return "  " + strings.Join(parts, "    ")
+}
+
+// usageWindows are the spans the [w] key cycles.
+var usageWindows = []struct {
+	window     time.Duration
+	resolution time.Duration
+}{
+	{10 * time.Minute, time.Minute},
+	{time.Hour, 5 * time.Minute},
+	{6 * time.Hour, 30 * time.Minute},
+}

--- a/authbridge/cmd/abctl/tui/usage_render_test.go
+++ b/authbridge/cmd/abctl/tui/usage_render_test.go
@@ -1,0 +1,170 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
+)
+
+func mkBuckets(vals []int64) []usage.Bucket {
+	base := time.Date(2026, 9, 4, 23, 24, 0, 0, time.UTC)
+	out := make([]usage.Bucket, 0, len(vals))
+	for i, v := range vals {
+		var reqs int64
+		if v > 0 {
+			reqs = 1
+		}
+		out = append(out, usage.Bucket{
+			At:     base.Add(time.Duration(i) * time.Minute),
+			Counts: usage.Counts{Requests: reqs, Tokens: v},
+		})
+	}
+	return out
+}
+
+// The whole reason the value row exists: an idle bucket must print "0", and a
+// very small one must print its value. A blank cell for both would make a gap in
+// traffic indistinguishable from traffic too small to plot — the exact confusion
+// an operator hits when usage looks wrong.
+func TestRenderBars_ZeroBucketIsStatedNotBlank(t *testing.T) {
+	lines := renderBars(mkBuckets([]int64{4100, 0, 300}), metricTokens, 80)
+	values := lines[len(lines)-1]
+
+	if !strings.Contains(values, "0") {
+		t.Errorf("value row has no zero marker for the idle bucket:\n%q", values)
+	}
+	if !strings.Contains(values, "300") {
+		t.Errorf("value row lost the small bucket's value:\n%q", values)
+	}
+	// The small bucket must also draw at least one glyph, or the chart implies
+	// no traffic there.
+	plot := strings.Join(lines[:len(lines)-3], "\n")
+	if !strings.ContainsAny(plot, "▁▂▃▄▅▆▇█") {
+		t.Errorf("no bar glyphs rendered at all:\n%s", plot)
+	}
+}
+
+// A bucket far below the peak still has to be visible. Rounding it to zero rows
+// would hide real traffic; the partial blocks exist for exactly this.
+func TestRenderBars_SmallValueStillDrawsAGlyph(t *testing.T) {
+	// 50 against a 50000 peak is 1/1000 — well under one full row.
+	lines := renderBars(mkBuckets([]int64{50000, 50}), metricTokens, 80)
+	bottom := lines[len(lines)-4] // last plot row before the axis
+
+	// Two bars: the tall one full, the short one a partial block.
+	if !strings.Contains(bottom, "█") {
+		t.Errorf("tall bar missing from bottom row:\n%q", bottom)
+	}
+	if !strings.ContainsAny(bottom, "▁▂▃▄▅▆▇") {
+		t.Errorf("small bar rendered no partial block, so it is invisible:\n%q", bottom)
+	}
+}
+
+// Output must fit the terminal it was given. A line wider than the width wraps
+// and destroys the chart.
+func TestRenderBars_FitsWidth(t *testing.T) {
+	for _, width := range []int{80, 100, 60, 40} {
+		vals := make([]int64, 10)
+		for i := range vals {
+			vals[i] = int64(10000 * (i + 1))
+		}
+		for _, line := range renderBars(mkBuckets(vals), metricTokens, width) {
+			if got := len([]rune(line)); got > width {
+				t.Errorf("width %d: line is %d columns wide:\n%q", width, got, line)
+			}
+		}
+	}
+}
+
+// A narrow terminal keeps the NEWEST buckets: an operator watching live traffic
+// cares about now, not about the start of the window.
+func TestRenderBars_NarrowKeepsNewest(t *testing.T) {
+	vals := []int64{111, 222, 333, 444, 555, 666, 777, 888, 999, 1000}
+	lines := renderBars(mkBuckets(vals), metricTokens, 30)
+	values := lines[len(lines)-1]
+
+	// 1000 humanizes to "1.0k".
+	if !strings.Contains(values, "1.0k") {
+		t.Errorf("newest bucket dropped on a narrow terminal:\n%q", values)
+	}
+	if strings.Contains(values, "111") {
+		t.Errorf("oldest bucket kept instead of newest:\n%q", values)
+	}
+}
+
+// All-zero data must render without panicking or dividing by a zero peak.
+func TestRenderBars_AllZeroIsSafe(t *testing.T) {
+	lines := renderBars(mkBuckets([]int64{0, 0, 0}), metricTokens, 80)
+	if len(lines) == 0 {
+		t.Fatal("no output for an all-idle window")
+	}
+	values := lines[len(lines)-1]
+	if strings.Count(values, "0") < 3 {
+		t.Errorf("all three idle buckets should be marked:\n%q", values)
+	}
+}
+
+func TestRenderBars_EmptyInput(t *testing.T) {
+	if got := renderBars(nil, metricTokens, 80); len(got) != 1 {
+		t.Errorf("renderBars(nil) = %v, want a single placeholder line", got)
+	}
+}
+
+// Cost is reserved but unpopulated. The summary must say so rather than render
+// $0.00, which reads as "this traffic was free".
+func TestRenderUsageSummary_UnpricedSaysUnavailable(t *testing.T) {
+	snap := &usage.Snapshot{
+		Totals:  usage.Counts{Requests: 100, Errors: 3, Tokens: 5000},
+		Priced:  false,
+		Buckets: mkBuckets([]int64{5000}),
+	}
+	got := renderUsageSummary(snap)
+	if !strings.Contains(got, "COST unavailable") {
+		t.Errorf("unpriced summary should say cost is unavailable, got:\n%q", got)
+	}
+	if strings.Contains(got, "$0.00") {
+		t.Errorf("summary renders $0.00, which reads as free traffic:\n%q", got)
+	}
+	if !strings.Contains(got, "3.0%") {
+		t.Errorf("error rate missing from summary:\n%q", got)
+	}
+}
+
+// Window latency must be request-weighted, not a mean of per-bucket means — the
+// same trap the server avoids when folding.
+func TestRenderUsageSummary_LatencyIsRequestWeighted(t *testing.T) {
+	snap := &usage.Snapshot{
+		Totals: usage.Counts{Requests: 100},
+		Buckets: []usage.Bucket{
+			{Counts: usage.Counts{Requests: 99}, LatMeanMs: 1000},
+			{Counts: usage.Counts{Requests: 1}, LatMeanMs: 5000},
+		},
+	}
+	got := renderUsageSummary(snap)
+	// (99*1000 + 1*5000)/100 = 1040ms = 1.04s. Mean-of-means would be 3.00s.
+	if !strings.Contains(got, "1.04s") {
+		t.Errorf("latency should be 1.04s (request-weighted), got:\n%q", got)
+	}
+	if strings.Contains(got, "3.00s") {
+		t.Errorf("latency is the mean-of-means:\n%q", got)
+	}
+}
+
+func TestHumanizeCount(t *testing.T) {
+	for _, tc := range []struct {
+		in   int64
+		want string
+	}{
+		{0, "0"}, {999, "999"}, {1200, "1.2k"}, {9999, "10.0k"},
+		{18900, "18k"}, {48200, "48k"}, {1_500_000, "1.5M"},
+	} {
+		if got := humanizeCount(tc.in); got != tc.want {
+			t.Errorf("humanizeCount(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+		if got := len(humanizeCount(tc.in)); got > 5 {
+			t.Errorf("humanizeCount(%d) is %d chars, too wide for the gutter", tc.in, got)
+		}
+	}
+}

--- a/authbridge/cmd/abctl/tui/usage_render_test.go
+++ b/authbridge/cmd/abctl/tui/usage_render_test.go
@@ -138,8 +138,8 @@ func TestRenderUsageSummary_LatencyIsRequestWeighted(t *testing.T) {
 	snap := &usage.Snapshot{
 		Totals: usage.Counts{Requests: 100},
 		Buckets: []usage.Bucket{
-			{Counts: usage.Counts{Requests: 99}, LatMeanMs: 1000},
-			{Counts: usage.Counts{Requests: 1}, LatMeanMs: 5000},
+			{Counts: usage.Counts{Requests: 99}, LatMeanMs: 1000, LatSamples: 99},
+			{Counts: usage.Counts{Requests: 1}, LatMeanMs: 5000, LatSamples: 1},
 		},
 	}
 	got := renderUsageSummary(snap)
@@ -159,12 +159,33 @@ func TestHumanizeCount(t *testing.T) {
 	}{
 		{0, "0"}, {999, "999"}, {1200, "1.2k"}, {9999, "10.0k"},
 		{18900, "18k"}, {48200, "48k"}, {1_500_000, "1.5M"},
+		{999_999_999, "999M"},
+		{1_000_000_000, "1.0G"}, // was "1000.0M" — 7 chars, broke the layout
+		{50_000_000_000, "50G"},
+		{1_500_000_000_000, "1.5T"},
+		{999_000_000_000_000, "999T"},
 	} {
 		if got := humanizeCount(tc.in); got != tc.want {
 			t.Errorf("humanizeCount(%d) = %q, want %q", tc.in, got, tc.want)
 		}
-		if got := len(humanizeCount(tc.in)); got > 5 {
-			t.Errorf("humanizeCount(%d) is %d chars, too wide for the gutter", tc.in, got)
+	}
+}
+
+// The width promise is what renderBars lays out against, so it must hold for
+// every magnitude an int64 can reach — not just the ones a table happens to list.
+func TestHumanizeCount_NeverExceedsWidth(t *testing.T) {
+	vals := []int64{0, -1, 9223372036854775807}
+	for _, base := range []int64{1, 7, 999} {
+		for mag := int64(1); mag <= 1_000_000_000_000_000_000; mag *= 10 {
+			if base <= (1<<62)/mag {
+				vals = append(vals, base*mag)
+			}
+		}
+	}
+	for _, v := range vals {
+		if got := humanizeCount(v); len(got) > maxCountLabelLen {
+			t.Errorf("humanizeCount(%d) = %q (%d chars), cap is %d",
+				v, got, len(got), maxCountLabelLen)
 		}
 	}
 }

--- a/authbridge/cmd/abctl/tui/usage_render_test.go
+++ b/authbridge/cmd/abctl/tui/usage_render_test.go
@@ -189,3 +189,98 @@ func TestHumanizeCount_NeverExceedsWidth(t *testing.T) {
 		}
 	}
 }
+
+// runeIndexAny returns the RUNE index of the first rune from set, or -1.
+// Byte offsets are useless here: the block glyphs and box-drawing characters are
+// multi-byte, so strings.IndexAny would report a position no terminal column
+// corresponds to.
+func runeIndexAny(s, set string) int {
+	for i, r := range []rune(s) {
+		if strings.ContainsRune(set, r) {
+			return i
+		}
+	}
+	return -1
+}
+
+// The axis must underline the bars, not sit one column off. Previously
+// renderAxis wrote axisLabel-2 spaces then "0 ┼" — a 7-column prefix against the
+// 6-column gutter every other row uses — so every tick landed one column right
+// of the bar above it.
+//
+// The existing tests could not catch this: they assert substrings and line
+// lengths, neither of which changes when a whole row shifts sideways. This
+// asserts the column positions that actually make the chart readable.
+func TestRenderBars_AxisAlignsWithBars(t *testing.T) {
+	lines := renderBars(mkBuckets([]int64{50000, 40000, 30000}), metricTokens, 80)
+
+	// Find the first bar glyph column from a plot row, and the axis row.
+	barCol := -1
+	for _, l := range lines {
+		if c := runeIndexAny(l, "▁▂▃▄▅▆▇█"); c >= 0 {
+			barCol = c
+			break
+		}
+	}
+	if barCol < 0 {
+		t.Fatal("no bar glyphs rendered")
+	}
+
+	axis := ""
+	for _, l := range lines {
+		if strings.ContainsRune(l, '┼') {
+			axis = l
+			break
+		}
+	}
+	if axis == "" {
+		t.Fatal("no axis row rendered")
+	}
+
+	// The corner sits in the last gutter column, so the dashes after it begin at
+	// the same column the bars do.
+	cornerCol := runeIndexAny(axis, "┼")
+	if cornerCol != barCol-1 {
+		t.Errorf("axis corner at column %d, bars start at %d — dashes begin at %d, "+
+			"so ticks are offset from the bars they underline",
+			cornerCol, barCol, cornerCol+1)
+	}
+
+	// And the first dash must be exactly under the first bar.
+	dashCol := runeIndexAny(axis, "─")
+	if dashCol != barCol {
+		t.Errorf("first axis dash at column %d, first bar at column %d", dashCol, barCol)
+	}
+}
+
+// Every tick must fall on a bar boundary: barStride columns apart, starting at
+// the first bar's column.
+func TestRenderBars_TicksFallOnBarBoundaries(t *testing.T) {
+	const n = 5
+	vals := make([]int64, n)
+	for i := range vals {
+		vals[i] = int64(1000 * (i + 1))
+	}
+	lines := renderBars(mkBuckets(vals), metricTokens, 80)
+
+	var axis []rune
+	for _, l := range lines {
+		if strings.ContainsRune(l, '┼') {
+			axis = []rune(l)
+			break
+		}
+	}
+	if axis == nil {
+		t.Fatal("no axis row")
+	}
+	for i, r := range axis {
+		if r != '┴' {
+			continue
+		}
+		// A tick closes bar k, so it sits at axisLabel + k*barStride + barWidth.
+		off := i - axisLabel - barWidth
+		if off < 0 || off%barStride != 0 {
+			t.Errorf("tick at column %d is not on a bar boundary", i)
+		}
+	}
+}

--- a/authbridge/cmd/abctl/tui/usage_state_test.go
+++ b/authbridge/cmd/abctl/tui/usage_state_test.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"testing"
-	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/usage"
 )
@@ -66,9 +65,81 @@ func TestUsage_BeginFetchClearsStaleData(t *testing.T) {
 // The poll must stop doing work once the pane loses focus.
 func TestUsage_TickIgnoredOffPane(t *testing.T) {
 	m := &model{pane: paneEvents}
-	_, cmd := m.Update(usageTickMsg(time.Now()))
+	m.usage.tickGen = 1
+	_, cmd := m.Update(usageTickMsg{gen: 1})
 	if cmd != nil {
 		t.Error("tick scheduled more work while the pane was not focused")
+	}
+}
+
+// A tick left over from an earlier visit must not reschedule itself. Without a
+// generation check, a quick exit and re-entry leaves two chains alive — each
+// rescheduling its own successor — and the request rate doubles for the life of
+// the session.
+func TestUsage_StaleTickChainDoesNotReschedule(t *testing.T) {
+	m := &model{pane: paneUsage}
+	m.usage.tickGen = 2 // second visit
+
+	if _, cmd := m.Update(usageTickMsg{gen: 1}); cmd != nil {
+		t.Error("tick from the first visit rescheduled itself, doubling the poll rate")
+	}
+	// The current generation still polls. m.client is nil so fetchUsage yields no
+	// command, but the tick half of the batch must still be scheduled.
+	if _, cmd := m.Update(usageTickMsg{gen: 2}); cmd == nil {
+		t.Error("current-generation tick did not reschedule")
+	}
+}
+
+// esc must return to the pane Usage was opened from, even after the catalog
+// overlay has been opened on top. model.previousPane is shared with the catalog,
+// so relying on it sent esc to Sessions instead of Events.
+func TestUsage_ReturnPaneSurvivesCatalogOverlay(t *testing.T) {
+	m := &model{pane: paneEvents, selectedSess: "s1", previousPane: paneNone}
+	m.openUsage("s1")
+	if m.usage.returnPane != paneEvents {
+		t.Fatalf("returnPane = %v, want paneEvents", m.usage.returnPane)
+	}
+
+	// Simulate opening the catalog from Usage and escaping back out of it: the
+	// catalog uses previousPane and clears it on the way out.
+	m.previousPane = paneUsage
+	m.pane = paneCatalog
+	m.previousPane = paneNone
+	m.pane = paneUsage
+
+	// Usage's own esc must still know where it came from.
+	if m.usage.returnPane != paneEvents {
+		t.Errorf("returnPane = %v after a catalog round trip, want paneEvents", m.usage.returnPane)
+	}
+}
+
+// Switching pods must invalidate in-flight work: a reply describing the old pod
+// must not land as if it described the new one, and the old polling chain must
+// stop. backToPodsPane needs a fully wired model (contexts, port-forward), so
+// this asserts the reset a stale reply would have to get past — that a bumped
+// sequence makes the previous request's reply undeliverable.
+func TestUsage_PodSwitchInvalidatesInFlight(t *testing.T) {
+	m := &model{pane: paneUsage}
+	m.usage.reqSeq = 5
+	m.usage.tickGen = 3
+	m.usage.snap = &usage.Snapshot{Totals: usage.Counts{Tokens: 42}}
+
+	// The reset backToPodsPane performs on the usage fields.
+	m.usage.snap = nil
+	m.usage.err = nil
+	m.usage.reqSeq++
+	m.usage.tickGen++
+
+	// A reply issued against the old pod must now be rejected.
+	u, _ := m.Update(usageLoadedMsg{req: 5, snap: &usage.Snapshot{
+		Totals: usage.Counts{Tokens: 999},
+	}})
+	if got := u.(*model); got.usage.snap != nil {
+		t.Errorf("a reply from the previous pod was applied: %+v", got.usage.snap.Totals)
+	}
+	// And the old polling chain must not reschedule.
+	if _, cmd := m.Update(usageTickMsg{gen: 3}); cmd != nil {
+		t.Error("the previous pod's polling chain is still alive")
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/usage_state_test.go
+++ b/authbridge/cmd/abctl/tui/usage_state_test.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
+)
+
+// A reply from a superseded request must be dropped. Two rapid `w` presses leave
+// two requests in flight; without an id check an out-of-order response repaints a
+// stale window under the current heading.
+func TestUsage_StaleReplyIsDiscarded(t *testing.T) {
+	m := &model{pane: paneUsage}
+	m.usage.reqSeq = 2 // two requests issued; newest is 2
+
+	stale := usageLoadedMsg{req: 1, snap: &usage.Snapshot{
+		Totals: usage.Counts{Tokens: 111},
+	}}
+	u, _ := m.Update(stale)
+	mm := u.(*model)
+	if mm.usage.snap != nil {
+		t.Errorf("stale reply (req=1 vs seq=2) was applied: %+v", mm.usage.snap.Totals)
+	}
+
+	fresh := usageLoadedMsg{req: 2, snap: &usage.Snapshot{
+		Totals: usage.Counts{Tokens: 222},
+	}}
+	u, _ = mm.Update(fresh)
+	mm = u.(*model)
+	if mm.usage.snap == nil || mm.usage.snap.Totals.Tokens != 222 {
+		t.Error("current reply (req=2) was not applied")
+	}
+	if mm.usage.loading {
+		t.Error("loading should clear once the current reply lands")
+	}
+}
+
+// Changing a view option must clear the old snapshot, not just set loading.
+// Leaving it in place renders the previous window's bars under the new heading
+// until the reply arrives — the same wrong-heading failure the discard guard
+// exists to prevent, from the other direction.
+func TestUsage_BeginFetchClearsStaleData(t *testing.T) {
+	m := &model{pane: paneUsage}
+	m.usage.snap = &usage.Snapshot{Totals: usage.Counts{Tokens: 999}}
+	m.usage.err = errUsageUnsupported
+	before := m.usage.reqSeq
+
+	m.beginFetch() // client is nil, so no command; state changes are what matter
+
+	if m.usage.snap != nil {
+		t.Error("beginFetch left the previous snapshot on screen")
+	}
+	if m.usage.err != nil {
+		t.Error("beginFetch left a stale error on screen")
+	}
+	if !m.usage.loading {
+		t.Error("beginFetch did not mark the pane loading")
+	}
+	if m.usage.reqSeq != before+1 {
+		t.Errorf("reqSeq = %d, want %d — a new request must invalidate older replies",
+			m.usage.reqSeq, before+1)
+	}
+}
+
+// The poll must stop doing work once the pane loses focus.
+func TestUsage_TickIgnoredOffPane(t *testing.T) {
+	m := &model{pane: paneEvents}
+	_, cmd := m.Update(usageTickMsg(time.Now()))
+	if cmd != nil {
+		t.Error("tick scheduled more work while the pane was not focused")
+	}
+}
+
+// Cycling window and metric must stay in range rather than growing an index.
+func TestUsageState_CyclesWrap(t *testing.T) {
+	var u usageState
+	for i := 0; i < len(usageWindows)*3; i++ {
+		u.cycleWindow()
+		if w, r := u.window(); w <= 0 || r <= 0 {
+			t.Fatalf("cycle %d produced window=%v resolution=%v", i, w, r)
+		}
+	}
+	seen := map[usageMetric]bool{}
+	for i := 0; i < 6; i++ {
+		u.cycleMetric()
+		seen[u.metric] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("metric cycle covered %d of 3 metrics", len(seen))
+	}
+}

--- a/authbridge/cmd/abctl/tui/usage_state_test.go
+++ b/authbridge/cmd/abctl/tui/usage_state_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
+
 	"testing"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/usage"
@@ -159,5 +161,47 @@ func TestUsageState_CyclesWrap(t *testing.T) {
 	}
 	if len(seen) != 3 {
 		t.Errorf("metric cycle covered %d of 3 metrics", len(seen))
+	}
+}
+
+// Returning into Usage from the catalog overlay must restart the poll chain.
+// The tick in flight when the catalog opened was dropped by the focus guard, so
+// without an explicit restart the 20s auto-refresh is silently dead: the chart
+// freezes and only `r` (a one-shot refetch) or backing all the way out and
+// re-entering with `u` brings it back.
+func TestUsage_CatalogRoundTripRestartsPolling(t *testing.T) {
+	m := &model{pane: paneEvents, selectedSess: "s1", previousPane: paneNone}
+	m.openUsage("s1")
+	genBefore := m.usage.tickGen
+
+	// P opens the catalog from Usage; previousPane records where to return.
+	m.previousPane = paneUsage
+	m.pane = paneCatalog
+
+	// A tick from the pre-catalog chain arrives while the catalog has focus and
+	// is dropped — this is what leaves nothing scheduled.
+	if _, cmd := m.Update(usageTickMsg{gen: genBefore}); cmd != nil {
+		t.Error("a tick was rescheduled while the catalog had focus")
+	}
+
+	// esc out of the catalog, back into Usage.
+	cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.pane != paneUsage {
+		t.Fatalf("pane = %v after esc from catalog, want paneUsage", m.pane)
+	}
+	if cmd == nil {
+		t.Fatal("returning into Usage scheduled no work — the poll chain is dead")
+	}
+	if m.usage.tickGen == genBefore {
+		t.Error("tickGen unchanged: the stale chain was not invalidated")
+	}
+
+	// The new chain must be the one that polls, and the old generation must stay
+	// dead so only one chain is alive.
+	if _, c := m.Update(usageTickMsg{gen: m.usage.tickGen}); c == nil {
+		t.Error("the restarted chain does not reschedule")
+	}
+	if _, c := m.Update(usageTickMsg{gen: genBefore}); c != nil {
+		t.Error("the pre-catalog chain is still alive — two chains would double the poll rate")
 	}
 }

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -332,7 +332,11 @@ func main() {
 		// No Pricer is passed, so cost fields stay absent and the response
 		// reports priced:false — see the TODO on usage.Pricer for where real
 		// rates would come from.
-		usageAgg = usage.New()
+		// Same session cap as the store, so the two agree on how many sessions
+		// are worth remembering. The aggregator reclaims its coldest ring at the
+		// cap rather than refusing new sessions, which matters because the store
+		// evicts and expires sessions without telling it.
+		usageAgg = usage.New(usage.WithMaxSessions(maxSessions))
 		sessions.AddRecorder(usageAgg)
 
 		slog.Info("session tracking enabled", "ttl", ttl, "maxEvents", maxEvents, "maxSessions", maxSessions)

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/spiffe"
 	authtls "github.com/rossoctl/cortex/authbridge/authlib/tls"
 	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
 
 	// Only HTTP listeners are compiled in: no extproc/extauthz
 	// (no gRPC, no envoy types).
@@ -301,6 +302,7 @@ func main() {
 	}
 
 	var sessions *session.Store
+	var usageAgg *usage.Aggregator
 	if cfg.Session.SessionEnabled() {
 		ttl := 30 * time.Minute
 		if cfg.Session.TTL != "" {
@@ -319,6 +321,20 @@ func main() {
 			maxSessions = cfg.Session.MaxSessions
 		}
 		sessions = session.New(ttl, maxEvents, maxSessions)
+
+		// Usage aggregation feeds GET /v1/usage. Registered as a store Recorder
+		// so it sees every appended event, and deliberately independent of the
+		// event store's own retention: session.max_events trims the per-session
+		// event list, but a bucket counter must keep counting after the events
+		// it counted have aged out, or a chart would appear to lose history an
+		// operator could still see a minute ago.
+		//
+		// No Pricer is passed, so cost fields stay absent and the response
+		// reports priced:false — see the TODO on usage.Pricer for where real
+		// rates would come from.
+		usageAgg = usage.New()
+		sessions.AddRecorder(usageAgg)
+
 		slog.Info("session tracking enabled", "ttl", ttl, "maxEvents", maxEvents, "maxSessions", maxSessions)
 	} else {
 		slog.Info("session tracking disabled")
@@ -516,6 +532,7 @@ func main() {
 			sessions,
 			sessionapi.WithPipelines(inboundH, outboundH),
 			sessionapi.WithCatalog(sessionapi.PluginsCatalog),
+			sessionapi.WithUsage(usageAgg),
 		)
 		go func() {
 			slog.Warn("session API listening — UNAUTHENTICATED; contains raw user content; never expose via ingress",


### PR DESCRIPTION
Closes #873.  (There will be a follow-up for more screens soon after this merges.

Volume and performance over wall-clock time were only inferable by reading the event picker row by row. This adds server-side aggregation and a chart that reads it.

```
abctl · http://localhost:47601 · usage · default                                    
  USAGE — session: default — 10m0s @ 1m0s — tokens                                  
                                                                                    
 212k                                         ████                                  
                                              ████                                  
 170k                                         ████                                  
                                              ████                                  
 127k                                         ████                                  
                                         ▂▂▂▂ ████                                  
  85k                                    ████ ████                                  
                                         ████ ████                                  
  42k                                    ████ ████                                  
                                         ████ ████                                  
    0 ┼────┴────┴────┴────┴────┴────┴────┴────┴────┴────                            
      12:45     :47       :49       :51       :53                                   
     0    0    0    0    0    0    0    91k  212k 0                                 
                                                                                    
  REQUESTS 12    ERRORS 0 (0.0%)    TOKENS 304k    LATENCY 2.46s    COST unavailable
                                                                                    
  updated 17s ago (every 20s)                                                       
                                                                                    
  [t] metric  [w] window  [r] refresh  [esc] back                                   

```

## Why the proxy aggregates, not the client

A client-side aggregate would start empty when that client connected, so two operators watching one pod would see different histories of the same traffic — and neither would see anything from before they attached. The store is the only place with the whole picture.

## `authlib/usage`

A fixed ring of 360 one-minute buckets (6h). Expiry is implicit: a slot whose recorded start does not match its timestamp has landed on a stale lap and resets, so there is no sweeper goroutine. Memory is O(buckets × distinct labels), independent of event volume — mean and standard deviation come from running sums rather than retained samples.

All three groupings (method / status / plugin) accumulate simultaneously, so cycling the `group` parameter shows the same history from each angle rather than each grouping starting empty when first selected.

## `GET /v1/usage`

| Param | Values |
|---|---|
| `window` | `10m` (default), `1h`, `6h` — any multiple of the bucket width |
| `resolution` | returned bucket width, e.g. `5m` for a 1h window as 12 bars |
| `session` | session ID; omit for all sessions |
| `group` | `none` (default), `method`, `status`, `plugin` |

Folding happens server-side so every client gets the same arithmetic. Latency in particular cannot be folded naively — averaging per-bucket means weights a minute with 1 request the same as a minute with 500 — so `fold` reconstitutes each bucket's running sums and re-accumulates, yielding exactly what one wider bucket would have recorded. `TestFold_MatchesNativeWideBucket` pins the two paths to each other; `TestFold_LatencyIsRequestWeightedNotMeanOfMeans` guards the plausible-looking wrong answer explicitly.

Idle buckets are emitted with zeroed counts rather than omitted, and the chart marks them `0`. A blank column would otherwise mean both "no traffic" and "traffic too small to plot" — the distinction an operator is looking for when usage looks wrong.

## abctl

`u` opens the screen: from the events timeline it charts the selected session, from the session picker all sessions. Polls every 20s while focused (the ticker no-ops otherwise, and a reply for a scope the user has left is discarded). In-pane: `[t]` metric, `[w]` window, `[r]` refresh, `[s]` scope, `[esc]` back.

The renderer is a pure function of buckets, so its exact glyph output is table-tested. The stacked-by-status and mean-with-whiskers renderers from #873 follow in a separate PR; `usageMetric` cycles only the three count metrics today.

## Cost is reserved, not implemented

`costMicros` and `priced` are on the wire but nothing populates them. Rates exist in `toolprune`'s table, but it is package-private and measured against a gateway that bills well below vendor list — applying it to a direct-to-Anthropic deployment would understate cost by roughly 4× on the input tier. `priced:false` makes a client say "unavailable" rather than render `$0.00`, which would read as free traffic. TODOs on `usage.Pricer` and `handleUsage` name the two candidate sources; having `litellm-budget-track` surface its `X-Litellm-Response-Cost` figure onto the session event is the better fix.

## Security

Unauthenticated like the rest of the listener. The response carries no message content, but `group=method` exposes model names and `group=plugin` the pipeline composition (already public via `/v1/pipeline`); `handleUsage` documents both. Validation errors are fixed strings that never echo query input — `TestParseErrors_DoNotEchoInput` asserts it.

## Testing

29 new tests. Verified live against a running proxy: real inference traffic → aggregator → endpoint → abctl client → chart. Folding, session isolation, all three groupings, and error/denial counting confirmed end to end.

Two bugs found by the tests during development: a bar small relative to the peak truncated to zero eighths and rendered as an empty column (indistinguishable from idle), and value labels wider than their 4-column bars shoved their neighbours rightward out of alignment. Both fixed.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added usage analytics for requests, tokens, errors, latency, and time-bucketed activity.
  * Added a Usage pane in the terminal interface with charts, summaries, session scoping, metric selection, and refresh controls.
  * Added usage API access with configurable time windows, resolutions, and grouping by method, status, or plugin.
  * Added optional cost reporting when pricing information is configured.
* **Bug Fixes**
  * Improved handling of idle periods, unavailable usage data, unsupported endpoints, and stale results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->