### PR TITLE
Fix: Make Cortex look as simple as it is (installer output, README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,58 @@
 # Cortex
 
-Cortex delivers easy-to-use platform services to agentic workloads. It runs in a workload's request path — a sidecar in Kubernetes, or a standalone binary anywhere else — and provides:
+**See what your coding agent actually sends — and pay less for it.**
 
-- **Identity & access** — a verifiable identity for each workload, authentication and authorization of its calls, and the right credentials for each downstream service.
-- **Guardrails** — block agent actions that stray from the user's intent or aren't grounded in the conversation.
-- **Observability** — decrypt and parse a workload's model, tool, and agent-to-agent traffic into a live view.
-- **Egress control** — govern which external services a workload can reach.
-- **Optimizations** — trim the model context a workload sends and cap its spend, to cut latency and cost.
+Cortex sits in your agent's request path, decrypts its traffic, and shows you the model
+calls, tool calls and agent-to-agent messages as they happen. It can also strip the
+tool definitions your agent never calls, which is 4–20% of the prompt on every turn.
 
-It ships as a single binary; the identity and access layer is **AuthBridge**, and the code lives under [`authbridge/`](./authbridge/).
+One binary, no Kubernetes. macOS or Linux, amd64 or arm64.
 
-## Quick start — Claude Code on your laptop
-
-See what Claude Code sends: model calls, tool calls, and agent-to-agent traffic,
-decrypted and parsed live. No Kubernetes. macOS or Linux, amd64 or arm64.
+## Quick start
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
   | sh -s -- --claude-code
 ```
 
-That is the install. It asks before changing your Claude Code settings, then runs
-Cortex as a background service that comes back at login and restarts itself if it
-crashes.
+It asks before changing your Claude Code settings, then runs Cortex as a background
+service that survives crashes and logins.
 
-> **macOS note:** launchd will not restart a user agent added mid-session, so on
-> macOS the proxy runs under a small supervisor process that does. Verify with
-> `kill -9 $(pgrep -f 'authbridge-proxy --config')` — it comes back within ~2s.
-
-Now open two terminals:
+Then open two terminals:
 
 ```sh
 abctl      # the viewer
-claude     # Claude Code, as usual — no environment variables needed
+claude     # as usual — no environment variables to set
 ```
 
-Claude Code's calls stream into `abctl`. Cortex only reads them; nothing is rewritten.
+Your agent's calls stream into `abctl`. Cortex only reads them; nothing is rewritten.
 
-**Cut token cost too** — strip the tool definitions your agent never calls, worth
-4–20% of the prompt per turn, median 6%:
-**[one more command](./authbridge/docs/laptop-token-savings.md)**.
+- **[Cut token cost](./authbridge/docs/laptop-token-savings.md)** — one more command
+- **[Start, stop, remove](./authbridge/docs/laptop-service.md)** — `abctl service status | start | stop`
+- **[Run it in Kubernetes](./authbridge/docs/kubernetes.md)** — sidecars, Keycloak, SPIFFE/SPIRE
 
-**Starting, stopping, removing** — `abctl service status | start | stop`, and
-`abctl claude-code disable` to unwire Claude Code:
-**[the full lifecycle](./authbridge/docs/laptop-service.md)**.
+**Any agent works**, not only Claude Code: point it at `localhost:47600` and trust
+`~/.cortex/ca/ca.crt`.
 
-Any agent works, not just Claude Code — point it at `localhost:47600` and trust
-`~/.cortex/ca/ca.crt`. The URL is on `main`, but the script re-runs the copy from the
-newest **release**, so `curl | sh` does not run unreleased code — `--ref` overrides.
+The install URL is on `main`, but the script re-runs the copy from the newest
+**release**, so `curl | sh` does not execute unreleased code. `--ref` overrides that.
 
-## Running on Kubernetes
+## What else Cortex does
 
-In a cluster, Cortex sidecars are injected automatically by the [operator](https://github.com/rossoctl/operator), with Keycloak + SPIFFE/SPIRE for identity and token exchange. Start with the end-to-end **[Weather Agent walkthrough](./authbridge/demos/weather-agent/demo-ui.md)** (or the [`abctl` version](./authbridge/demos/weather-agent/demo-with-abctl.md)); see the [demos index](./authbridge/demos/README.md) and the [architecture reference](./authbridge/README.md) for all modes and details.
+Traffic visibility is the part you can use in a minute. The same binary provides the
+platform services agentic workloads need in production, as a sidecar or standalone:
 
-## Related repositories
+- **Identity & access** — a verifiable identity per workload, and the right credentials
+  for each downstream call, so an agent never holds a tool's secret. This layer is
+  **AuthBridge**.
+- **Guardrails** — block agent actions that stray from the user's intent or aren't
+  grounded in the conversation.
+- **Egress control** — govern which external services a workload can reach.
+- **Cost controls** — trim the context a workload sends, and cap its spend.
 
-- [rossoctl](https://github.com/rossoctl/rossoctl) — core platform
-- [operator](https://github.com/rossoctl/operator) — sidecar injection + admission webhook
+Everything is a plugin in one pipeline; the [plugin catalog](./authbridge/docs/plugin-catalog.md)
+lists what ships, and the [architecture reference](./authbridge/README.md) explains how
+a request flows through it. Code lives under [`authbridge/`](./authbridge/).
 
 ## License
 

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -271,12 +271,13 @@ func claudeCodeEnable2(settingsPath, cortexCfgPath, statePath string, yes bool, 
 		return 0
 	}
 
-	fmt.Fprintf(stdout, "This will add to the \"env\" block of %s:\n%s\n\n",
+	// Three short lines, not three paragraphs. This is a confirmation prompt, so it
+	// needs to say what changes and that the file is backed up; the rest (how to undo
+	// it, that `claude` needs no env vars afterwards) belongs in the closing summary,
+	// where it was also being printed.
+	fmt.Fprintf(stdout, "Adds to the \"env\" block of %s:\n%s\n",
 		settingsPath, strings.Join(changes, "\n"))
-	fmt.Fprintf(stdout, "Everything else in the file is left alone, and the current version is\n"+
-		"copied to %s.bak first. Afterwards, run Claude Code as plain `claude`.\n\n", settingsPath)
-	fmt.Fprintf(stdout, "While enabled, Claude Code needs Cortex running. Undo with:\n"+
-		"  abctl claude-code disable\n\n")
+	fmt.Fprintf(stdout, "Nothing else in the file changes; a copy is kept as %s.bak\n\n", settingsPath)
 	if !yes && !confirm(stdout) {
 		fmt.Fprintln(stdout, "Not changed.")
 		return exitDeclined
@@ -307,7 +308,7 @@ func claudeCodeEnable2(settingsPath, cortexCfgPath, statePath string, yes bool, 
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
 	}
-	fmt.Fprintf(stdout, "\nEnabled. Run `claude` — no environment variables needed.\n")
+	fmt.Fprintln(stdout, "Enabled — run `claude` as usual.")
 	return 0
 }
 

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -369,8 +369,7 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 
 	if p.healthURL != "" {
 		if waitHealthy(p.healthURL, serviceReadyTimeout) {
-			fmt.Fprintf(stdout, "Running as a %s, healthy.\n", supervisorName())
-			reportCrashRecovery(stdout)
+			reportInstallSuccess(true, stdout)
 			return 0
 		}
 		fmt.Fprintf(stderr, "\nabctl: installed, but nothing answered %s within %s.\n"+
@@ -378,24 +377,34 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 			"  abctl service status shows the current state.\n", p.healthURL, serviceReadyTimeout, p.logFile)
 		return 1
 	}
-	fmt.Fprintf(stdout, "Running as a %s.\n", supervisorName())
-	reportCrashRecovery(stdout)
+	reportInstallSuccess(false, stdout)
 	return 0
 }
 
-// reportCrashRecovery names how crashes are handled, and how to check it.
+// crashRecoveryNote explains why there are two authbridge-proxy processes on macOS.
 //
-// It has to be on BOTH success paths. It was originally only on the one taken when
-// there is no health endpoint to probe — so the note explaining the feature appeared
-// exactly when the install could verify least, and not on the normal healthy install.
-func reportCrashRecovery(stdout io.Writer) {
-	if runtime.GOOS != "darwin" {
-		return
+// launchd does not restart these agents — see renderUnitFor and
+// cmd/authbridge-proxy/supervise.go — so crash recovery belongs to the supervisor, not
+// to KeepAlive. A package-level const so its content can be asserted on any platform,
+// not only when the test happens to run on darwin.
+const crashRecoveryNote = "A supervisor process handles crashes (launchd will not restart these agents)."
+
+// reportInstallSuccess prints the outcome of an install that worked.
+//
+// ONE function for both outcomes, deliberately. This was previously two call sites
+// that each had to remember to print the crash-recovery note, and one of them did not
+// — so the note appeared only when the install could verify least, never on a normal
+// healthy install. A test could have caught that; not being able to express it is
+// better. There is now no "which path prints what" to get wrong.
+func reportInstallSuccess(healthy bool, stdout io.Writer) {
+	if healthy {
+		fmt.Fprintf(stdout, "Running as a %s, healthy.\n", supervisorName())
+	} else {
+		fmt.Fprintf(stdout, "Running as a %s.\n", supervisorName())
 	}
-	// launchd does not restart these agents — see renderUnitFor and
-	// cmd/authbridge-proxy/supervise.go — so crash recovery belongs to the supervisor,
-	// not to KeepAlive.
-	fmt.Fprintln(stdout, "A supervisor process handles crashes (launchd will not restart these agents).")
+	if runtime.GOOS == "darwin" {
+		fmt.Fprintln(stdout, crashRecoveryNote)
+	}
 }
 
 func serviceUninstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -243,10 +243,16 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "This will install a %s that runs:\n  %s --config %s\n\n",
-		supervisorName(), p.binary, p.configFile)
-	fmt.Fprintf(stdout, "It restarts on failure and starts at login, so Claude Code keeps working\n"+
-		"after a crash or a reboot. Unit file: %s\n\n", p.unitFile)
+	// Only when there is actually a decision to make. With --yes this text explained a
+	// choice nobody was being offered, and it said "restarts on failure and starts at
+	// login" a second time right after the caller had already said it — three sentences
+	// of the installer's output for one fact.
+	if !yes {
+		fmt.Fprintf(stdout, "This will install a %s that runs:\n  %s --config %s\n\n",
+			supervisorName(), p.binary, p.configFile)
+		fmt.Fprintf(stdout, "It restarts on failure and starts at login, so Claude Code keeps working\n"+
+			"after a crash or a reboot. Unit file: %s\n\n", p.unitFile)
+	}
 
 	// Adopt rather than collide. Two copies cannot share the ports, and the
 	// supervised one would lose the race and crash-loop while the hand-started one
@@ -256,7 +262,9 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "A Cortex you started by hand is running (pid %d). It will be stopped\n"+
 			"so the supervised one can take the ports.\n\n", adopt)
 	}
-	fmt.Fprintf(stdout, "Undo with: abctl service uninstall\n\n")
+	if !yes {
+		fmt.Fprintf(stdout, "Undo with: abctl service uninstall\n\n")
+	}
 	if !yes && !confirm(stdout) {
 		fmt.Fprintln(stdout, "Not changed.")
 		return exitDeclined
@@ -319,7 +327,12 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "abctl: writing %s: %v\n", p.unitFile, err)
 		return 1
 	}
-	fmt.Fprintf(stdout, "Wrote %s\n", p.unitFile)
+	// The path is not printed on the happy path: it is one more line of output on an
+	// install that already says what happened, and `abctl service status` reports it
+	// whenever someone actually needs it.
+	if !yes {
+		fmt.Fprintf(stdout, "Wrote %s\n", p.unitFile)
+	}
 
 	if err := loadService(p); errors.Is(err, errLingerUnavailable) {
 		// The unit IS loaded, so this is a caveat rather than a failure: keep going,
@@ -356,8 +369,7 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 
 	if p.healthURL != "" {
 		if waitHealthy(p.healthURL, serviceReadyTimeout) {
-			fmt.Fprintf(stdout, "\nRunning under %s and healthy. Claude Code will keep working across\n"+
-				"crashes and logins.\n", supervisorName())
+			fmt.Fprintf(stdout, "Running as a %s, healthy.\n", supervisorName())
 			reportCrashRecovery(stdout)
 			return 0
 		}
@@ -366,7 +378,7 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 			"  abctl service status shows the current state.\n", p.healthURL, serviceReadyTimeout, p.logFile)
 		return 1
 	}
-	fmt.Fprintf(stdout, "\nRunning under %s.\n", supervisorName())
+	fmt.Fprintf(stdout, "Running as a %s.\n", supervisorName())
 	reportCrashRecovery(stdout)
 	return 0
 }
@@ -383,9 +395,7 @@ func reportCrashRecovery(stdout io.Writer) {
 	// launchd does not restart these agents — see renderUnitFor and
 	// cmd/authbridge-proxy/supervise.go — so crash recovery belongs to the supervisor,
 	// not to KeepAlive.
-	fmt.Fprintln(stdout, "\n  Crash recovery is handled by a supervisor process, because launchd does")
-	fmt.Fprintln(stdout, "  not restart user agents added mid-session. Check it with:")
-	fmt.Fprintln(stdout, "    kill -9 $(pgrep -f 'authbridge-proxy --config')   # back within ~2s")
+	fmt.Fprintln(stdout, "A supervisor process handles crashes (launchd will not restart these agents).")
 }
 
 func serviceUninstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -358,6 +358,7 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		if waitHealthy(p.healthURL, serviceReadyTimeout) {
 			fmt.Fprintf(stdout, "\nRunning under %s and healthy. Claude Code will keep working across\n"+
 				"crashes and logins.\n", supervisorName())
+			reportCrashRecovery(stdout)
 			return 0
 		}
 		fmt.Fprintf(stderr, "\nabctl: installed, but nothing answered %s within %s.\n"+
@@ -366,15 +367,25 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		return 1
 	}
 	fmt.Fprintf(stdout, "\nRunning under %s.\n", supervisorName())
-	if runtime.GOOS == "darwin" {
-		// launchd does not restart these agents — see the comment in the plist and in
-		// cmd/authbridge-proxy/supervise.go — so the proxy runs under --supervise and
-		// crash recovery belongs to that supervisor, not to KeepAlive.
-		fmt.Fprintln(stdout, "  Crash recovery is handled by a supervisor process, because launchd")
-		fmt.Fprintln(stdout, "  does not restart user agents added mid-session. Check it with:")
-		fmt.Fprintln(stdout, "    kill -9 $(pgrep -f 'authbridge-proxy --config')  # back within ~2s")
-	}
+	reportCrashRecovery(stdout)
 	return 0
+}
+
+// reportCrashRecovery names how crashes are handled, and how to check it.
+//
+// It has to be on BOTH success paths. It was originally only on the one taken when
+// there is no health endpoint to probe — so the note explaining the feature appeared
+// exactly when the install could verify least, and not on the normal healthy install.
+func reportCrashRecovery(stdout io.Writer) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	// launchd does not restart these agents — see renderUnitFor and
+	// cmd/authbridge-proxy/supervise.go — so crash recovery belongs to the supervisor,
+	// not to KeepAlive.
+	fmt.Fprintln(stdout, "\n  Crash recovery is handled by a supervisor process, because launchd does")
+	fmt.Fprintln(stdout, "  not restart user agents added mid-session. Check it with:")
+	fmt.Fprintln(stdout, "    kill -9 $(pgrep -f 'authbridge-proxy --config')   # back within ~2s")
 }
 
 func serviceUninstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {

--- a/authbridge/cmd/abctl/cmd_service_recovery_test.go
+++ b/authbridge/cmd/abctl/cmd_service_recovery_test.go
@@ -77,27 +77,47 @@ func TestServiceInstall_RefusesABrokenConfig(t *testing.T) {
 	}
 }
 
-// TestReportCrashRecovery_OnDarwin: the note must appear on the healthy install path,
-// not only on the one where there is nothing to probe. It was originally the latter,
-// so a normal install never mentioned the feature or how to verify it.
-func TestReportCrashRecovery_OnDarwin(t *testing.T) {
-	var out bytes.Buffer
-	reportCrashRecovery(&out)
-	got := out.String()
-	if runtime.GOOS != "darwin" {
-		if got != "" {
-			t.Errorf("non-darwin should stay silent, got: %s", got)
+// TestReportInstallSuccess covers both outcomes through the single function that
+// prints them.
+//
+// The previous version of this test called the note helper directly, so it asserted
+// the helper's CONTENT and not its placement: deleting the call from the healthy
+// branch — the exact bug this fixes — left every package green. Verified by mutation.
+// The structural fix was to collapse the two call sites into one, so the divergence
+// cannot be expressed; this test then pins what that one path prints.
+func TestReportInstallSuccess(t *testing.T) {
+	for _, healthy := range []bool{true, false} {
+		var out bytes.Buffer
+		reportInstallSuccess(healthy, &out)
+		got := out.String()
+
+		if !strings.Contains(got, "Running as a") {
+			t.Errorf("healthy=%v: no outcome line:\n%s", healthy, got)
 		}
-		return
+		if healthy && !strings.Contains(got, "healthy") {
+			t.Errorf("healthy=true does not say so:\n%s", got)
+		}
+		if !healthy && strings.Contains(got, "healthy") {
+			t.Errorf("healthy=false claims healthy:\n%s", got)
+		}
+		// The note has to be on BOTH outcomes on darwin — that is the regression.
+		if runtime.GOOS == "darwin" && !strings.Contains(got, crashRecoveryNote) {
+			t.Errorf("healthy=%v is missing the crash-recovery note:\n%s", healthy, got)
+		}
+		if runtime.GOOS != "darwin" && strings.Contains(got, "supervisor") {
+			t.Errorf("non-darwin should not mention a supervisor:\n%s", got)
+		}
 	}
-	// One line: it must name the supervisor, because two authbridge-proxy processes
-	// with no explanation is the first thing people ask about. The kill -9
-	// verification lives in docs/laptop-service.md instead — install output is not
-	// where a tutorial belongs.
-	if !strings.Contains(got, "supervisor") {
-		t.Errorf("note does not mention the supervisor:\n%s", got)
+}
+
+// TestCrashRecoveryNote checks the message itself, on every platform rather than only
+// on darwin: the const exists so these assertions are not skipped on CI.
+func TestCrashRecoveryNote(t *testing.T) {
+	if !strings.Contains(crashRecoveryNote, "supervisor") {
+		t.Error("note does not name the supervisor; two authbridge-proxy processes " +
+			"with no explanation is the first thing people ask about")
 	}
-	if n := strings.Count(strings.TrimSpace(got), "\n"); n != 0 {
-		t.Errorf("note is %d lines; keep it to one:\n%s", n+1, got)
+	if strings.Contains(strings.TrimSpace(crashRecoveryNote), "\n") {
+		t.Errorf("note is more than one line; keep it short:\n%s", crashRecoveryNote)
 	}
 }

--- a/authbridge/cmd/abctl/cmd_service_recovery_test.go
+++ b/authbridge/cmd/abctl/cmd_service_recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -73,5 +74,25 @@ func TestServiceInstall_RefusesABrokenConfig(t *testing.T) {
 	}
 	if _, serr := os.Stat(p.unitFile); serr == nil {
 		t.Error("a unit was written for a config that cannot load")
+	}
+}
+
+// TestReportCrashRecovery_OnDarwin: the note must appear on the healthy install path,
+// not only on the one where there is nothing to probe. It was originally the latter,
+// so a normal install never mentioned the feature or how to verify it.
+func TestReportCrashRecovery_OnDarwin(t *testing.T) {
+	var out bytes.Buffer
+	reportCrashRecovery(&out)
+	got := out.String()
+	if runtime.GOOS != "darwin" {
+		if got != "" {
+			t.Errorf("non-darwin should stay silent, got: %s", got)
+		}
+		return
+	}
+	for _, want := range []string{"supervisor process", "kill -9", "~2s"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("note is missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/authbridge/cmd/abctl/cmd_service_recovery_test.go
+++ b/authbridge/cmd/abctl/cmd_service_recovery_test.go
@@ -90,9 +90,14 @@ func TestReportCrashRecovery_OnDarwin(t *testing.T) {
 		}
 		return
 	}
-	for _, want := range []string{"supervisor process", "kill -9", "~2s"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("note is missing %q:\n%s", want, got)
-		}
+	// One line: it must name the supervisor, because two authbridge-proxy processes
+	// with no explanation is the first thing people ask about. The kill -9
+	// verification lives in docs/laptop-service.md instead — install output is not
+	// where a tutorial belongs.
+	if !strings.Contains(got, "supervisor") {
+		t.Errorf("note does not mention the supervisor:\n%s", got)
+	}
+	if n := strings.Count(strings.TrimSpace(got), "\n"); n != 0 {
+		t.Errorf("note is %d lines; keep it to one:\n%s", n+1, got)
 	}
 }

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -204,7 +204,10 @@ func main() {
 		// for `abctl service install` to load. Exiting here keeps one source of truth
 		// for the built-in config instead of teaching abctl to write it too.
 		if *writeConfigOnly {
-			slog.Info("wrote the built-in config; not starting", "config", p, "ca_dir", absCA)
+			// Silent on success. This runs from install.sh, which reports progress
+			// itself; a structured INFO line with timestamps and key=value pairs in the
+			// middle of that output reads like something went wrong. Failures still
+			// surface — writeBuiltinConfig's error is fatal above.
 			return
 		}
 		slog.Info("local mode — using the built-in config; edit it to hot-reload",

--- a/authbridge/demos/session-budget/hitl-with-claude-code.md
+++ b/authbridge/demos/session-budget/hitl-with-claude-code.md
@@ -11,7 +11,7 @@ The [README quickstart][qs] `install.sh` binary isn't compiled
 with `include_plugin_sessionbudget`, so this doc builds
 `authbridge-proxy` from source with the tag on.
 
-[qs]: ../../../README.md#quick-start--claude-code-on-your-laptop
+[qs]: ../../../README.md#quick-start
 
 ## Prerequisites
 

--- a/authbridge/docs/kubernetes.md
+++ b/authbridge/docs/kubernetes.md
@@ -1,0 +1,59 @@
+# Running Cortex in Kubernetes
+
+On a laptop Cortex is one binary you install yourself. In a cluster it is a sidecar,
+and almost everything else follows from that difference.
+
+## What changes
+
+- **You do not install it per workload.** The
+  [operator](https://github.com/rossoctl/operator) injects the sidecar, so a workload
+  opts in with a label rather than a command.
+- **Identity comes from the cluster.** Workloads get a verifiable identity from
+  SPIFFE/SPIRE, and Cortex exchanges it for the credentials each downstream service
+  expects — so an agent calling a tool never holds that tool's secret.
+- **Keycloak issues and exchanges tokens** (OAuth 2.0 token exchange, RFC 8693).
+  Inbound calls are validated against it; outbound calls are re-minted for the target
+  audience.
+- **Configuration is ConfigMaps**, not `~/.cortex/config.yaml`, and it hot-reloads.
+
+The plugin pipeline, the session API, and `abctl` are the same in both places. If you
+learned them on your laptop, they behave identically in a pod — point `abctl` at one
+with `kubectl port-forward`, or let it pick a pod from its own Namespaces → Pods
+picker.
+
+## Getting a cluster
+
+Cortex needs SPIRE and Keycloak in place. The
+[rossoctl](https://github.com/rossoctl/rossoctl) installer sets up both, plus the
+[operator](https://github.com/rossoctl/operator) that does the injecting — start from
+its [quickstart](https://www.rossoctl.dev/docs/overview/quickstart) rather than wiring
+them by hand.
+
+## Start here
+
+The **[Weather Agent walkthrough](../demos/weather-agent/demo-ui.md)** is the shortest
+end-to-end path: a cluster, an agent, inbound validation, and traffic you can watch.
+There is also an [`abctl` version](../demos/weather-agent/demo-with-abctl.md) that
+focuses on the plugin pipeline.
+
+Then, in rough order of how often people need them:
+
+| Topic | Where |
+|---|---|
+| All the demos, with a recommended order | [demos index](../demos/README.md) |
+| Deployment modes (proxy-sidecar, envoy-sidecar, lite) | [architecture reference](../README.md#deployment-modes) |
+| Full request flow, what gets verified | [architecture reference](../README.md) |
+| Token exchange per destination | [token-exchange routes](../demos/token-exchange-routes/README.md) |
+| Writing or configuring a plugin | [plugin reference](./plugin-reference.md) |
+| mTLS between workloads | [AuthBridge CLAUDE.md](../CLAUDE.md) |
+
+## A note on trust boundaries
+
+Two things that are safe in a pod are not safe on a laptop, and the defaults differ
+accordingly:
+
+- The **session API** (`:9094` in-cluster, `:47601` locally) is unauthenticated. In a
+  pod the network namespace is the boundary. Never expose it through an ingress.
+- **Wildcard binds** are correct in a pod and wrong on a laptop, so the laptop config
+  sets `listener.bind_loopback_only: true`. Do not set it in a cluster: kubelet probes
+  health from outside the container's loopback and would fail.

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -13,9 +13,22 @@ abctl service install     # set it up in the first place (the installer does thi
 abctl service uninstall   # stop it and remove the service
 ```
 
-**Never use `kill` or `pkill`.** The proxy is supervised: killing it gets it restarted
-within a couple of seconds, which looks like a process refusing to die. `abctl service
-stop` is the stop that works.
+**Never use `kill` or `pkill` to stop it.** The proxy is supervised, so killing it gets
+it restarted within a couple of seconds, which looks like a process refusing to die.
+`abctl service stop` is the stop that works.
+
+That restart is the point, though, and it is worth seeing once:
+
+```sh
+kill -9 $(pgrep -f 'authbridge-proxy --config')   # comes back within ~2s
+abctl service status                              # healthy again
+```
+
+On macOS you will see **two** `authbridge-proxy` processes: a supervisor (the one
+launchd starts, holding no ports) and the proxy itself. launchd does not restart user
+agents added mid-session — verified across `KeepAlive`, `StartInterval` and
+`RunAtLoad` — so the supervisor is what makes crash recovery work. On Linux there is
+one process; systemd handles it.
 
 ## Is it working?
 

--- a/authbridge/docs/laptop-token-savings.md
+++ b/authbridge/docs/laptop-token-savings.md
@@ -5,7 +5,7 @@ tokens of JSON schema, billed each time. Cortex strips the definitions you never
 call.
 
 Needs the proxy from the
-[quick start](../../README.md#quick-start--claude-code-on-your-laptop) first. This
+[quick start](../../README.md#quick-start) first. This
 step is opt-in because it rewrites requests.
 
 ## Turn it on

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -375,10 +375,16 @@ done
 lines=$(wc -l < "${tmp}/checksums.filtered" | tr -d '[:space:]')
 [ "${lines}" = "2" ] \
 	|| die "expected 2 checksum entries, got ${lines} — refusing to install"
-# Output suppressed: sha_check prints an "OK" line per archive, which is two lines
-# saying what one line already implies. A failure still speaks — die reports it, and
-# the exit status is what matters.
-( cd "$tmp" && sha_check checksums.filtered >/dev/null 2>&1 ) || die "checksum verification failed"
+# Quiet on success, loud on failure. The per-archive "OK" lines are two lines saying
+# what one line implies — but sending them to /dev/null took the FAILED lines (stdout)
+# and shasum's "computed checksum did NOT match" warning (stderr) with them, so a
+# corrupt download or a tampered release would surface as a bare "checksum verification
+# failed" naming neither archive. That is the one step whose whole job is not to fail
+# open; it should not also fail silently.
+if ! ( cd "$tmp" && sha_check checksums.filtered >"${tmp}/sha.out" 2>&1 ); then
+	cat "${tmp}/sha.out" >&2
+	die "checksum verification failed — do NOT use these binaries"
+fi
 
 # --- extract + install ---
 mkdir -p "$BIN_DIR"
@@ -460,10 +466,16 @@ fi
 # doing the starting, nothing else creates the file, and `abctl service install`
 # refuses to run without it.
 if [ ! -f "${CORTEX_DIR}/config.yaml" ]; then
+	# Executed by explicit path, and REPORTED by the same explicit path. proxy_cmd is
+	# the display form — a bare "authbridge-proxy" when BIN_DIR is on PATH — so naming
+	# it here would hand back a command that resolves through PATH, which is not
+	# necessarily the binary that just failed. That distinction is the whole point of
+	# pinning the path: an older authbridge-proxy earlier on PATH is exactly how the
+	# service came up dead in end-to-end testing.
 	if ! "${BIN_DIR}/authbridge-proxy" --local --write-config; then
 		die "could not write ${CORTEX_DIR}/config.yaml.
   Run this to see why:
-    \"${proxy_cmd}\" --local --write-config"
+    \"${BIN_DIR}/authbridge-proxy\" --local --write-config"
 	fi
 fi
 
@@ -520,10 +532,10 @@ if [ -n "${WIRE_CLAUDE_CODE:-}" ]; then
 			# The service is already installed above — it is how the proxy runs now,
 			# not an option — so there is nothing to offer here.
 			info ""
-			info "  ${abctl_cmd}                         watch traffic"
-			info "  ${abctl_cmd} tools scan              cut token cost (prunes unused tools)"
-			info "  ${abctl_cmd} service stop            stop Cortex"
-			info "  ${abctl_cmd} claude-code disable     undo"
+			info "  \"${abctl_cmd}\"                         watch traffic"
+			info "  \"${abctl_cmd}\" tools scan              propose unused tools to prune"
+			info "  \"${abctl_cmd}\" service stop            stop Cortex"
+			info "  \"${abctl_cmd}\" claude-code disable     undo"
 			info ""
 			exit 0
 			;;

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -328,7 +328,6 @@ if [ -z "$version" ]; then
 			;;
 	esac
 fi
-info "Release: $version"
 
 # --- download + verify ---
 tmp=$(mktemp -d)
@@ -338,12 +337,11 @@ base="https://github.com/${REPO}/releases/download/${version}"
 abctl_tgz="abctl_${version}_${os}_${arch}.tar.gz"
 proxy_tgz="authbridge-proxy_${version}_${os}_${arch}.tar.gz"
 
-info "Downloading binaries for ${os}/${arch}..."
+info "Downloading ${version} for ${os}/${arch}..."
 curl -fsSL "${base}/${abctl_tgz}" -o "${tmp}/${abctl_tgz}" || die "download failed: ${abctl_tgz}"
 curl -fsSL "${base}/${proxy_tgz}" -o "${tmp}/${proxy_tgz}" || die "download failed: ${proxy_tgz}"
 curl -fsSL "${base}/checksums.txt" -o "${tmp}/checksums.txt" || die "download failed: checksums.txt"
 
-info "Verifying checksums..."
 # One grep per archive, not an alternation. An alternation SUCCEEDS on a single
 # match, so a checksums.txt missing one entry — a truncated or partly-generated
 # release build — passed the guard, sha_check verified only the file that was
@@ -377,10 +375,12 @@ done
 lines=$(wc -l < "${tmp}/checksums.filtered" | tr -d '[:space:]')
 [ "${lines}" = "2" ] \
 	|| die "expected 2 checksum entries, got ${lines} — refusing to install"
-( cd "$tmp" && sha_check checksums.filtered ) || die "checksum verification failed"
+# Output suppressed: sha_check prints an "OK" line per archive, which is two lines
+# saying what one line already implies. A failure still speaks — die reports it, and
+# the exit status is what matters.
+( cd "$tmp" && sha_check checksums.filtered >/dev/null 2>&1 ) || die "checksum verification failed"
 
 # --- extract + install ---
-info "Installing to ${BIN_DIR}..."
 mkdir -p "$BIN_DIR"
 tar -xzf "${tmp}/${abctl_tgz}" -C "$tmp"
 tar -xzf "${tmp}/${proxy_tgz}" -C "$tmp"
@@ -408,7 +408,7 @@ case ":${PATH}:" in
 esac
 
 info ""
-info "Installed abctl and authbridge-proxy (${version}) to ${BIN_DIR}"
+info "Installed abctl and authbridge-proxy to ${BIN_DIR}"
 case ":${PATH}:" in
 	*":${BIN_DIR}:"*) ;;
 	*)
@@ -468,8 +468,7 @@ if [ ! -f "${CORTEX_DIR}/config.yaml" ]; then
 fi
 
 info ""
-info "Setting Cortex up as a ${SUPERVISOR_NAME} so it restarts on failure and"
-info "comes back at login..."
+info "Setting up the ${SUPERVISOR_NAME}..."
 set +e
 # --proxy: use the binary this script just installed, not whatever happens to be
 # earlier on PATH. An end-to-end run found the unit pointing at an older
@@ -495,14 +494,12 @@ fi
 # mutation with no upside. Opting in is one command, and it belongs to the person
 # who knows whether they want it.
 local_cfg="${CORTEX_DIR}/config.yaml"
-if [ -f "${local_cfg}" ]; then
-	info "  Skip the env vars below — configure Claude Code once, then just run \`claude\`:"
+# Only when we are NOT about to do it ourselves: with --claude-code this told the
+# reader to run the exact command that runs two lines later. The prune hint moved to
+# the closing summary, so the middle of the flow carries no side quests.
+if [ -f "${local_cfg}" ] && [ -z "${WIRE_CLAUDE_CODE}" ]; then
+	info "  Point Claude Code at Cortex, then just run \`claude\`:"
 	info "    ${abctl_cmd} claude-code enable"
-	info ""
-	info "  Using Claude Code? Cut its token cost by pruning tools you never call:"
-	info "    \"${abctl_cmd}\" tools scan --write \"${local_cfg}\""
-	info "    (proposes tools absent from your last 30 days of transcripts;"
-	info "     add --all to spare anything you have ever called; hot-reloaded)"
 	info ""
 fi
 # --claude-code: hand off to abctl, which owns the JSON merge (a shell-side edit
@@ -523,10 +520,10 @@ if [ -n "${WIRE_CLAUDE_CODE:-}" ]; then
 			# The service is already installed above — it is how the proxy runs now,
 			# not an option — so there is nothing to offer here.
 			info ""
-			info "  Run Claude Code:   claude"
-			info "  Watch traffic:     \"${abctl_cmd}\""
-			info "  Undo:              \"${abctl_cmd}\" claude-code disable"
-			info "  Stop Cortex:       \"${abctl_cmd}\" service stop"
+			info "  ${abctl_cmd}                         watch traffic"
+			info "  ${abctl_cmd} tools scan              cut token cost (prunes unused tools)"
+			info "  ${abctl_cmd} service stop            stop Cortex"
+			info "  ${abctl_cmd} claude-code disable     undo"
 			info ""
 			exit 0
 			;;


### PR DESCRIPTION
Three things, all about how complicated Cortex *looks* rather than what it does.

1. The installer printed ~45 lines. It is now 21, with the same result.
2. The README opened with abstract platform framing before anything a reader could do.
3. The crash-recovery note printed on the wrong success path.

## Before → after

```
Installed abctl and authbridge-proxy to ~/.local/bin

Setting up the launchd user agent...
Running as a launchd user agent, healthy.
A supervisor process handles crashes (launchd will not restart these agents).

Adds to the "env" block of ~/.claude/settings.json:
  HTTPS_PROXY=http://127.0.0.1:47600
  NODE_EXTRA_CA_CERTS=~/.cortex/ca/ca.crt
  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
Nothing else in the file changes; a copy is kept as settings.json.bak

Enabled — run `claude` as usual.

  abctl                         watch traffic
  abctl tools scan              cut token cost (prunes unused tools)
  abctl service stop            stop Cortex
  abctl claude-code disable     undo
```

## What went, and why

- **`service install` printed its consent explanation under `--yes`** — describing a choice nobody was offered, and repeating "restarts on failure and starts at login" right after install.sh said it. Now only when there is a prompt.
- **install.sh told the reader to run `abctl claude-code enable`** two lines before running it for them. Now only when `--claude-code` was not passed.
- **The prune-tools hint** sat mid-flow as a side quest → one line in the closing summary.
- `Release: <v>` duplicated `Using the installer from <v>`.
- **"Verifying checksums..." plus one `OK` per archive** — three lines for a step whose failure already aborts. Suppressed; the exit status is what matters.
- `Installing to <dir>...` followed by `Installed ... to <dir>`.
- **`--write-config` logged a structured INFO line** with timestamps into the middle of the output, which reads like a fault. Silent on success; failures were already fatal.
- The plist path on a non-interactive install — `abctl service status` reports it when needed.
- The claude-code prompt's three paragraphs → two lines: what changes, and that a backup is kept.
- The summary repeated "run `claude`" directly under a line saying it.

## Kept deliberately

One line naming the supervisor. Two `authbridge-proxy` processes with no explanation is the first thing anyone asks — it was asked about this build within a minute of installing — and a line up front is cheaper than the confusion.

## Also here

The original fix this PR was opened for: the crash-recovery note only printed on the success path taken when there is *no* health endpoint to probe, so it appeared exactly when the install could verify least, and never on a normal healthy install.

The `kill -9` verification moved into `docs/laptop-service.md`, which now also explains the two-processes-on-macOS/one-on-Linux difference. My own test caught that removal and now asserts the note stays a single line.

Verified: 21 lines, and the result is unchanged — service healthy, `kill -9` on the proxy still recovers.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

---

## README rewrite

447 words to 346, five sections to four. It now opens with what you get — see what your
agent sends, and pay less for it — then the install, then two commands.

- **Kubernetes moved to `docs/kubernetes.md`**, one link in the quickstart's "next" list.
  The old section was a dense paragraph carrying six links. The new page says what
  actually differs in a cluster (the operator injects rather than you installing, SPIRE
  provides identity, Keycloak exchanges tokens, config is ConfigMaps), routes to the
  weather-agent walkthrough, and tables the rest. It also states the two trust-boundary
  inversions between laptop and cluster: the session API is unauthenticated and leans on
  the pod boundary, and `bind_loopback_only` is right on a laptop but would fail kubelet
  probes in a cluster.
- **Related repositories removed.** Nothing is orphaned — `rossoctl` is still referenced
  from five docs, and both it and the operator now appear in `docs/kubernetes.md` under
  how to get a cluster, which is where they are actually needed.
- **The macOS supervisor blockquote is gone** from the quickstart; it explained a launchd
  limitation to someone three lines into their first install. `docs/laptop-service.md`
  covers it, including why there are two `authbridge-proxy` processes.
- The capability list stays, shorter and below the fold. Dropping it would misrepresent
  the repo — identity and access is most of the code — but it is not what gets anyone
  started.

Renaming the quickstart heading broke two inbound anchors; both fixed, and every anchor
into the README, every link out of it, and every link out of the new page resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes deployment documentation, including sidecar setup, identity, token exchange, configuration, and trust boundaries.
  * Added platform-specific service supervision and restart guidance.

* **Improvements**
  * Streamlined installer and Claude Code setup messaging.
  * Installer downloads now show version and platform, with clearer checksum failure details.
  * Non-interactive service installation reports concise status information.
  * Updated README positioning and quick-start guidance, including the plugin catalog.

* **Bug Fixes**
  * Corrected documentation links to the general quick-start section.

* **Documentation**
  * Clarified supported service shutdown procedures and warned against direct process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->