### PR TITLE
Feat: Name unbridged CONNECT tunnels in the events ACTION column

### DIFF
--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -516,6 +516,8 @@ Every plugin emits one of these 5 action values per invocation, so operators can
 
 Use `reason` to discriminate within an action — e.g. `skip/path_bypass` vs `skip/no_matching_route` tell different stories at the detail-pane level but both scan as "skip" in the at-a-glance timeline.
 
+**abctl's ACTION column is not only this vocabulary.** Two of its values are rendering, not plugin output: `—` when nothing acted, and `tunnel` for an opaque CONNECT — a row where no plugin ran, no protocol was parsed and there is no status, so METHOD and STATUS are blank too and the label is the only thing identifying it. Neither is ever emitted by a plugin, and neither is a verdict on the request.
+
 > **Producer-side contract:** the authoritative definition of the 5-value vocabulary, the `Invocation` struct fields, and which diagnostic fields each plugin type populates lives in [`docs/plugin-reference.md`](docs/plugin-reference.md#emitting-session-events). Edit that file when the vocabulary changes; this table is the consumer-side summary.
 
 ### Gotcha: denied requests

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -22,7 +22,7 @@ func newEventsTable() table.Model {
 			{Title: "TIME", Width: 12},
 			{Title: "DIR", Width: 4},
 			{Title: "PHASE", Width: 7},
-			{Title: "ACTION", Width: 8},
+			{Title: "ACTION", Width: actionColWidth},
 			{Title: "PLUGIN", Width: 18},
 			{Title: "METHOD", Width: 22},
 			{Title: "STATUS", Width: 7},
@@ -115,7 +115,7 @@ func (m *model) rebuildEventsTable() {
 			continue
 		}
 
-		action, plugin := rowAction(er)
+		action, plugin := rowAction(er, invs)
 		var idCell string
 		if id, ok := ids[ev]; ok {
 			idCell = strconv.Itoa(id)
@@ -316,7 +316,18 @@ func shadowFlagged(invs []pipeline.Invocation) bool {
 	return false
 }
 
+// actionColWidth is the ACTION column's width. Named rather than inlined in the
+// column literal so a test can assert against the real value: transcribing it
+// into the test gave two independent 8s, and narrowing the column left the test
+// passing while the label overflowed.
+const actionColWidth = 8
+
 // tunnelAction is the ACTION cell for an opaque CONNECT that no plugin acted on.
+//
+// It must fit actionColWidth. Truncation matters more here than on other rows:
+// METHOD and STATUS are both empty for an unbridged CONNECT, so a clipped
+// "tunne" would take the row back to unreadable — the state this label exists to
+// fix.
 const tunnelAction = "tunnel"
 
 // rowAction is the ACTION + PLUGIN pair for one display row.
@@ -330,8 +341,15 @@ const tunnelAction = "tunnel"
 // tunnel-open itself, and that deny must keep the headline. A BRIDGED tunnel never
 // reaches this branch — buildEventRows folds it into the decrypted inner request,
 // whose own action is the interesting one.
-func rowAction(er eventRow) (action, plugin string) {
-	action, plugin = eventAction(er.invocations())
+//
+// invs is passed in rather than derived from er, so the headline is computed from
+// the same set the caller's visibility decision used. Deriving it again would make
+// that relationship implicit and silently divergent: were the call site ever to
+// filter invs — to honour a plugin-name filter in the hide logic, say — the ACTION
+// cell would keep using the unfiltered set and disagree with the row's own reason
+// for being visible.
+func rowAction(er eventRow, invs []pipeline.Invocation) (action, plugin string) {
+	action, plugin = eventAction(invs)
 	if er.event != nil && er.event.Tunnel && action == "—" {
 		return tunnelAction, "—"
 	}

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -115,7 +115,7 @@ func (m *model) rebuildEventsTable() {
 			continue
 		}
 
-		action, plugin := eventAction(invs)
+		action, plugin := rowAction(er)
 		var idCell string
 		if id, ok := ids[ev]; ok {
 			idCell = strconv.Itoa(id)
@@ -314,6 +314,28 @@ func shadowFlagged(invs []pipeline.Invocation) bool {
 		}
 	}
 	return false
+}
+
+// tunnelAction is the ACTION cell for an opaque CONNECT that no plugin acted on.
+const tunnelAction = "tunnel"
+
+// rowAction is the ACTION + PLUGIN pair for one display row.
+//
+// It wraps eventAction to name an unbridged CONNECT. Such a row carries TLS bytes,
+// so no plugin ran, no protocol was parsed and there is no status — left as "— —"
+// it reads as a request that failed or that the pipeline ignored, which is how a
+// routine egress tunnel came to look like a bug.
+//
+// The label applies only when nothing acted: a gate CAN deny a CONNECT on the
+// tunnel-open itself, and that deny must keep the headline. A BRIDGED tunnel never
+// reaches this branch — buildEventRows folds it into the decrypted inner request,
+// whose own action is the interesting one.
+func rowAction(er eventRow) (action, plugin string) {
+	action, plugin = eventAction(er.invocations())
+	if er.event != nil && er.event.Tunnel && action == "—" {
+		return tunnelAction, "—"
+	}
+	return action, plugin
 }
 
 // eventAction folds a message's per-plugin invocations into the single ACTION +

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -847,3 +847,117 @@ func TestComputeEventPairs_FieldTrace(t *testing.T) {
 		}
 	}
 }
+
+// An unbridged CONNECT must name itself in the ACTION column. It carries TLS
+// bytes, so no plugin ran, no protocol was parsed and there is no status — left
+// blank the row reads as a request that failed or that the pipeline ignored, which
+// is how a routine egress tunnel (git, gh, an SDK that does not trust the bridge
+// CA) came to look like a bug.
+func TestRowAction_UnbridgedTunnelIsNamed(t *testing.T) {
+	er := eventRow{event: &pipeline.SessionEvent{
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionRequest,
+		Host:      "api.github.com:443",
+		Tunnel:    true,
+	}}
+	action, plugin := rowAction(er)
+	if action != tunnelAction {
+		t.Errorf("ACTION = %q, want %q", action, tunnelAction)
+	}
+	if plugin != "—" {
+		t.Errorf("PLUGIN = %q, want an em dash: no plugin ran", plugin)
+	}
+}
+
+// A gate can deny a CONNECT on the tunnel-open itself. That deny is the whole
+// point of the row and must keep the headline.
+func TestRowAction_DeniedTunnelKeepsTheDeny(t *testing.T) {
+	er := eventRow{event: &pipeline.SessionEvent{
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionRequest,
+		Host:      "blocked.example:443",
+		Tunnel:    true,
+		Invocations: &pipeline.Invocations{Outbound: []pipeline.Invocation{
+			{Plugin: "egress-gate", Action: pipeline.ActionDeny},
+		}},
+	}}
+	action, plugin := rowAction(er)
+	if action != string(pipeline.ActionDeny) {
+		t.Errorf("ACTION = %q, want deny — the label must not mask a gate decision", action)
+	}
+	if plugin != "egress-gate" {
+		t.Errorf("PLUGIN = %q, want egress-gate", plugin)
+	}
+}
+
+// A bridged tunnel is folded into its decrypted inner request, so the row shows
+// the inner request's action. The tunnel label must not override it.
+func TestRowAction_BridgedTunnelShowsInnerAction(t *testing.T) {
+	tunnel := &pipeline.SessionEvent{
+		Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
+		Host: "ete-litellm.example:443", Tunnel: true,
+	}
+	inner := &pipeline.SessionEvent{
+		Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
+		Host: "ete-litellm.example",
+		Invocations: &pipeline.Invocations{Outbound: []pipeline.Invocation{
+			{Plugin: "inference-parser", Action: pipeline.ActionObserve},
+		}},
+	}
+	er := eventRow{event: inner, tunnel: tunnel}
+	action, plugin := rowAction(er)
+	if action != string(pipeline.ActionObserve) {
+		t.Errorf("ACTION = %q, want observe from the decrypted inner request", action)
+	}
+	if plugin != "inference-parser" {
+		t.Errorf("PLUGIN = %q, want inference-parser", plugin)
+	}
+}
+
+// An ordinary request that no plugin touched keeps its em dash: only a tunnel
+// earns the label, or every passthrough row would claim to be one.
+func TestRowAction_PlainPassthroughIsUnchanged(t *testing.T) {
+	er := eventRow{event: &pipeline.SessionEvent{
+		Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
+		Host: "example.com",
+	}}
+	if action, _ := rowAction(er); action != "—" {
+		t.Errorf("ACTION = %q for a non-tunnel passthrough, want an em dash", action)
+	}
+}
+
+// The label must fit the column, or the table shifts.
+func TestTunnelAction_FitsTheActionColumn(t *testing.T) {
+	const actionColWidth = 8 // {Title: "ACTION", Width: 8}
+	if got := len([]rune(tunnelAction)); got > actionColWidth {
+		t.Errorf("%q is %d columns, ACTION is %d wide", tunnelAction, got, actionColWidth)
+	}
+}
+
+// End to end through buildEventRows, using the event shapes a live server records:
+// an unbridged CONNECT stands alone and is named; a bridged pair folds to one row
+// showing the inner action.
+func TestBuildEventRows_TunnelRowsAreLabelled(t *testing.T) {
+	base := time.Now()
+	events := []pipeline.SessionEvent{
+		{At: base, Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
+			RequestID: "40", Host: "api.github.com:443", Tunnel: true},
+		{At: base.Add(time.Second), Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
+			RequestID: "41", Host: "ete-litellm.example:443", Tunnel: true},
+		{At: base.Add(time.Second), Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
+			RequestID: "41", Host: "ete-litellm.example",
+			Invocations: &pipeline.Invocations{Outbound: []pipeline.Invocation{
+				{Plugin: "inference-parser", Action: pipeline.ActionObserve},
+			}}},
+	}
+	rows := buildEventRows(events)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (the bridged pair folds)", len(rows))
+	}
+	if a, _ := rowAction(rows[0]); a != tunnelAction {
+		t.Errorf("unbridged tunnel row ACTION = %q, want %q", a, tunnelAction)
+	}
+	if a, _ := rowAction(rows[1]); a != string(pipeline.ActionObserve) {
+		t.Errorf("bridged row ACTION = %q, want observe", a)
+	}
+}

--- a/authbridge/cmd/abctl/tui/events_pane_test.go
+++ b/authbridge/cmd/abctl/tui/events_pane_test.go
@@ -860,7 +860,7 @@ func TestRowAction_UnbridgedTunnelIsNamed(t *testing.T) {
 		Host:      "api.github.com:443",
 		Tunnel:    true,
 	}}
-	action, plugin := rowAction(er)
+	action, plugin := rowAction(er, er.invocations())
 	if action != tunnelAction {
 		t.Errorf("ACTION = %q, want %q", action, tunnelAction)
 	}
@@ -881,7 +881,7 @@ func TestRowAction_DeniedTunnelKeepsTheDeny(t *testing.T) {
 			{Plugin: "egress-gate", Action: pipeline.ActionDeny},
 		}},
 	}}
-	action, plugin := rowAction(er)
+	action, plugin := rowAction(er, er.invocations())
 	if action != string(pipeline.ActionDeny) {
 		t.Errorf("ACTION = %q, want deny — the label must not mask a gate decision", action)
 	}
@@ -905,7 +905,7 @@ func TestRowAction_BridgedTunnelShowsInnerAction(t *testing.T) {
 		}},
 	}
 	er := eventRow{event: inner, tunnel: tunnel}
-	action, plugin := rowAction(er)
+	action, plugin := rowAction(er, er.invocations())
 	if action != string(pipeline.ActionObserve) {
 		t.Errorf("ACTION = %q, want observe from the decrypted inner request", action)
 	}
@@ -921,14 +921,13 @@ func TestRowAction_PlainPassthroughIsUnchanged(t *testing.T) {
 		Direction: pipeline.Outbound, Phase: pipeline.SessionRequest,
 		Host: "example.com",
 	}}
-	if action, _ := rowAction(er); action != "—" {
+	if action, _ := rowAction(er, er.invocations()); action != "—" {
 		t.Errorf("ACTION = %q for a non-tunnel passthrough, want an em dash", action)
 	}
 }
 
 // The label must fit the column, or the table shifts.
 func TestTunnelAction_FitsTheActionColumn(t *testing.T) {
-	const actionColWidth = 8 // {Title: "ACTION", Width: 8}
 	if got := len([]rune(tunnelAction)); got > actionColWidth {
 		t.Errorf("%q is %d columns, ACTION is %d wide", tunnelAction, got, actionColWidth)
 	}
@@ -954,10 +953,10 @@ func TestBuildEventRows_TunnelRowsAreLabelled(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("got %d rows, want 2 (the bridged pair folds)", len(rows))
 	}
-	if a, _ := rowAction(rows[0]); a != tunnelAction {
+	if a, _ := rowAction(rows[0], rows[0].invocations()); a != tunnelAction {
 		t.Errorf("unbridged tunnel row ACTION = %q, want %q", a, tunnelAction)
 	}
-	if a, _ := rowAction(rows[1]); a != string(pipeline.ActionObserve) {
+	if a, _ := rowAction(rows[1], rows[1].invocations()); a != string(pipeline.ActionObserve) {
 		t.Errorf("bridged row ACTION = %q, want observe", a)
 	}
 }


### PR DESCRIPTION
Split out of #883, which was getting large. Independent of the usage work — touches only `events_pane.go`.

## Problem

An opaque CONNECT stands in abctl's events timeline as a row of em dashes: no ACTION, no PLUGIN, no STATUS.

```
 4     13:49:09.91   out   req      —         —                   api.github.com:443
```

That is accurate — the bytes inside are TLS, so no plugin ran, no protocol was parsed and there is no status — but it reads as a request that failed or that the pipeline ignored. On a laptop install where some hosts bridge and others do not, a screen full of these looks like a regression rather than routine egress.

The rows come from clients the bridge cannot terminate for, and the log distinguishes two reasons:

```
tls-bridge passthrough host=api.github.com      reason=handshake-fail error="remote error: tls: bad certificate"
tls-bridge passthrough host=api.anthropic.com   reason=handshake-fail error=EOF
```

`bad certificate` is CA distrust — the client evaluated the forged cert and rejected it. `EOF` is the client hanging up without an alert, the signature of certificate pinning, which no amount of CA installation fixes. Either way `Skip.Add(host)` makes the host a permanent passthrough for the process lifetime, so these rows are the correct and lasting outcome, not something to repair.

## Change

Such rows now show `tunnel` in ACTION.

```
 4     13:49:09.91   out   req      tunnel    —                   api.github.com:443
```

Three cases the label deliberately does not claim:

- **A denied tunnel keeps its deny.** A gate can reject a CONNECT on the tunnel-open itself, and that decision is the point of the row — the label applies only when nothing acted.
- **A bridged tunnel shows the inner action.** `buildEventRows` folds it into the decrypted request, so `observe`/`modify` still wins.
- **A plain passthrough keeps its em dash.** Otherwise every unprocessed row would claim to be a tunnel.

The logic lives in a `rowAction` wrapper rather than inline in `rebuildEventsTable`, so it is testable without a terminal.

## Testing

Six tests: the three cases above, an empty-invocations tunnel, and a width check (`ACTION` is 8 columns, `tunnel` is 6).

Verified against a 344-event capture from a live server — 17 rows that were blank now read `tunnel`, and the 143 `observe` / 67 `modify` rows are unchanged. The 10 remaining em-dash rows are genuine passthroughs where a plugin ran but none matched, which are correctly blank.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved event display in the ACTION column:
    - Unbridged CONNECT tunnel events now show `tunnel`.
    - Events with no plugin activity show `—`.
    - Plugin actions and denied tunnel decisions remain unchanged.
    - Bridged tunnels display the action from the decrypted request.
  - Updated documentation to clarify that these rendering labels are not plugin actions or request verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->