### PR TITLE
Feat: Serve an endpoint index at / on the session API

### DIFF
--- a/authbridge/CLAUDE.md
+++ b/authbridge/CLAUDE.md
@@ -460,6 +460,7 @@ When `session.enabled` is true (default) and `listener.session_api_addr` is non-
 
 | Method & Path | Format | Purpose |
 |---|---|---|
+| `GET /` | text | One-line-per-endpoint index. Answers "is this the session API, and on the right port?" — the reason a 404 here was worth replacing. |
 | `GET /v1/sessions` | `application/json` | List active sessions: `{sessions: [{id, createdAt, updatedAt, eventCount, active}]}`. |
 | `GET /v1/sessions/{id}` | `application/json` | Full snapshot of one session's events. 404 if unknown/expired. |
 | `GET /v1/events` | `text/event-stream` | SSE stream of new events. Optional `?session=<id>` filters to one session. Heartbeat every 30s. |

--- a/authbridge/authlib/sessionapi/index_test.go
+++ b/authbridge/authlib/sessionapi/index_test.go
@@ -1,0 +1,109 @@
+package sessionapi
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func getPath(t *testing.T, base, path string) (*http.Response, string) {
+	t.Helper()
+	resp, err := http.Get(base + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return resp, string(body)
+}
+
+// GET / must answer, not 404. A 404 there gives no way to tell "wrong port" from
+// "right port, no route" — and the port is often assigned dynamically, so an
+// operator running curl against it has nothing confirming they found the session
+// API at all.
+func TestHandleIndex_IdentifiesTheAPI(t *testing.T) {
+	ts, _ := newTestServer(t)
+	resp, body := getPath(t, ts.URL, "/")
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain", ct)
+	}
+	if !strings.Contains(body, "Session API") {
+		t.Errorf("body does not identify the API:\n%s", body)
+	}
+	// The trust model belongs here: this is the one page a stranger to the port
+	// will read, and the payloads carry request and response bodies.
+	if !strings.Contains(strings.ToLower(body), "unauthenticated") {
+		t.Errorf("index does not state the trust model:\n%s", body)
+	}
+}
+
+// Every route the server registers must be listed, or the index becomes a stale
+// map of the API — worse than none, since a reader would trust it.
+func TestHandleIndex_ListsEveryRegisteredRoute(t *testing.T) {
+	ts, _ := newTestServer(t)
+	_, body := getPath(t, ts.URL, "/")
+
+	for _, route := range []string{
+		"/v1/sessions",
+		"/v1/sessions/{id}",
+		"/v1/events",
+		"/v1/pipeline",
+		"/v1/plugins",
+		"/v1/usage",
+		"/healthz",
+	} {
+		if !strings.Contains(body, route) {
+			t.Errorf("index omits %s:\n%s", route, body)
+		}
+	}
+}
+
+// Registered as "/{$}", not "/". Go's "/" is a catch-all, which would turn every
+// genuine 404 into the index page and hide a typo like /v1/session.
+func TestHandleIndex_DoesNotSwallow404s(t *testing.T) {
+	ts, _ := newTestServer(t)
+	for _, path := range []string{"/nope", "/v1/session", "/v1/", "/v1/sessions/x/y"} {
+		resp, body := getPath(t, ts.URL, path)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s: status = %d, want 404 — the index must match only /",
+				path, resp.StatusCode)
+		}
+		if strings.Contains(body, "Session API") {
+			t.Errorf("GET %s served the index instead of 404ing", path)
+		}
+	}
+}
+
+// The index is one line per endpoint, per the issue: short enough to read in a
+// terminal without scrolling.
+func TestHandleIndex_StaysShort(t *testing.T) {
+	ts, _ := newTestServer(t)
+	_, body := getPath(t, ts.URL, "/")
+
+	lines := strings.Split(strings.TrimRight(body, "\n"), "\n")
+	if len(lines) > 16 {
+		t.Errorf("index is %d lines; keep it terminal-sized", len(lines))
+	}
+	for _, l := range lines {
+		if len(l) > 80 {
+			t.Errorf("line exceeds 80 columns (%d):\n%q", len(l), l)
+		}
+	}
+}
+
+// Reachable regardless of which optional endpoints are wired: the index is how an
+// operator identifies the port, so it must not depend on WithUsage/WithCatalog.
+func TestHandleIndex_WorksWithNoOptionalEndpoints(t *testing.T) {
+	ts, _ := newTestServer(t) // no WithUsage, no WithCatalog
+	if resp, _ := getPath(t, ts.URL, "/"); resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d with no optional endpoints wired, want 200", resp.StatusCode)
+	}
+}

--- a/authbridge/authlib/sessionapi/server.go
+++ b/authbridge/authlib/sessionapi/server.go
@@ -138,6 +138,7 @@ func New(addr string, store *session.Store, opts ...Option) *Server {
 	mux.HandleFunc("GET /v1/plugins", s.handlePluginCatalog)
 	mux.HandleFunc("GET /v1/usage", s.handleUsage)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	mux.HandleFunc("GET /{$}", s.handleIndex)
 
 	s.server = &http.Server{
 		Addr:              addr,
@@ -159,6 +160,41 @@ func (s *Server) ListenAndServe() error { return s.server.ListenAndServe() }
 func (s *Server) Shutdown(ctx context.Context) error { return s.server.Shutdown(ctx) }
 
 // --- handlers -------------------------------------------------------------
+
+// indexBody is the plain-text index served at /. Kept as a const rather than
+// built per request: it is the same bytes every time, and a static string cannot
+// drift from itself under concurrent reads.
+//
+// Plain text, not HTML: the reader is someone who just ran curl against a port
+// they are not sure about, and one line per endpoint answers that. Anything
+// richer would need styling nobody asked for, and this listener has no other
+// HTML to be consistent with.
+const indexBody = `Cortex / AuthBridge Session API
+
+  GET /v1/sessions        list active sessions
+  GET /v1/sessions/{id}   one session's events
+  GET /v1/events          SSE stream of new events (?session=<id> to filter)
+  GET /v1/pipeline        active plugin pipeline
+  GET /v1/plugins         catalog of registered plugins
+  GET /v1/usage           time-bucketed usage aggregates
+  GET /healthz            liveness probe
+
+Unauthenticated: payloads may contain request and response bodies.
+`
+
+// handleIndex answers GET / with a one-line-per-endpoint index.
+//
+// It exists because a 404 on / gives no way to tell "wrong port" from "right port,
+// no route" — and the port is often assigned dynamically, so an operator running
+// curl against it has nothing to confirm they found the session API at all.
+//
+// Registered as "/{$}" so it matches ONLY the root. Go's "/" pattern is a
+// catch-all, which would turn every genuine 404 into this page and hide typos
+// like /v1/session.
+func (s *Server) handleIndex(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write([]byte(indexBody))
+}
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Closes #893.

`curl http://localhost:47601/` returned 404, which gives no way to tell "wrong port" from "right port, no route" — and the port is often assigned dynamically, so there was nothing confirming you had found the session API at all.

`GET /` now answers:

```
Cortex / AuthBridge Session API

  GET /v1/sessions        list active sessions
  GET /v1/sessions/{id}   one session's events
  GET /v1/events          SSE stream of new events (?session=<id> to filter)
  GET /v1/pipeline        active plugin pipeline
  GET /v1/plugins         catalog of registered plugins
  GET /v1/usage           time-bucketed usage aggregates
  GET /healthz            liveness probe

Unauthenticated: payloads may contain request and response bodies.
```

Plain text rather than HTML, per the issue's note that it was unclear which: the reader is someone who just ran curl against a port they are unsure about, and one line per endpoint answers that. Anything richer would need styling nobody asked for, and this listener serves no other HTML to be consistent with.

The trust-model line is there because this is the one page a stranger to the port will read, and the payloads carry request and response bodies verbatim.

## One thing worth a look

Registered as `/{$}`, not `/`. Go's `/` pattern is a **catch-all**, so it would turn every genuine 404 into this page and hide a typo like `/v1/session`. `TestHandleIndex_DoesNotSwallow404s` covers that — `/nope`, `/v1/session`, `/v1/`, and `/v1/sessions/x/y` all still 404.

## Size

36 lines of production code in one file. Five tests: identifies the API and states the trust model, lists every registered route (so the index cannot silently go stale), does not swallow 404s, stays terminal-sized, and works with no optional endpoints wired — `WithUsage`/`WithCatalog` are optional, and identifying the port must not depend on them.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a plain-text index at the session API root (`GET /`).
  - The index identifies the API, describes its trust model, and lists available session endpoints.
  - Root handling is limited to the API’s exact root path, preserving normal 404 responses for unknown paths.

- **Documentation**
  - Documented the new session API index endpoint and its use for identifying the API and confirming the correct port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->