### PR TITLE
Fix: Detect environments that cannot run a service, and say what to do

### DIFF
--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -268,7 +268,9 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	adopt := runningPID(p.pidFile)
 	if adopt > 0 {
 		fmt.Fprintf(stdout, "A Cortex you started by hand is running (pid %d). It will be stopped\n"+
-			"so the supervised one can take the ports.\n\n", adopt)
+			"so the supervised one can take the ports.\n", adopt)
+		reportSessionInterruption(p, stdout)
+		fmt.Fprintln(stdout)
 	}
 	if !yes {
 		fmt.Fprintf(stdout, "Undo with: abctl service uninstall\n\n")
@@ -276,6 +278,15 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	if !yes && !confirm(stdout) {
 		fmt.Fprintln(stdout, "Not changed.")
 		return exitDeclined
+	}
+
+	// Replacing a running Cortex — supervised or not — cuts whatever is talking to it.
+	// Said before the work starts, not after: HTTPS_PROXY is fixed in each Claude Code
+	// process's environment at startup, so a session cannot fall back to a direct
+	// connection and simply starts failing. That looked like a Cortex bug twice during
+	// development, to me, on my own machine.
+	if adopt == 0 {
+		reportSessionInterruption(p, stdout)
 	}
 
 	// Probed before anything is written. Without this the first sign of trouble was
@@ -651,4 +662,18 @@ func loginHome() string {
 		return ""
 	}
 	return fields[len(fields)-1]
+}
+
+// reportSessionInterruption names how many clients a restart will disconnect.
+//
+// Nothing on this side can make it graceful: HTTPS_PROXY is baked into each client's
+// environment when it starts, so a running Claude Code has no way back to a direct
+// connection and just begins failing to connect. Saying "3 connections" turns that into
+// a five-second diagnosis instead of a bug report. Silent when there is nothing attached,
+// or when we cannot tell — a confident "0" would be worse than no number.
+func reportSessionInterruption(p servicePaths, stdout io.Writer) {
+	if n := establishedConns(p.forwardAddr); n > 0 {
+		fmt.Fprintf(stdout, "  %d connection(s) are attached and will be cut. A running Claude Code\n"+
+			"  cannot reconnect on its own — restart any session that starts failing.\n", n)
+	}
 }

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -266,11 +266,11 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	// supervised one would lose the race and crash-loop while the hand-started one
 	// kept serving — a break that only surfaces at the next reboot.
 	adopt := runningPID(p.pidFile)
-	if adopt > 0 {
+	if adopt > 0 && !yes {
+		// Preview only. The connection count is printed once, at the point of action
+		// below, so it cannot be announced for a run that turns out to change nothing.
 		fmt.Fprintf(stdout, "A Cortex you started by hand is running (pid %d). It will be stopped\n"+
-			"so the supervised one can take the ports.\n", adopt)
-		reportSessionInterruption(p, stdout)
-		fmt.Fprintln(stdout)
+			"so the supervised one can take the ports.\n\n", adopt)
 	}
 	if !yes {
 		fmt.Fprintf(stdout, "Undo with: abctl service uninstall\n\n")
@@ -278,15 +278,6 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	if !yes && !confirm(stdout) {
 		fmt.Fprintln(stdout, "Not changed.")
 		return exitDeclined
-	}
-
-	// Replacing a running Cortex — supervised or not — cuts whatever is talking to it.
-	// Said before the work starts, not after: HTTPS_PROXY is fixed in each Claude Code
-	// process's environment at startup, so a session cannot fall back to a direct
-	// connection and simply starts failing. That looked like a Cortex bug twice during
-	// development, to me, on my own machine.
-	if adopt == 0 {
-		reportSessionInterruption(p, stdout)
 	}
 
 	// Probed before anything is written. Without this the first sign of trouble was
@@ -329,6 +320,7 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 	// older config up to date: the service starts it with --config, which honours
 	// listeners that --local skipped, so an unpinned transparent_proxy_addr would
 	// start binding every interface precisely now.
+	configChanged := false
 	if changed, mErr := migrateConfig(p.configFile, stdout); mErr != nil {
 		// Refuse only if continuing would actually expose something. A migration that
 		// fails on a config already bound to loopback costs nothing to skip; one that
@@ -345,11 +337,39 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "abctl: could not update %s (%v); it already binds loopback only, continuing\n",
 			p.configFile, mErr)
 	} else if changed {
+		configChanged = true
 		// The paths were resolved from the pre-migration config, so anything the
 		// migration added — health_addr above all — is not in them yet. Without this
 		// the probe below is skipped for precisely the configs that were just fixed.
 		p.healthURL = resolveHealthURL(p.configFile)
 	}
+
+	// Nothing to do is a valid outcome, and the common one: this command is what the
+	// one-liner runs every time, including when everything is already current. Without
+	// this it went ahead with bootout + bootstrap, which restarts the proxy and cuts
+	// every attached Claude Code session — for no change at all. Re-running an installer
+	// should be free.
+	//
+	// Deliberately AFTER the migration: a config that still needs pins is a change, so
+	// it must not be short-circuited. `changed` above is false only when the config was
+	// already up to date.
+	if !configChanged && serviceIsCurrent(p) {
+		fmt.Fprintf(stdout, "Already current: %s is running under %s and healthy.\n"+
+			"  Nothing to change. Use `abctl service restart` to restart it anyway.\n",
+			filepath.Base(p.binary), supervisorName())
+		return 0
+	}
+
+	// Warned HERE, not earlier: past the no-op check we know a restart is really going
+	// to happen. Announcing "connections will be cut" and then changing nothing would be
+	// its own small lie, and it printed on every re-run.
+	//
+	// Replacing a running Cortex cuts whatever is talking to it and nothing on this side
+	// can soften that: HTTPS_PROXY is fixed in each Claude Code process's environment at
+	// startup, so a session cannot fall back to a direct connection and simply starts
+	// failing. That looked like a Cortex bug twice during development, to me, on my own
+	// machine.
+	reportSessionInterruption(p, stdout)
 
 	if adopt > 0 {
 		fmt.Fprintf(stdout, "Stopping pid %d...\n", adopt)
@@ -676,4 +696,41 @@ func reportSessionInterruption(p servicePaths, stdout io.Writer) {
 		fmt.Fprintf(stdout, "  %d connection(s) are attached and will be cut. A running Claude Code\n"+
 			"  cannot reconnect on its own — restart any session that starts failing.\n", n)
 	}
+}
+
+// serviceIsCurrent reports whether the installed service already matches what
+// serviceInstall would write, and is actually serving.
+//
+// Every clause is necessary, because each one is a way for "installed" to be a lie:
+// a unit written by a different abctl pins whatever binary THAT one chose; a unit naming
+// a different binary or config is stale; a job the supervisor does not report running is
+// the installed-but-dead state; and "loaded" is not "serving", which is where a bad
+// config hides.
+func serviceIsCurrent(p servicePaths) bool {
+	if !serviceInstalled(p) {
+		return false
+	}
+	if unitWriterVersion(p.unitFile) != version {
+		return false
+	}
+	unit, err := os.ReadFile(p.unitFile) //nolint:gosec // path we wrote
+	if err != nil {
+		return false
+	}
+	body := string(unit)
+	if !strings.Contains(body, p.binary) || !strings.Contains(body, p.configFile) {
+		return false
+	}
+	// On macOS the proxy must be supervised; a unit that lost --supervise would leave
+	// crashes unrecovered, which is the whole point of the feature.
+	if runtime.GOOS == "darwin" && !strings.Contains(body, "--supervise") {
+		return false
+	}
+	if running, _ := supervisorRunning(p); !running {
+		return false
+	}
+	if p.healthURL == "" {
+		return false // cannot confirm it is serving, so do not claim it is
+	}
+	return waitHealthy(p.healthURL, 2*time.Second)
 }

--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -30,6 +30,10 @@ const (
 	// maxLogBytes bounds one generation of proxy.log; rotateLog keeps one previous
 	// file, so the pair tops out near twice this.
 	maxLogBytes = 8 << 20
+	// exitNoSupervisor means this environment cannot manage services at all — a
+	// restricted sandbox, or a shell without a usable launchd session. Distinct from a
+	// failure, so install.sh can offer the unsupervised path instead of a dead end.
+	exitNoSupervisor = 4
 	// serviceBootoutTimeout bounds the wait for a previous job to leave the domain.
 	// Longer than the supervisor's own teardown: it SIGTERMs the proxy, allows its 15s
 	// graceful shutdown, then insists at 20s.
@@ -274,10 +278,35 @@ func serviceInstall(p servicePaths, yes bool, stdout, stderr io.Writer) int {
 		return exitDeclined
 	}
 
+	// Probed before anything is written. Without this the first sign of trouble was
+	// launchctl's "Bootstrap failed: 5: Input/output error" after the unit was already on
+	// disk — a message that names neither the cause nor a way forward. Reported from a
+	// restricted sandbox environment.
+	if ok, why := launchdUsable(); !ok {
+		fmt.Fprintf(stderr, "abctl: this environment cannot manage %ss (%s).\n\n"+
+			"  Cortex still runs, just not supervised — start it yourself:\n"+
+			"    %s --local\n\n"+
+			"  It will not restart after a crash or come back at login while running that\n"+
+			"  way. To stop it: kill that process.\n", supervisorName(), why, p.binary)
+		return exitNoSupervisor
+	}
+
 	if _, serr := os.Stat(p.binary); serr != nil {
 		fmt.Fprintf(stderr, "abctl: authbridge-proxy not found at %s; install it first\n", p.binary)
 		return 1
 	}
+	// launchd loads the LOGIN home's ~/Library/LaunchAgents, taken from the user
+	// record — not $HOME. With $HOME pointed at a project directory (sandboxes do this)
+	// the unit is written somewhere launchd will never scan, so bootstrap succeeds and
+	// "comes back at login" is quietly false. Warn rather than refuse: it is a real way
+	// to run, just not a persistent one.
+	if lh := loginHome(); lh != "" && lh != p.home {
+		fmt.Fprintf(stderr, "abctl: $HOME is %s but your login home is %s.\n"+
+			"  The unit goes to $HOME/Library/LaunchAgents, which launchd does not scan at\n"+
+			"  login, so Cortex will NOT come back after a logout. Crash recovery still\n"+
+			"  works while you are logged in.\n\n", p.home, lh)
+	}
+
 	if p.configErr != nil {
 		fmt.Fprintf(stderr, "abctl: %s will not load, so a supervised proxy could not start:\n  %v\n"+
 			"  Fix it (or delete it and run: authbridge-proxy --local --write-config), then re-run.\n",
@@ -596,4 +625,30 @@ func isLoopbackHost(host string) bool {
 func fileExists(p string) bool {
 	fi, err := os.Stat(p)
 	return err == nil && !fi.IsDir()
+}
+
+// loginHome returns the home directory from the user record, or "" if it cannot be
+// determined. Deliberately not os.UserHomeDir, which returns $HOME — the value whose
+// trustworthiness is the question.
+func loginHome() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	u := os.Getenv("USER")
+	if u == "" {
+		out, err := exec.Command("id", "-un").Output()
+		if err != nil {
+			return ""
+		}
+		u = strings.TrimSpace(string(out))
+	}
+	out, err := exec.Command("dscl", ".", "-read", "/Users/"+u, "NFSHomeDirectory").Output()
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 {
+		return ""
+	}
+	return fields[len(fields)-1]
 }

--- a/authbridge/cmd/abctl/cmd_service_platform.go
+++ b/authbridge/cmd/abctl/cmd_service_platform.go
@@ -582,9 +582,59 @@ func waitBootedOut(target string, d time.Duration) bool {
 // teardown — the common case — stays silent.
 func waitBootedOutf(target string, d time.Duration, progress io.Writer) bool {
 	return waitGone(d, progress, func() bool {
-		// A non-zero exit from `launchctl print` means the label is no longer there.
-		return exec.Command("launchctl", "print", target).Run() != nil
+		gone, _ := labelGone(target)
+		return gone
 	})
+}
+
+// labelGone reports whether target is absent from its domain, and whether we could
+// tell at all.
+//
+// "Any non-zero exit means gone" was wrong, and wrong in the direction that hurts:
+// launchctl print exits 113 with "Could not find service" when the label really is
+// absent, but 125 ("Domain does not support specified action"), 64, or a permission
+// denial when it cannot see the domain — which happens in restricted sandboxes. Reading
+// those as "gone" made the code march into a bootstrap that then failed with a bare
+// EIO, and report the one state we had actually ruled out.
+func labelGone(target string) (gone, known bool) {
+	out, err := exec.Command("launchctl", "print", target).CombinedOutput()
+	if err == nil {
+		return false, true // present
+	}
+	if strings.Contains(string(out), "Could not find service") {
+		return true, true
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == 113 {
+		return true, true
+	}
+	// Anything else: launchctl could not answer. Not gone, and not known.
+	return false, false
+}
+
+// launchdUsable reports whether this process can manage launchd jobs at all.
+//
+// Restricted environments — sandboxes, some CI, a shell without a full user session —
+// deny the launchd IPC that bootstrap needs. Probing the DOMAIN rather than our label
+// separates "cannot talk to launchd" from "our job is not loaded", so the failure can be
+// explained instead of surfacing as "Bootstrap failed: 5: Input/output error", which
+// names neither cause nor remedy.
+func launchdUsable() (bool, string) {
+	if runtime.GOOS != "darwin" {
+		return true, ""
+	}
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		return false, "launchctl is not on PATH"
+	}
+	out, err := exec.Command("launchctl", "print", "gui/"+strconv.Itoa(os.Getuid())).CombinedOutput()
+	if err == nil {
+		return true, ""
+	}
+	first := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	if first == "" {
+		first = err.Error()
+	}
+	return false, first
 }
 
 // waitGone polls gone() until it reports true, or d elapses.

--- a/authbridge/cmd/abctl/cmd_service_restricted_test.go
+++ b/authbridge/cmd/abctl/cmd_service_restricted_test.go
@@ -146,3 +146,34 @@ func TestLoginHome(t *testing.T) {
 	}
 	_ = strconv.Itoa(os.Getuid())
 }
+
+// TestReportSessionInterruption: replacing a running Cortex cuts whatever is attached,
+// and nothing on this side can make that graceful — HTTPS_PROXY is fixed in each
+// client's environment at startup. A count turns the resulting "connection refused" into
+// a five-second diagnosis. Silence when there is nothing to say matters just as much:
+// a confident "0 connections" when we could not look would be worse than no number.
+func TestReportSessionInterruption(t *testing.T) {
+	t.Run("silent when the address is unknown", func(t *testing.T) {
+		var out strings.Builder
+		reportSessionInterruption(servicePaths{forwardAddr: ""}, &out)
+		if out.Len() != 0 {
+			t.Errorf("said something with nothing to go on: %q", out.String())
+		}
+	})
+	t.Run("silent when the address is unparseable", func(t *testing.T) {
+		var out strings.Builder
+		reportSessionInterruption(servicePaths{forwardAddr: "not-an-address"}, &out)
+		if out.Len() != 0 {
+			t.Errorf("guessed at a count: %q", out.String())
+		}
+	})
+	t.Run("silent on a port nothing is connected to", func(t *testing.T) {
+		var out strings.Builder
+		// A port in the ephemeral range that is almost certainly idle. If something is
+		// attached the assertion would be wrong rather than the code, so tolerate it.
+		reportSessionInterruption(servicePaths{forwardAddr: "127.0.0.1:59999"}, &out)
+		if strings.Contains(out.String(), "0 connection") {
+			t.Errorf("reported a zero count instead of staying quiet: %q", out.String())
+		}
+	})
+}

--- a/authbridge/cmd/abctl/cmd_service_restricted_test.go
+++ b/authbridge/cmd/abctl/cmd_service_restricted_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeLaunchctl puts a launchctl on PATH that behaves like a restricted sandbox: it
+// cannot answer, exactly as reported from a real one.
+func fakeLaunchctl(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "launchctl"), []byte(body), 0o700); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestLabelGone_UnknownIsNotGone is the defect this fixes. launchctl print exits 113
+// with "Could not find service" when a label is really absent, but 125 or a permission
+// denial when it cannot see the domain. Treating the latter as "gone" walked into a
+// bootstrap that failed with a bare EIO, reporting the one state we had ruled out.
+func TestLabelGone_UnknownIsNotGone(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchctl only")
+	}
+	t.Run("really absent reads as gone", func(t *testing.T) {
+		fakeLaunchctl(t, "#!/bin/sh\necho 'Could not find service \"x\" in domain for user gui: 501' >&2\nexit 113\n")
+		gone, known := labelGone("gui/501/whatever")
+		if !gone || !known {
+			t.Errorf("gone=%v known=%v, want true/true", gone, known)
+		}
+	})
+	t.Run("cannot query does NOT read as gone", func(t *testing.T) {
+		fakeLaunchctl(t, "#!/bin/sh\necho 'Could not print domain: 125: Domain does not support specified action' >&2\nexit 125\n")
+		gone, known := labelGone("gui/501/whatever")
+		if gone {
+			t.Error("a domain we cannot query was reported as gone — this is the bug")
+		}
+		if known {
+			t.Error("claimed to know the state it could not query")
+		}
+	})
+	t.Run("permission denied does NOT read as gone", func(t *testing.T) {
+		fakeLaunchctl(t, "#!/bin/sh\necho 'Operation not permitted' >&2\nexit 1\n")
+		if gone, _ := labelGone("gui/501/whatever"); gone {
+			t.Error("a denial was reported as gone")
+		}
+	})
+	t.Run("present reads as present", func(t *testing.T) {
+		fakeLaunchctl(t, "#!/bin/sh\necho 'state = running'\nexit 0\n")
+		gone, known := labelGone("gui/501/whatever")
+		if gone || !known {
+			t.Errorf("gone=%v known=%v, want false/true", gone, known)
+		}
+	})
+}
+
+// TestLaunchdUsable distinguishes "cannot talk to launchd" from "our job is not
+// loaded" — the difference between an explainable failure and a bare EIO.
+func TestLaunchdUsable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd only")
+	}
+	t.Run("a restricted domain is not usable, and says why", func(t *testing.T) {
+		fakeLaunchctl(t, "#!/bin/sh\necho 'Could not print domain: 125: Domain does not support specified action' >&2\nexit 125\n")
+		ok, why := launchdUsable()
+		if ok {
+			t.Error("reported usable in a restricted environment")
+		}
+		if !strings.Contains(why, "125") && !strings.Contains(why, "Domain") {
+			t.Errorf("reason does not explain anything: %q", why)
+		}
+	})
+	t.Run("a working domain is usable", func(t *testing.T) {
+		fakeLaunchctl(t, "#!/bin/sh\necho 'com.apple.something'\nexit 0\n")
+		if ok, why := launchdUsable(); !ok {
+			t.Errorf("reported unusable against a working launchctl: %s", why)
+		}
+	})
+}
+
+// TestServiceInstall_RestrictedEnvironment: no unit on disk, a distinct exit code so
+// install.sh can offer the unsupervised path, and a message naming the way forward.
+func TestServiceInstall_RestrictedEnvironment(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd only")
+	}
+	fakeLaunchctl(t, "#!/bin/sh\necho 'Could not print domain: 125' >&2\nexit 125\n")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgDir := filepath.Join(home, ".cortex")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := filepath.Join(cfgDir, "config.yaml")
+	if err := os.WriteFile(cfg, []byte("mode: proxy-sidecar\nlistener:\n  roles: [forward]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unit := filepath.Join(home, "unit.plist")
+	p, err := resolveServicePaths(cfg, unit, filepath.Join(home, "proxy"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut strings.Builder
+	code := serviceInstall(p, true, &out, &errOut)
+
+	if code != exitNoSupervisor {
+		t.Errorf("exit = %d, want %d so install.sh can offer the fallback", code, exitNoSupervisor)
+	}
+	if _, serr := os.Stat(unit); serr == nil {
+		t.Error("a unit was written in an environment that cannot load it")
+	}
+	msg := errOut.String()
+	for _, want := range []string{"cannot manage", "--local"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message is missing %q, so the user has no way forward:\n%s", want, msg)
+		}
+	}
+}
+
+// TestLoginHome reports the user-record home, which is what launchd scans — not $HOME.
+func TestLoginHome(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("dscl only")
+	}
+	if _, err := exec.LookPath("dscl"); err != nil {
+		t.Skip("no dscl")
+	}
+	// A bogus $HOME must not change the answer: that independence is the whole point.
+	t.Setenv("HOME", "/tmp/definitely-not-my-home")
+	got := loginHome()
+	if got == "" {
+		t.Skip("could not read the user record here")
+	}
+	if got == "/tmp/definitely-not-my-home" {
+		t.Error("loginHome returned $HOME; it must come from the user record")
+	}
+	if !strings.HasPrefix(got, "/") {
+		t.Errorf("loginHome = %q, want an absolute path", got)
+	}
+	_ = strconv.Itoa(os.Getuid())
+}

--- a/authbridge/cmd/abctl/cmd_service_restricted_test.go
+++ b/authbridge/cmd/abctl/cmd_service_restricted_test.go
@@ -177,3 +177,91 @@ func TestReportSessionInterruption(t *testing.T) {
 		}
 	})
 }
+
+// TestServiceIsCurrent covers the no-op decision. Each clause is a way for
+// "installed" to be a lie, and getting any of them wrong means either a pointless
+// restart — which cuts every attached Claude Code session — or skipping a real upgrade.
+func TestServiceIsCurrent(t *testing.T) {
+	base := func(t *testing.T) servicePaths {
+		t.Helper()
+		dir := t.TempDir()
+		p := servicePaths{
+			unitFile:   filepath.Join(dir, "unit.plist"),
+			binary:     filepath.Join(dir, "authbridge-proxy"),
+			configFile: filepath.Join(dir, "config.yaml"),
+			home:       dir,
+		}
+		body := renderUnitFor(runtime.GOOS, p)
+		if err := os.WriteFile(p.unitFile, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("no unit at all is not current", func(t *testing.T) {
+		p := base(t)
+		if err := os.Remove(p.unitFile); err != nil {
+			t.Fatal(err)
+		}
+		if serviceIsCurrent(p) {
+			t.Error("claimed current with no unit installed")
+		}
+	})
+
+	t.Run("a unit from a different abctl is not current", func(t *testing.T) {
+		p := base(t)
+		body, err := os.ReadFile(p.unitFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stale := strings.Replace(string(body), version, "v0.0.1-ancient", 1)
+		if err := os.WriteFile(p.unitFile, []byte(stale), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if serviceIsCurrent(p) {
+			t.Error("claimed current for a unit another abctl wrote; it pins that abctl's binary")
+		}
+	})
+
+	t.Run("a unit naming a different binary is not current", func(t *testing.T) {
+		p := base(t)
+		p.binary = filepath.Join(t.TempDir(), "some-other-proxy")
+		if serviceIsCurrent(p) {
+			t.Error("claimed current while the unit names a different binary")
+		}
+	})
+
+	t.Run("a unit naming a different config is not current", func(t *testing.T) {
+		p := base(t)
+		p.configFile = filepath.Join(t.TempDir(), "other.yaml")
+		if serviceIsCurrent(p) {
+			t.Error("claimed current while the unit names a different config")
+		}
+	})
+
+	t.Run("no health URL means we cannot confirm it is serving", func(t *testing.T) {
+		p := base(t)
+		p.healthURL = ""
+		if serviceIsCurrent(p) {
+			t.Error("claimed current without being able to confirm it serves")
+		}
+	})
+
+	t.Run("darwin requires --supervise, or crashes go unrecovered", func(t *testing.T) {
+		if runtime.GOOS != "darwin" {
+			t.Skip("darwin only")
+		}
+		p := base(t)
+		body, err := os.ReadFile(p.unitFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		no := strings.Replace(string(body), "<string>--supervise</string>", "", 1)
+		if err := os.WriteFile(p.unitFile, []byte(no), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if serviceIsCurrent(p) {
+			t.Error("claimed current for a unit that lost --supervise")
+		}
+	})
+}

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -30,6 +30,30 @@ agents added mid-session — verified across `KeepAlive`, `StartInterval` and
 `RunAtLoad` — so the supervisor is what makes crash recovery work. On Linux there is
 one process; systemd handles it.
 
+## Restricted environments (sandboxes, no launchd session)
+
+Some environments cannot manage services at all — a sandboxed shell, a session without
+a usable launchd domain, CI. `abctl service install` detects this before writing
+anything and tells you so, rather than failing at `launchctl bootstrap` with
+`Input/output error`.
+
+Cortex still runs there; it just is not supervised:
+
+```sh
+authbridge-proxy --local     # in its own terminal, or backgrounded
+abctl                        # the viewer, as usual
+```
+
+What you give up: no restart after a crash, and nothing brings it back at login. Stop
+it with `kill $(pgrep -f authbridge-proxy)` — there is no service to stop.
+
+Two assumptions that do not hold in such environments, and what happens:
+
+| Assumption | If it does not hold |
+|---|---|
+| `launchctl` can manage the user domain | `service install` stops early and prints the command above |
+| `$HOME` is your login home | launchd never scans `$HOME/Library/LaunchAgents`, so the service cannot start at login. `service install` warns and continues; crash recovery still works while you are logged in |
+
 ## Is it working?
 
 ```sh

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -30,6 +30,18 @@ agents added mid-session — verified across `KeepAlive`, `StartInterval` and
 `RunAtLoad` — so the supervisor is what makes crash recovery work. On Linux there is
 one process; systemd handles it.
 
+## `abctl: command not found`
+
+The installer puts both binaries in `~/.local/bin`. If that is not on your PATH it
+offers to add it to your shell profile; new terminals pick it up, and for the one you
+are in:
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+To undo, delete the two lines the installer marked in your profile.
+
 ## Restricted environments (sandboxes, no launchd session)
 
 Some environments cannot manage services at all — a sandboxed shell, a session without

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -30,6 +30,20 @@ agents added mid-session — verified across `KeepAlive`, `StartInterval` and
 `RunAtLoad` — so the supervisor is what makes crash recovery work. On Linux there is
 one process; systemd handles it.
 
+## Re-running the installer is safe
+
+The one-liner is how you upgrade, so it is meant to be run repeatedly. When nothing has
+changed it changes nothing: it does not re-download binaries already at that version, and
+`service install` reports `Already current` and leaves the running proxy alone rather
+than restarting it.
+
+That last part matters — a restart cuts every attached Claude Code session, because
+`HTTPS_PROXY` is fixed in each session's environment at startup and cannot fall back to a
+direct connection. When a restart genuinely is needed, install says how many connections
+it is about to cut.
+
+To restart deliberately: `abctl service restart`.
+
 ## `abctl: command not found`
 
 The installer puts both binaries in `~/.local/bin`. If that is not on your PATH it

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -61,6 +61,18 @@ CORTEX_DIR="${HOME}/.cortex"
 # PATH_MARKER identifies our block in a shell profile, so a re-run does not add a
 # second copy and a person can find what to delete.
 PATH_MARKER="# added by Cortex (rossoctl/cortex) — delete these two lines to undo"
+
+# installed_version prints the version of an already-installed binary, or nothing.
+#
+# Both binaries print "<name> vX.Y.Z"; the tag is the last field. Anything unexpected —
+# missing binary, a build that does not know --version, a quarantined binary that will
+# not run — prints nothing, which reads as "not this version" and re-installs. Erring
+# toward re-installing is right: a wrong skip leaves someone on an old build believing
+# they upgraded.
+installed_version() {
+	[ -x "${BIN_DIR}/$1" ] || return 0
+	"${BIN_DIR}/$1" --version 2>/dev/null | awk 'NR==1{print $NF}'
+}
 case "$(uname -s)" in
 	Darwin) SUPERVISOR_NAME="launchd user agent" ;;
 	*) SUPERVISOR_NAME="systemd user unit" ;;
@@ -314,6 +326,7 @@ if [ "${AUTHBRIDGE_SKIP_DOWNLOAD:-}" = "1" ]; then
 		[ -x "${BIN_DIR}/${b}" ] || die "AUTHBRIDGE_SKIP_DOWNLOAD=1 but ${BIN_DIR}/${b} is missing"
 	done
 	version="already installed"
+	skip_install=1
 	info "Using the binaries already in ${BIN_DIR}"
 else
 
@@ -340,6 +353,18 @@ base="https://github.com/${REPO}/releases/download/${version}"
 abctl_tgz="abctl_${version}_${os}_${arch}.tar.gz"
 proxy_tgz="authbridge-proxy_${version}_${os}_${arch}.tar.gz"
 
+# Already at this version? Then there is nothing to download, and nothing to
+# overwrite. Re-running the one-liner is how people upgrade, so it runs constantly
+# against installs that are already current — it should cost nothing and change
+# nothing. Both binaries must match: replacing one and not the other is the version
+# skew that put an older proxy in the launchd unit.
+if installed_version abctl | grep -qx "${version}" &&
+	installed_version authbridge-proxy | grep -qx "${version}"; then
+	info "Already at ${version} — not re-downloading."
+	skip_install=1
+fi
+
+if [ -z "${skip_install:-}" ]; then
 info "Downloading ${version} for ${os}/${arch}..."
 curl -fsSL "${base}/${abctl_tgz}" -o "${tmp}/${abctl_tgz}" || die "download failed: ${abctl_tgz}"
 curl -fsSL "${base}/${proxy_tgz}" -o "${tmp}/${proxy_tgz}" || die "download failed: ${proxy_tgz}"
@@ -406,6 +431,7 @@ fi
 
 rm -rf "$tmp"
 trap - EXIT
+fi # end of the skip-if-already-at-this-version guard
 fi # end of download block
 
 # offer_path_setup adds BIN_DIR to the shell profile, with consent.
@@ -490,8 +516,13 @@ case ":${PATH}:" in
 	*) abctl_cmd="${BIN_DIR}/abctl" proxy_cmd="$proxy" ;;
 esac
 
-info ""
-info "Installed abctl and authbridge-proxy to ${BIN_DIR}"
+# Both skip paths have already said what they did ("Already at <v>" or "Using the
+# binaries already in ..."), so saying "Installed" after them would be both redundant
+# and untrue.
+if [ -z "${skip_install:-}" ]; then
+	info ""
+	info "Installed abctl and authbridge-proxy to ${BIN_DIR}"
+fi
 case ":${PATH}:" in
 	*":${BIN_DIR}:"*) ;;
 	*)

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -489,12 +489,21 @@ set +e
 "${BIN_DIR}/abctl" service install --yes --proxy "${BIN_DIR}/authbridge-proxy"
 svc_status=$?
 set -e
-if [ "${svc_status}" != "0" ]; then
+# Exit 4 means the environment cannot manage services — a restricted sandbox, or a
+# shell without a usable launchd session. That is not a broken install, so it does not
+# get an error: abctl has already explained it and printed the command to run instead.
+# Reported from a real sandbox, where the only sign of trouble was launchctl's EIO.
+if [ "${svc_status}" = "4" ]; then
+	info ""
+	info "  Continuing without a service. Start Cortex in another terminal with the"
+	info "  command above, then come back and run \"${abctl_cmd}\"."
+	info ""
+elif [ "${svc_status}" != "0" ]; then
 	die "could not set up the service (exit ${svc_status}).
   Cortex is NOT running. Inspect the unit it would install with:
     \"${abctl_cmd}\" service install --print-unit
   or run the proxy in the foreground to see what it says:
-    \"${proxy_cmd}\" --local"
+    \"${BIN_DIR}/authbridge-proxy\" --local"
 fi
 
 # tool-prune is in the config but INERT: its remove list is empty, so it does
@@ -534,7 +543,14 @@ if [ -n "${WIRE_CLAUDE_CODE:-}" ]; then
 			info ""
 			info "  \"${abctl_cmd}\"                         watch traffic"
 			info "  \"${abctl_cmd}\" tools scan              propose unused tools to prune"
-			info "  \"${abctl_cmd}\" service stop            stop Cortex"
+			# `service stop` is meaningless where no service could be installed, so do
+			# not offer it there — the whole point of catching exit 4 is to stop handing
+			# people commands their environment cannot run.
+			if [ "${svc_status}" = "4" ]; then
+				info "  kill \$(pgrep -f authbridge-proxy)   stop Cortex (unsupervised)"
+			else
+				info "  \"${abctl_cmd}\" service stop            stop Cortex"
+			fi
 			info "  \"${abctl_cmd}\" claude-code disable     undo"
 			info ""
 			exit 0

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -58,6 +58,9 @@ BIN_DIR="${HOME}/.local/bin"
 # Every file Cortex writes for this user lives here: config, CA, keys, logs,
 # pidfiles. One directory to inspect, back up, or delete.
 CORTEX_DIR="${HOME}/.cortex"
+# PATH_MARKER identifies our block in a shell profile, so a re-run does not add a
+# second copy and a person can find what to delete.
+PATH_MARKER="# added by Cortex (rossoctl/cortex) — delete these two lines to undo"
 case "$(uname -s)" in
 	Darwin) SUPERVISOR_NAME="launchd user agent" ;;
 	*) SUPERVISOR_NAME="systemd user unit" ;;
@@ -405,6 +408,80 @@ rm -rf "$tmp"
 trap - EXIT
 fi # end of download block
 
+# offer_path_setup adds BIN_DIR to the shell profile, with consent.
+#
+# Warning and printing a line to paste was not enough: the first thing a real user hit
+# was `abctl: command not found`, before any of the actual bugs. An install that
+# succeeds and then cannot run the command it just told you to run is the worst first
+# impression available, and the most common one.
+#
+# Consent, a backup, and a guarded block, matching what `abctl claude-code enable` does
+# to settings.json — same pattern, no new concept. Declining keeps the old advice.
+offer_path_setup() {
+	_profile=""
+	case "$(basename "${SHELL:-}")" in
+		zsh) _profile="${HOME}/.zshrc" ;;
+		bash)
+			# bash reads .bash_profile for login shells on macOS and .bashrc elsewhere;
+			# .profile is read by both when the others are absent, so prefer whichever
+			# already exists rather than creating a file the shell may never read.
+			for _c in "${HOME}/.bash_profile" "${HOME}/.bashrc" "${HOME}/.profile"; do
+				[ -f "$_c" ] && _profile="$_c" && break
+			done
+			[ -n "${_profile}" ] || _profile="${HOME}/.bash_profile"
+			;;
+	esac
+
+	if [ -z "${_profile}" ]; then
+		# An unknown shell: we do not know which file it reads, and guessing would edit
+		# the wrong one.
+		warn "${BIN_DIR} is not on your PATH."
+		warn "Add it for future sessions:  export PATH=\"${BIN_DIR}:\$PATH\""
+		return 0
+	fi
+
+	# Already done by an earlier run.
+	if [ -f "${_profile}" ] && grep -q "${PATH_MARKER}" "${_profile}" 2>/dev/null; then
+		info "${BIN_DIR} is in ${_profile} but not in this shell yet. For this terminal:"
+		info "  export PATH=\"${BIN_DIR}:\$PATH\""
+		return 0
+	fi
+
+	info ""
+	info "${BIN_DIR} is not on your PATH, so \`abctl\` will not be found."
+	info "This adds two lines to ${_profile}:"
+	info "  ${PATH_MARKER}"
+	info "  export PATH=\"${BIN_DIR}:\$PATH\""
+	if [ -z "${ASSUME_YES}" ]; then
+		if [ ! -r /dev/tty ]; then
+			warn "no terminal to ask on; add it yourself:  export PATH=\"${BIN_DIR}:\$PATH\""
+			return 0
+		fi
+		printf 'Apply? [y/N] ' > /dev/tty
+		read -r _ans < /dev/tty || _ans=""
+		case "${_ans}" in
+			y | Y | yes | YES) ;;
+			*)
+				info "Not changed. For this terminal:  export PATH=\"${BIN_DIR}:\$PATH\""
+				return 0
+				;;
+		esac
+	fi
+
+	[ -f "${_profile}" ] && cp "${_profile}" "${_profile}.bak"
+	{
+		printf '\n%s\n' "${PATH_MARKER}"
+		# shellcheck disable=SC2016 # $PATH must stay literal: it is expanded by the
+		# shell at startup, not by this script now.
+		printf 'export PATH="%s:$PATH"\n' "${BIN_DIR}"
+	} >> "${_profile}" || {
+		warn "could not write ${_profile}; add it yourself:  export PATH=\"${BIN_DIR}:\$PATH\""
+		return 0
+	}
+	info "Added to ${_profile}. It applies to new terminals; for this one:"
+	info "  export PATH=\"${BIN_DIR}:\$PATH\""
+}
+
 # --- report ---
 proxy="${BIN_DIR}/authbridge-proxy"
 ca_dir="${CORTEX_DIR}/ca" # matches defaultCortexDir()+caDirName in local.go
@@ -418,8 +495,7 @@ info "Installed abctl and authbridge-proxy to ${BIN_DIR}"
 case ":${PATH}:" in
 	*":${BIN_DIR}:"*) ;;
 	*)
-		warn "${BIN_DIR} is not on your PATH."
-		warn "Add it for future sessions:  export PATH=\"${BIN_DIR}:\$PATH\""
+		offer_path_setup
 		;;
 esac
 


### PR DESCRIPTION
Reported from a restricted sandbox on `v0.7.0-alpha.7`:

```
abctl: launchctl bootstrap failed: exit status 5: Bootstrap failed: 5: Input/output error
error: could not set up the service (exit 1).
  Cortex is NOT running.
```

## This was not the alpha.7 race

The message is only reachable after the wait reported the label absent **and** three bootstrap attempts each re-verified it. So the race fix worked; something else returns EIO. His shell was also printing `Error opening /private/var/select/sh: Operation not permitted` — launchd IPC being denied.

## A defect in that wait

`launchctl print` exits **113** with "Could not find service" when a label is genuinely absent, but **125**, **64**, or a permission denial when it cannot see the domain. `waitBootedOut` treated *any* non-zero exit as "gone" — so in a restricted environment it read a denial as absence, walked into the bootstrap, and reported the one state it had ruled out. `labelGone` now distinguishes gone / present / cannot-tell.

## Detected before anything is written

`launchdUsable` probes the **domain**, not our label, separating "cannot talk to launchd" from "our job is not loaded". `serviceInstall` stops there with **exit 4** — distinct from a failure — and prints what does work:

```
Cortex still runs, just not supervised — start it yourself:
  authbridge-proxy --local
```

`install.sh` treats exit 4 as a workaround: it continues, wires Claude Code, and the closing summary offers `kill $(pgrep -f authbridge-proxy)` instead of `service stop`, which cannot work there. The point of catching this is to stop handing people commands their environment will not run.

## A second assumption that did not hold

His `$HOME` was `/Users/sabath/sandbox/rosso-project`, not his login home. launchd scans the **login** home's `~/Library/LaunchAgents` from the user record, so a unit under `$HOME` is somewhere it will never look and "comes back at login" is quietly false. I verified bootstrap from such a path *does* succeed, so this was not his EIO — it is its own silent bug. Warns and continues, since it is a real way to run, just not a persistent one.

## Testing

A fake `launchctl` on PATH that behaves like the sandbox (exits 125). Asserts no unit is written, exit code 4, and a message naming a way forward — plus each `labelGone` case including that a denial is not "gone". A normal environment still installs and still offers `service stop`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service installation now detects restricted environments before making changes and provides guidance for running the proxy manually.
  * The installer can continue without configuring a background service when service management is unavailable.
  * The installer can offer to add installed binaries to the shell’s PATH.
  * Clear warnings are shown when the configured home directory differs from the login home.
  * Users are notified when restarting the service will interrupt active connections.

* **Bug Fixes**
  * Service removal now distinguishes between a missing service and environments where service status cannot be queried.

* **Documentation**
  * Added guidance for running and stopping the proxy in sandboxed or restricted environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->