### PR TITLE
Feat: Add `abctl observe`, deprecate bare `abctl` for the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ service that survives crashes and logins.
 Then open two terminals:
 
 ```sh
-abctl      # the viewer
-claude     # as usual — no environment variables to set
+abctl observe   # the viewer
+claude          # as usual — no environment variables to set
 ```
 
 Your agent's calls stream into `abctl`. Cortex only reads them; nothing is rewritten.

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -36,12 +36,19 @@ Either way you get a single binary (~10 MB; the linux build is fully static).
 
 ## Run
 
-`abctl` discovers AuthBridge agents in your current `kubectl` context
-and lets you pick one:
+`abctl observe` discovers AuthBridge agents in your current `kubectl`
+context and lets you pick one:
 
 ```sh
-./abctl
+./abctl observe
 ```
+
+Bare `./abctl` does the same thing, but is **deprecated** and will stop
+opening the viewer in a future release. It printed no hint that the
+other subcommands existed, so anyone who never ran `--help` reasonably
+concluded the TUI was all abctl did — `abctl service` least visible of
+all, and that is what you need when Cortex is not running. Run
+`abctl --help` for the full list.
 
 You'll see a Namespaces pane listing each namespace that contains an
 AuthBridge agent. Enter drills into the Pods pane for that namespace;
@@ -74,7 +81,7 @@ Pass `--endpoint` to skip the picker entirely:
 
 ```sh
 kubectl port-forward -n team1 pod/weather-agent-xxxx 9094:9094 &
-./abctl --endpoint http://localhost:9094
+./abctl observe --endpoint http://localhost:9094
 ```
 
 This preserves the pre-picker behavior for scripts, CI, or remote

--- a/authbridge/cmd/abctl/cmd_observe_test.go
+++ b/authbridge/cmd/abctl/cmd_observe_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+)
+
+// usageText renders the root usage block the way --help does, so the assertions
+// below read the same text a user does.
+func usageText(t *testing.T) string {
+	t.Helper()
+	var buf bytes.Buffer
+	fs := flag.NewFlagSet("abctl", flag.ContinueOnError)
+	fs.SetOutput(&buf)
+	// Mirror the flags runObserve registers, so PrintDefaults has something to
+	// print and the block is shaped as it is in practice.
+	fs.String("endpoint", "", "endpoint")
+	fs.Bool("version", false, "version")
+	writeRootUsage(fs)
+	return buf.String()
+}
+
+// The viewer must be reachable by name. Subcommands were discoverable only by
+// typing --help, so a user who never did saw a TUI and concluded that was all
+// abctl offered — the service commands least visible of all, and those are what
+// you need when Cortex is down.
+func TestRootUsage_ListsObserveFirst(t *testing.T) {
+	out := usageText(t)
+	if !strings.Contains(out, "abctl observe") {
+		t.Errorf("usage does not mention the observe subcommand:\n%s", out)
+	}
+	// Listed above the deprecated bare form, so the reader meets the supported
+	// spelling first.
+	obs := strings.Index(out, "abctl observe")
+	bare := strings.Index(out, "deprecated")
+	if obs < 0 || bare < 0 || obs > bare {
+		t.Errorf("observe should be listed before the deprecated bare form:\n%s", out)
+	}
+}
+
+// Bare abctl still works, but the usage says it is going away — otherwise the
+// deprecation exists only in a commit message.
+func TestRootUsage_MarksBareInvocationDeprecated(t *testing.T) {
+	out := usageText(t)
+	if !strings.Contains(out, "deprecated") {
+		t.Errorf("usage does not mark bare abctl deprecated:\n%s", out)
+	}
+	if !strings.Contains(out, "future release") {
+		t.Errorf("usage does not say the behaviour will change:\n%s", out)
+	}
+}
+
+// Every subcommand main dispatches must appear in the usage, or the discovery
+// problem this change fixes reappears for the next one added.
+func TestRootUsage_ListsEverySubcommand(t *testing.T) {
+	out := usageText(t)
+	for _, name := range dispatchableSubcommands {
+		if !strings.Contains(out, "abctl "+name) {
+			t.Errorf("usage omits the %q subcommand:\n%s", name, out)
+		}
+	}
+}
+
+// The unknown-subcommand error must name the same set main dispatches, so a typo
+// gets a complete list rather than a stale one.
+func TestUnknownSubcommandMessage_NamesEverySubcommand(t *testing.T) {
+	msg := unknownSubcommandMessage("bogus")
+	if !strings.Contains(msg, `"bogus"`) {
+		t.Errorf("message does not quote the input: %q", msg)
+	}
+	for _, name := range dispatchableSubcommands {
+		if !strings.Contains(msg, name) {
+			t.Errorf("message omits %q: %q", name, msg)
+		}
+	}
+}
+
+// --help and --version must not carry the deprecation notice: --help is where the
+// replacement is documented, so a warning above it pushes the answer further up
+// the scrollback.
+func TestWantsInfoFlagOnly(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"--help"}, true},
+		{[]string{"-h"}, true},
+		{[]string{"-help"}, true},
+		{[]string{"--version"}, true},
+		{[]string{"-version"}, true},
+		{[]string{"--help", "--version"}, true},
+		{nil, false},                                // bare abctl does warn
+		{[]string{"--endpoint", "http://x"}, false}, // real work does warn
+		{[]string{"--help", "--endpoint"}, false},   // mixed: opens the viewer
+	} {
+		if got := wantsInfoFlagOnly(tc.args); got != tc.want {
+			t.Errorf("wantsInfoFlagOnly(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+}

--- a/authbridge/cmd/abctl/cmd_observe_test.go
+++ b/authbridge/cmd/abctl/cmd_observe_test.go
@@ -17,7 +17,6 @@ func usageText(t *testing.T) string {
 	// Mirror the flags runObserve registers, so PrintDefaults has something to
 	// print and the block is shaped as it is in practice.
 	fs.String("endpoint", "", "endpoint")
-	fs.Bool("version", false, "version")
 	writeRootUsage(fs)
 	return buf.String()
 }
@@ -98,5 +97,43 @@ func TestWantsInfoFlagOnly(t *testing.T) {
 		if got := wantsInfoFlagOnly(tc.args); got != tc.want {
 			t.Errorf("wantsInfoFlagOnly(%v) = %v, want %v", tc.args, got, tc.want)
 		}
+	}
+}
+
+// --version describes the binary, not the viewer, so it is answered at the root
+// and is not a flag on the subcommand. `abctl observe --version` is now the
+// unknown flag it should be.
+func TestIsVersionFlag(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"--version"}, true},
+		{[]string{"-version"}, true},
+		{nil, false},
+		{[]string{"observe"}, false},
+		// Exactly a version request, not merely containing one: printing a version
+		// while silently discarding the rest would hide a confused invocation.
+		{[]string{"--endpoint", "http://x", "--version"}, false},
+		{[]string{"--version", "--endpoint"}, false},
+	} {
+		if got := isVersionFlag(tc.args); got != tc.want {
+			t.Errorf("isVersionFlag(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
+}
+
+// The root usage must document --version, since it is a root flag with no
+// FlagSet entry to print it — removing it from the viewer's flag set took it out
+// of PrintDefaults, so the usage text is now its only home.
+func TestRootUsage_DocumentsVersion(t *testing.T) {
+	out := usageText(t)
+	if !strings.Contains(out, "--version") {
+		t.Errorf("usage does not document --version:\n%s", out)
+	}
+	// And the flag list is labelled as the viewer's, not the binary's, so a
+	// reader does not expect --version to appear among them.
+	if !strings.Contains(out, "abctl observe") || !strings.Contains(out, "Viewer flags") {
+		t.Errorf("usage does not scope the flag list to the viewer:\n%s", out)
 	}
 }

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -61,9 +61,11 @@ Usage:
   abctl                      deprecated: same as "abctl observe". Bare abctl
                              will stop opening the viewer in a future release.
 
+  abctl --version            print the version and exit
+
 Run a subcommand with no action, or with --help, for its own usage.
 
-Flags:
+Viewer flags (abctl observe):
 `)
 	fs.PrintDefaults()
 }
@@ -88,6 +90,16 @@ func main() {
 		}
 	}
 
+	// --version belongs to the binary, not to any subcommand, so it is answered
+	// here rather than inside runObserve. Handled before the flag set exists
+	// because a bare `abctl --version` must not carry the viewer's flags into its
+	// output, and `abctl observe --version` must be rejected as the unknown flag it
+	// now is.
+	if isVersionFlag(os.Args[1:]) {
+		fmt.Println("abctl", version)
+		return
+	}
+
 	// Bare `abctl` still opens the viewer, but is no longer the documented way in.
 	// Subcommands were reachable only by name, so a user who never typed --help saw
 	// a TUI and reasonably concluded that was all abctl did — the service commands
@@ -102,6 +114,23 @@ func main() {
 			"bare `abctl` will stop doing this in a future release. See `abctl --help`.")
 	}
 	os.Exit(runObserve(os.Args[1:]))
+}
+
+// isVersionFlag reports whether args are exactly a request for the version.
+//
+// Exactly, not merely containing one: `abctl --endpoint x --version` is a
+// confused invocation, and printing a version while silently discarding the rest
+// would hide that. Anything else falls through to the viewer, whose flag set
+// rejects what it does not know.
+func isVersionFlag(args []string) bool {
+	if len(args) != 1 {
+		return false
+	}
+	switch args[0] {
+	case "-version", "--version":
+		return true
+	}
+	return false
 }
 
 // wantsInfoFlagOnly reports whether args ask only for help or version output.
@@ -138,14 +167,8 @@ func runObserve(args []string) int {
 
 	endpoint := fs.String("endpoint", "",
 		"AuthBridge session API URL (e.g. http://localhost:9094). When omitted, abctl connects to the Cortex on this machine if one is running, otherwise it opens a Namespaces → Pods picker.")
-	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return 2
-	}
-
-	if *showVersion {
-		fmt.Println("abctl", version)
-		return 0
 	}
 
 	// Best-effort sweep of edit-tempfiles older than 24h. Tempfiles are

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -158,7 +158,6 @@ func wantsInfoFlagOnly(args []string) bool {
 // This is the behaviour bare `abctl` has always had, extracted so the subcommand
 // and the deprecated bare invocation cannot drift apart.
 func runObserve(args []string) int {
-
 	// Without this, `abctl --help` printed only -endpoint and -version, so the
 	// subcommands were invisible to anyone who asked the tool what it could do — the
 	// service commands most of all, since those are what you need when Cortex is down.
@@ -167,9 +166,11 @@ func runObserve(args []string) int {
 
 	endpoint := fs.String("endpoint", "",
 		"AuthBridge session API URL (e.g. http://localhost:9094). When omitted, abctl connects to the Cortex on this machine if one is running, otherwise it opens a Namespaces → Pods picker.")
-	if err := fs.Parse(args); err != nil {
-		return 2
-	}
+	// ExitOnError, so Parse exits 2 itself (0 for -h) rather than returning — there
+	// is no error branch to write here. Chosen over ContinueOnError because a bad
+	// flag has nothing useful to fall back to: the alternative is printing usage and
+	// then opening the viewer anyway.
+	fs.Parse(args) //nolint:errcheck // ExitOnError never returns
 
 	// Best-effort sweep of edit-tempfiles older than 24h. Tempfiles are
 	// intentionally left in place on every exit path (success / abort /

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -1,9 +1,14 @@
-// Command abctl is an interactive terminal UI for inspecting AuthBridge's
-// in-memory session store.
+// Command abctl inspects and runs Cortex: a terminal UI over AuthBridge's
+// in-memory session store, plus subcommands for running Cortex as a service,
+// pointing Claude Code at it, and costing tool definitions.
 //
-// Default mode opens a Namespaces → Pods picker, port-forwards the
-// selected pod, and renders the session-events view. Pass --endpoint
-// to skip the picker and connect directly (the pre-picker behavior).
+// `abctl observe` opens the viewer — a Namespaces → Pods picker, then the
+// session-events view for the pod it port-forwards. Pass --endpoint to skip the
+// picker and connect directly.
+//
+// Bare `abctl` still opens the viewer for compatibility, but is deprecated: with
+// subcommands reachable only by name, it left users thinking the TUI was all
+// abctl did.
 package main
 
 import (
@@ -25,6 +30,44 @@ import (
 // -ldflags "-X main.version=<tag>". Defaults to "dev" for local builds.
 var version = "dev"
 
+// dispatchableSubcommands are the names main routes on, in the order the usage
+// block lists them.
+//
+// One list rather than two: the unknown-subcommand error used to hardcode its own
+// copy, so adding a subcommand meant editing both and forgetting one left a typo
+// getting an incomplete list. A test holds the usage block to this slice.
+var dispatchableSubcommands = []string{"observe", "service", "claude-code", "tools"}
+
+// unknownSubcommandMessage is the error for an unrecognised first argument.
+func unknownSubcommandMessage(name string) string {
+	return fmt.Sprintf("abctl: unknown subcommand %q (known: %s)",
+		name, strings.Join(dispatchableSubcommands, ", "))
+}
+
+// writeRootUsage prints the root usage block to fs's output.
+//
+// Takes the FlagSet so the flag list underneath comes from the same set that
+// parsed the arguments, and so a test can render it into a buffer.
+func writeRootUsage(fs *flag.FlagSet) {
+	fmt.Fprint(fs.Output(), `abctl — inspect and run Cortex
+
+Usage:
+  abctl observe              open the traffic viewer (TUI)
+  abctl service <action>     run Cortex as a service: install, uninstall,
+                             status, stop, start, restart
+  abctl claude-code <action> point Claude Code at Cortex: enable, disable, status
+  abctl tools <action>       tool-definition costs: scan
+
+  abctl                      deprecated: same as "abctl observe". Bare abctl
+                             will stop opening the viewer in a future release.
+
+Run a subcommand with no action, or with --help, for its own usage.
+
+Flags:
+`)
+	fs.PrintDefaults()
+}
+
 func main() {
 	// Subcommand dispatch happens before flag.Parse: a non-flag first
 	// argument selects a subcommand, and anything else falls through to the
@@ -37,40 +80,72 @@ func main() {
 			os.Exit(runClaudeCode(os.Args[2:], os.Stdout, os.Stderr))
 		case "service":
 			os.Exit(runService(os.Args[2:], os.Stdout, os.Stderr))
+		case "observe":
+			os.Exit(runObserve(os.Args[2:]))
 		default:
-			fmt.Fprintf(os.Stderr, "abctl: unknown subcommand %q (known: tools, claude-code, service)\n", os.Args[1])
+			fmt.Fprintln(os.Stderr, unknownSubcommandMessage(os.Args[1]))
 			os.Exit(2)
 		}
 	}
 
+	// Bare `abctl` still opens the viewer, but is no longer the documented way in.
+	// Subcommands were reachable only by name, so a user who never typed --help saw
+	// a TUI and reasonably concluded that was all abctl did — the service commands
+	// least discoverable of all, and those are what you need when Cortex is down.
+	//
+	// Warned on stderr rather than stdout, and not fatal: this path has to keep
+	// working for anyone with it in a script or in muscle memory. Suppressed when
+	// the caller only wants --help or --version, where a deprecation notice would
+	// be noise ahead of the very text that explains the replacement.
+	if !wantsInfoFlagOnly(os.Args[1:]) {
+		fmt.Fprintln(os.Stderr, "abctl: opening the traffic viewer — use `abctl observe` instead; "+
+			"bare `abctl` will stop doing this in a future release. See `abctl --help`.")
+	}
+	os.Exit(runObserve(os.Args[1:]))
+}
+
+// wantsInfoFlagOnly reports whether args ask only for help or version output.
+//
+// Those two make the deprecation notice counterproductive: --help is where the
+// replacement is documented, so printing a warning above it just pushes the
+// answer further up the scrollback.
+func wantsInfoFlagOnly(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	for _, a := range args {
+		switch a {
+		case "-h", "--help", "-help", "-version", "--version":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// runObserve opens the traffic viewer: the Namespaces → Pods picker, or a direct
+// connection when --endpoint is given or a local Cortex is answering.
+//
+// This is the behaviour bare `abctl` has always had, extracted so the subcommand
+// and the deprecated bare invocation cannot drift apart.
+func runObserve(args []string) int {
+
 	// Without this, `abctl --help` printed only -endpoint and -version, so the
 	// subcommands were invisible to anyone who asked the tool what it could do — the
 	// service commands most of all, since those are what you need when Cortex is down.
-	flag.Usage = func() {
-		fmt.Fprint(flag.CommandLine.Output(), `abctl — inspect and run Cortex
+	fs := flag.NewFlagSet("abctl", flag.ExitOnError)
+	fs.Usage = func() { writeRootUsage(fs) }
 
-Usage:
-  abctl                      open the traffic viewer (TUI)
-  abctl service <action>     run Cortex as a service: install, uninstall,
-                             status, stop, start, restart
-  abctl claude-code <action> point Claude Code at Cortex: enable, disable, status
-  abctl tools <action>       tool-definition costs: scan
-
-Run a subcommand with no action, or with --help, for its own usage.
-
-Flags:
-`)
-		flag.PrintDefaults()
-	}
-
-	endpoint := flag.String("endpoint", "",
+	endpoint := fs.String("endpoint", "",
 		"AuthBridge session API URL (e.g. http://localhost:9094). When omitted, abctl connects to the Cortex on this machine if one is running, otherwise it opens a Namespaces → Pods picker.")
-	showVersion := flag.Bool("version", false, "print version and exit")
-	flag.Parse()
+	showVersion := fs.Bool("version", false, "print version and exit")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
 
 	if *showVersion {
 		fmt.Println("abctl", version)
-		return
+		return 0
 	}
 
 	// Best-effort sweep of edit-tempfiles older than 24h. Tempfiles are
@@ -107,7 +182,7 @@ Flags:
 					"  Or pass --endpoint http://... , or install kubectl to browse a cluster."
 			}
 			fmt.Fprintln(os.Stderr, msg)
-			os.Exit(1)
+			return 1
 		}
 	}
 
@@ -134,6 +209,7 @@ Flags:
 	}
 	if err := tui.Run(ctx, opts); err != nil {
 		fmt.Fprintf(os.Stderr, "abctl: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }

--- a/authbridge/demos/weather-agent/demo-with-abctl.md
+++ b/authbridge/demos/weather-agent/demo-with-abctl.md
@@ -57,7 +57,7 @@ Either way you get a single `abctl` binary. See [the abctl README](../../cmd/abc
 ## 2. Launch `abctl`
 
 ```sh
-./abctl
+./abctl observe
 ```
 
 `abctl` discovers AuthBridge agents in your current `kubectl` context


### PR DESCRIPTION
Subcommands were reachable only by name, so `abctl` with no arguments opened the viewer and said nothing about the rest. Anyone who never ran `--help` reasonably concluded the TUI was all abctl did — `abctl service` least visible of all, and that is exactly what you need when Cortex is not running.

## Change

`abctl observe` now opens the viewer. Bare `abctl` still does, unchanged, but prints a one-line notice:

```
abctl: opening the traffic viewer — use `abctl observe` instead; bare `abctl`
will stop doing this in a future release. See `abctl --help`.
```

On stderr and non-fatal: the old spelling has to keep working for anyone with it in a script or in muscle memory.

`--help` now leads with the supported spelling:

```
Usage:
  abctl observe              open the traffic viewer (TUI)
  abctl service <action>     run Cortex as a service: install, uninstall,
                             status, stop, start, restart
  abctl claude-code <action> point Claude Code at Cortex: enable, disable, status
  abctl tools <action>       tool-definition costs: scan

  abctl                      deprecated: same as "abctl observe". Bare abctl
                             will stop opening the viewer in a future release.

  abctl --version            print the version and exit

Run a subcommand with no action, or with --help, for its own usage.

Viewer flags (abctl observe):
  -endpoint string
        ...
```

## Decisions worth a look

**The notice is suppressed for `--help` and `--version`.** `--help` is where the replacement is documented, so a warning above it only pushes the answer further up the scrollback.

**`--version` is a root flag, not a viewer flag.** It reports the binary's build version, so `abctl observe --version` is now rejected as the unknown flag it should be (exit 2). Matched only when it is the sole argument: `abctl --endpoint x --version` is a confused invocation, and printing a version while silently discarding the rest would hide that. Removing it from the viewer's flag set took it out of `PrintDefaults`, so the usage text is now its only home — hence the explicit line and the `Viewer flags` relabel.

**The TUI launch moved out of `main()` into `runObserve`**, so the subcommand and the deprecated bare path are one function reached two ways and cannot drift. It takes its own `FlagSet`, so `abctl observe --endpoint x` parses exactly as bare abctl did.

## Removed a duplication this exposed

The unknown-subcommand error hardcoded its own list of names, so adding `observe` meant editing two places — and forgetting one would leave a typo getting an incomplete list. That list and the usage block now have one source, with tests holding both to it, so the next subcommand added cannot be omitted from either.

## Testing

Seven tests over the usage text, the subcommand list, and the two flag predicates. Verified by running the binary across every path rather than only in tests: `observe`, bare, `--help`, `--version`, `-version`, `observe --version` (exit 2), an unknown subcommand, and `observe --endpoint`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `abctl observe` subcommand for opening the AuthBridge agent viewer.
  - Improved command-line help, subcommand listings, version handling, and unknown-command messages.

- **Bug Fixes**
  - Viewer-specific flags are now handled only with the appropriate command.
  - Command errors now return cleanly with appropriate exit codes.

- **Documentation**
  - Updated usage examples and guidance to recommend `abctl observe`.
  - Marked bare `abctl` usage as deprecated; it still opens the viewer but displays a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->