### PR TITLE
Fix: Resolve the newest release tag without a greedy regex

### DIFF
--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -153,13 +153,43 @@ command -v tar  >/dev/null 2>&1 || die "tar is required"
 # `releases/latest` excludes prereleases and this project ships them, so list
 # releases (newest first) and take the first tag_name.
 newest_release() {
-	# Returns non-zero on empty. The pipeline ends in sed, which exits 0 for empty
-	# input, so `version=$(newest_release) || die` could never fire on a
-	# rate-limited or offline API — the caller got an empty tag and failed later
-	# with an unactionable "download failed: abctl__darwin_arm64.tar.gz".
+	# Three steps, each doing one thing that cannot silently go wrong:
+	#
+	#   tr ',{}' '\n'   put every JSON field on its own line, so nothing greedy can
+	#                   run past the field it was aimed at. Without this the old
+	#                   `sed 's/.*"tag_name": *"//'` depended on GitHub pretty-printing:
+	#                   against a COMPACT response the whole array is one line, the
+	#                   greedy .* runs to the LAST tag_name, and it returns the OLDEST
+	#                   release. Verified — it yields v0.3.1 from compact JSON.
+	#   grep -m1 ...    match tag_name only where it is a KEY (anchored, colon after).
+	#                   An unanchored match is hijacked by any release whose name or
+	#                   body contains the text "tag_name", and release bodies are ours
+	#                   to author.
+	#   cut -d'"' -f4   take the value by position, not by pattern.
+	#
+	# Then check the shape: a tag looks like v<digit>... Anything else means the API
+	# returned something we did not expect — an error page, a rate-limit body, a schema
+	# change — and the right move is to say so, not to build a download URL out of it.
+	# This is the difference that matters: a surprise becomes an error instead of a
+	# wrong answer.
+	#
+	# Not jq (not installed everywhere) and not gh (a far larger dependency than a
+	# curl|sh installer should require; this script needs curl, tar and a checksum tool).
+	# Not /releases/latest either: it excludes prereleases, and this project ships them,
+	# so it names a tag from January. Listing releases asks what we actually mean — the
+	# newest release, whatever its flags.
 	_tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null \
-		| grep -m1 '"tag_name"' | sed -e 's/.*"tag_name": *"//' -e 's/".*//')
-	[ -n "${_tag}" ] || return 1
+		| tr ',{}' '\n' \
+		| grep -m1 '^[[:space:]]*"tag_name"[[:space:]]*:' \
+		| cut -d'"' -f4)
+	case "${_tag}" in
+		v[0-9]*) ;;
+		'') return 1 ;;
+		*)
+			warn "the release API returned an unexpected tag: ${_tag}"
+			return 1
+			;;
+	esac
 	printf '%s\n' "${_tag}"
 }
 


### PR DESCRIPTION
`grep -m1 '"tag_name"' | sed 's/.*"tag_name": *"//'` is worse than untidy. The greedy `.*` depends on GitHub pretty-printing: against a **compact** response the whole array is one line, the match runs to the **last** `tag_name`, and it returns the **oldest** release.

```
compact JSON, 3 releases:
  old  ->  v0.3.1           ← the last object in the array
  new  ->  v0.7.0-alpha.7   ← the newest, which is what we asked for
```

Nothing promises the API keeps pretty-printing, and the failure mode is a wrong version rather than an error.

## What replaces it

```sh
| tr ',{}' '\n' \
| grep -m1 '^[[:space:]]*"tag_name"[[:space:]]*:' \
| cut -d'"' -f4
```

- **`tr`** — every field onto its own line, so nothing greedy can run past its target. JSON guarantees a key follows `,` or `{`, so after this split every key sits at line start. (`tr` pads `string2` with its last char — verified on BSD *and* GNU.)
- **anchored `grep`** — match `tag_name` only where it is a **key**. JSON escapes quotes inside strings, so string contents can never produce a bare quote at line start; that's what stops a release name or body containing the text `tag_name` from hijacking it. Both tested.
- **`cut -f4`** — value by position, not by pattern.

Then a shape check (`v[0-9]*`). Anything else — error page, rate-limit body, schema change — fails loudly instead of becoming a download URL. **This is the part that matters most:** it turns any future parsing surprise into an error rather than a wrong answer.

This is deliberately **not** presented as a JSON parser. It leans on two properties of well-formed JSON, and for a nested field it would be the wrong tool.

## Rejected, with reasons

| Option | Why not |
|---|---|
| `jq` | not installed everywhere |
| `gh` | far larger dependency than a `curl \| sh` installer should need |
| `awk -F'"'` | one process, looked ideal — but no anchoring, so a body containing `tag_name` returns `see tag_name notes`. Tested, rejected. |
| `git ls-remote` | no JSON at all, but **tags aren't releases** — a tag whose release build is still running (~4 min) or failed gets picked and every install 404s. Trades silent wrongness for an availability regression each release. |
| `/releases/latest` | excludes prereleases — exactly why it reports January's `v0.3.1` here |

The prerelease/release convention is unchanged; no workflow edits.

## Verified

Six valid shapes (compact, pretty, odd spacing, a name containing the literal text, a body crafted to look like a key, a draft entry) all resolve correctly. Four hostile inputs (rate-limit JSON, HTML error page, empty, non-tag string) all fail non-zero — where the old parser passed `not-a-tag` straight through. Live API resolves `v0.7.0-alpha.7` and installs both binaries; the release-pinned bootstrap path still works.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version detection when processing GitHub release data, including compact responses and text containing similar fields.
  * Added validation to prevent malformed version information from being returned.
  * Unexpected release API responses now produce a clear error instead of an invalid result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->