### PR TITLE
Feat: Monitor IBM Bob's inference traffic

### DIFF
--- a/authbridge/authlib/plugins/inferenceparser/anthropic.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic.go
@@ -16,6 +16,9 @@ import (
 // recognize both dialects.
 const anthropicMessagesPath = "/v1/messages"
 
+// bobMessagesPath is the IBM Bob API endpoint.
+const bobMessagesPath = "/inference/v1/chat/completions"
+
 // --- request ---
 
 // anthropicRequest is the subset of the Anthropic Messages request we surface.

--- a/authbridge/authlib/plugins/inferenceparser/anthropic.go
+++ b/authbridge/authlib/plugins/inferenceparser/anthropic.go
@@ -16,9 +16,6 @@ import (
 // recognize both dialects.
 const anthropicMessagesPath = "/v1/messages"
 
-// bobMessagesPath is the IBM Bob API endpoint.
-const bobMessagesPath = "/inference/v1/chat/completions"
-
 // --- request ---
 
 // anthropicRequest is the subset of the Anthropic Messages request we surface.

--- a/authbridge/authlib/plugins/inferenceparser/plugin.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin.go
@@ -45,6 +45,17 @@ func endpointPath(pctx *pipeline.Context) string {
 	return path
 }
 
+// bobPath is IBM Bob's inference endpoint. It speaks the OPENAI dialect — the
+// body is {model, messages, ...} — despite the path not matching any of the
+// OpenAI spellings above, because Bob mounts the API under an /inference prefix.
+//
+// A named const rather than another string in the switch: the prefix is what
+// makes it non-obvious that this is OpenAI-shaped, and the name is where that
+// gets said. It lives here, beside parseOpenAIRequest, rather than in
+// anthropic.go — routing an Anthropic-file const to the OpenAI parser reads as a
+// mistake even when it is not.
+const bobPath = "/inference/v1/chat/completions"
+
 func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) pipeline.Action {
 	// Dispatch by endpoint dialect: OpenAI chat/completions vs Anthropic
 	// Messages. No Invocation is recorded when the parser doesn't apply
@@ -52,12 +63,10 @@ func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) p
 	// "inference-parser is in this pipeline" from config, not per-event rows.
 	var ext *pipeline.InferenceExtension
 	switch endpointPath(pctx) {
-	case "/v1/chat/completions", "/v1/completions", "/chat/completions", "/completions":
+	case "/v1/chat/completions", "/v1/completions", "/chat/completions", "/completions", bobPath:
 		ext = parseOpenAIRequest(pctx.Body)
 	case anthropicMessagesPath:
 		ext = parseAnthropicRequest(pctx.Body)
-	case bobMessagesPath:
-		ext = parseOpenAIRequest(pctx.Body)
 	default:
 		return pipeline.Action{Type: pipeline.Continue}
 	}

--- a/authbridge/authlib/plugins/inferenceparser/plugin.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin.go
@@ -56,6 +56,8 @@ func (p *InferenceParser) OnRequest(_ context.Context, pctx *pipeline.Context) p
 		ext = parseOpenAIRequest(pctx.Body)
 	case anthropicMessagesPath:
 		ext = parseAnthropicRequest(pctx.Body)
+	case bobMessagesPath:
+		ext = parseOpenAIRequest(pctx.Body)
 	default:
 		return pipeline.Action{Type: pipeline.Continue}
 	}

--- a/authbridge/authlib/plugins/inferenceparser/plugin_test.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin_test.go
@@ -333,6 +333,98 @@ func TestInferenceParser_VlessPath_Completions(t *testing.T) {
 	}
 }
 
+// TestInferenceParser_BobPath covers IBM Bob, which mounts an OpenAI-dialect
+// inference API under an /inference prefix. The dispatch switch is exact-match, so
+// without the path the parser falls to the default arm and records no telemetry at
+// all — the body is never even looked at.
+func TestInferenceParser_BobPath_ChatCompletions(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: bobPath,
+		Body: []byte(`{"model":"granite-3-8b-instruct","messages":[{"role":"user","content":"hi"}],"stream":false}`),
+	}
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Continue {
+		t.Fatalf("expected Continue, got %v", action.Type)
+	}
+	ext := pctx.Extensions.Inference
+	if ext == nil {
+		t.Fatalf("Extensions.Inference is nil for %s", bobPath)
+	}
+	if ext.Model != "granite-3-8b-instruct" {
+		t.Errorf("Model = %q, want granite-3-8b-instruct", ext.Model)
+	}
+	if len(ext.Messages) != 1 || ext.Messages[0].Content != "hi" {
+		t.Errorf("Messages = %+v, want one user message \"hi\"", ext.Messages)
+	}
+	if !ext.IsAction {
+		t.Error("IsAction should be true: an outbound LLM call is an agent action")
+	}
+}
+
+// A query string must not defeat the match. endpointPath cuts at "?", and this is
+// the failure mode that made /v1/messages?beta=true invisible on the extproc path.
+func TestInferenceParser_BobPath_WithQueryString(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{
+		Path: bobPath + "?api-version=2024-02-01",
+		Body: []byte(`{"model":"granite-3-8b-instruct","messages":[{"role":"user","content":"hi"}]}`),
+	}
+	p.OnRequest(context.Background(), pctx)
+	if pctx.Extensions.Inference == nil {
+		t.Fatalf("Extensions.Inference is nil for %s with a query string", bobPath)
+	}
+}
+
+// Bob's responses must parse too. The response side branches on "is this
+// Anthropic", so an OpenAI-dialect path falls through to parseInferenceJSON — this
+// pins that, since a request-only path would give an operator a model name and no
+// token counts.
+func TestInferenceParser_BobPath_Response(t *testing.T) {
+	p := NewInferenceParser()
+	pctx := &pipeline.Context{Path: bobPath}
+	pctx.Extensions.Inference = &pipeline.InferenceExtension{
+		Model: "granite-3-8b-instruct", IsAction: true,
+	}
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"hello"},` +
+		`"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}`)
+
+	p.OnResponseFrame(context.Background(), pctx, body, true)
+
+	ext := pctx.Extensions.Inference
+	if ext.Completion != "hello" {
+		t.Errorf("Completion = %q, want hello", ext.Completion)
+	}
+	if ext.PromptTokens != 11 || ext.CompletionTokens != 3 {
+		t.Errorf("tokens = %d/%d, want 11/3", ext.PromptTokens, ext.CompletionTokens)
+	}
+	if ext.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want stop", ext.FinishReason)
+	}
+}
+
+// The sibling Bob endpoints seen alongside the inference one are NOT inference and
+// must stay unmatched — an exact-match switch is what keeps /admin/v1/profile from
+// being mistaken for a chat completion.
+func TestInferenceParser_BobNonInferencePathsAreIgnored(t *testing.T) {
+	for _, path := range []string{
+		"/admin/v1/profile",
+		"/inference/v1/model/info",
+		"/inference/v1/chat",              // prefix of the real path
+		"/inference/v1/chat/completions/", // trailing slash
+	} {
+		p := NewInferenceParser()
+		pctx := &pipeline.Context{
+			Path: path,
+			Body: []byte(`{"model":"granite-3-8b-instruct","messages":[{"role":"user","content":"hi"}]}`),
+		}
+		p.OnRequest(context.Background(), pctx)
+		if pctx.Extensions.Inference != nil {
+			t.Errorf("%s matched as inference; only %s should", path, bobPath)
+		}
+	}
+}
+
 func TestInferenceParser_NonMatchingPath(t *testing.T) {
 	p := NewInferenceParser()
 	pctx := &pipeline.Context{


### PR DESCRIPTION
## Summary

For #895

This allows abctl to show IBM Bob's inference traffic, instead of showing `—`

## (Optional) Testing Instructions

Start _authbridge-proxy_ in the usual well.

Run Bob Shell using

```bash
env HTTP_PROXY=http://localhost:47600 \
  HTTPS_PROXY=http://localhost:47600 \
  NODE_EXTRA_CA_CERTS=/Users/snible/.cortex/ca/ca.crt \
  bob
```

## Additional details

With this change we see Bob inference traffic in _abctl_:

```
 8     14:56:10.31   out   resp     —         —                                           200      53ms                                  s3.us-south.cloud-o… 
 9     14:56:16.13   out   req      tunnel    —                                                                                          api.us-east.bob.ibm… 
 10    14:56:16.16   out   req      observe   inference-parser    premium-ide                                                            api.us-east.bob.ibm… 
 11    14:56:16.16   out   req      observe   inference-parser    openai/gpt-oss-20b                                                     api.us-east.bob.ibm… 
 11    14:56:16.59   out   resp     observe   inference-parser    openai/gpt-oss-20b      200      436ms       1,413                     api.us-east.bob.ibm… 
 10    14:56:21.66   out   resp     observe   inference-parser    premium-ide             200      5.51s       8,681                     api.us-east.bob.ibm… 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IBM Bob API chat completion requests.
  * IBM Bob requests are now recognized and processed alongside existing supported inference formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->