### PR TITLE
Feat: Split abctl's TOKENS/SAVED column into TOKENS and COST

### DIFF
--- a/authbridge/cmd/abctl/tui/cost_event.go
+++ b/authbridge/cmd/abctl/tui/cost_event.go
@@ -11,13 +11,25 @@ import (
 // tags.
 //
 // Unlike tool-prune's event, this one carries a finished dollar figure rather
-// than rates: the plugin reads the authoritative post-discount cost out of
-// LiteLLM's response header, so there is nothing left for a consumer to compute.
+// than rates, so a consumer has no arithmetic left to do. It is NOT always an
+// authoritative figure though: the plugin prefers the cost LiteLLM stamps on the
+// response, but a streamed response always reports 0 there, so those are priced
+// from the plugin's own per-token rates instead. Source says which happened.
 type costEvent struct {
 	CostUSD float64 `json:"cost_usd"`
-	// Source is "gateway-header" (authoritative) or "usage-fallback" (priced
-	// from token counters, used for streamed responses whose header reports 0).
-	Source        string  `json:"source"`
+	// Source is "gateway-header" (the gateway's own post-discount figure) or
+	// "usage-fallback" (priced from token counters by the plugin, used for
+	// streamed responses whose header reports 0 — for a streaming agent this is
+	// the common case, not the exception).
+	//
+	// Decoded but deliberately not rendered: the COST column shows modelled and
+	// gateway-stamped figures identically, matching the request-side cost, which
+	// is modelled too. Marking one and not the other would be the inconsistency.
+	Source string `json:"source"`
+	// DailyTotalUSD / DailyMaxUSD are decoded for wire coverage — nothing renders
+	// them yet. Kept so the decode test pins every field the plugin publishes,
+	// which is what makes a tag rename fail here rather than silently blank a
+	// column later.
 	DailyTotalUSD float64 `json:"daily_total_usd"`
 	DailyMaxUSD   float64 `json:"daily_max_usd"`
 }
@@ -50,10 +62,10 @@ func decodeCostEvent(e *pipeline.SessionEvent) (costEvent, bool) {
 // close to an order of magnitude by flat pricing. The three rates needed are
 // exactly the three tool-prune already carries.
 //
-// This is a model, not a measurement — the authoritative figure only exists for
-// the exchange as a whole, on the response, and only when litellm-budget-track
-// is running. Rates resolved as "none" yield ok=false rather than a $0.00 that
-// would read as a free prompt.
+// This is a model, not a measurement: the only figure anyone reports is for the
+// exchange as a whole, on the response, and only when litellm-budget-track is
+// running. Rates resolved as "none" yield ok=false rather than a $0.00 that would
+// read as a free prompt.
 func promptCost(ps pruneSaving, resp *pipeline.InferenceExtension) (usd float64, ok bool) {
 	if resp == nil || ps.RateSource == "none" {
 		return 0, false
@@ -72,8 +84,12 @@ func promptCost(ps pruneSaving, resp *pipeline.InferenceExtension) (usd float64,
 // is the only party that tokenizes, but it is a request-side quantity — which is
 // what lets a request row show a total at all.
 //
-// Falls back to the reported aggregate when a provider exposes only PromptTokens
-// without the split, mirroring savedTokensAndCost.
+// The PromptTokens fallback cannot currently fire, and is kept only to mirror
+// savedTokensAndCost: parsercommon.TokenUsage.Fill is the sole production writer
+// of these fields and sets PromptTokens to Input+CacheRead+CacheWrite — the same
+// sum computed here — so when the split is zero the aggregate is zero too. It
+// costs nothing and would start earning its keep if a parser ever published the
+// aggregate directly.
 func promptTokens(resp *pipeline.InferenceExtension) int {
 	if resp == nil {
 		return 0

--- a/authbridge/cmd/abctl/tui/cost_event.go
+++ b/authbridge/cmd/abctl/tui/cost_event.go
@@ -1,0 +1,131 @@
+package tui
+
+import (
+	"encoding/json"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// costEvent is the litellm-budget-track per-response event as published under
+// "litellm-budget-track". Mirrors the plugin's shape; a decode test guards the
+// tags.
+//
+// Unlike tool-prune's event, this one carries a finished dollar figure rather
+// than rates: the plugin reads the authoritative post-discount cost out of
+// LiteLLM's response header, so there is nothing left for a consumer to compute.
+type costEvent struct {
+	CostUSD float64 `json:"cost_usd"`
+	// Source is "gateway-header" (authoritative) or "usage-fallback" (priced
+	// from token counters, used for streamed responses whose header reports 0).
+	Source        string  `json:"source"`
+	DailyTotalUSD float64 `json:"daily_total_usd"`
+	DailyMaxUSD   float64 `json:"daily_max_usd"`
+}
+
+// decodeCostEvent pulls the litellm-budget-track event off a response event, if
+// present. Absent whenever the plugin is not in the pipeline, or the response
+// was not priced (a cache hit / error charges nothing and emits nothing) — so a
+// false return is the normal case, not an error.
+func decodeCostEvent(e *pipeline.SessionEvent) (costEvent, bool) {
+	if e == nil || len(e.Plugins) == 0 {
+		return costEvent{}, false
+	}
+	raw, ok := e.Plugins["litellm-budget-track"]
+	if !ok {
+		return costEvent{}, false
+	}
+	var ce costEvent
+	if err := json.Unmarshal(raw, &ce); err != nil || ce.CostUSD <= 0 {
+		return costEvent{}, false
+	}
+	return ce, true
+}
+
+// promptCost models what the prompt of one request cost, from the response's
+// per-tier token counts and the rates tool-prune published on the request.
+//
+// Tier-weighted rather than a flat prompt × single-rate: providers bill a cache
+// read at ~0.1x the uncached input rate and a cache write at ~1.25x, so a
+// cache-heavy turn (the common case for a long-running agent) is overstated by
+// close to an order of magnitude by flat pricing. The three rates needed are
+// exactly the three tool-prune already carries.
+//
+// This is a model, not a measurement — the authoritative figure only exists for
+// the exchange as a whole, on the response, and only when litellm-budget-track
+// is running. Rates resolved as "none" yield ok=false rather than a $0.00 that
+// would read as a free prompt.
+func promptCost(ps pruneSaving, resp *pipeline.InferenceExtension) (usd float64, ok bool) {
+	if resp == nil || ps.RateSource == "none" {
+		return 0, false
+	}
+	usd = float64(resp.InputTokens)*ps.RateInput +
+		float64(resp.CacheReadTokens)*ps.RateCacheRead +
+		float64(resp.CacheWriteTokens)*ps.RateCacheWrite
+	if usd <= 0 {
+		return 0, false
+	}
+	return usd, true
+}
+
+// promptTokens is the request's own billed token count: what the provider
+// counted for everything we sent. It lives on the response because the provider
+// is the only party that tokenizes, but it is a request-side quantity — which is
+// what lets a request row show a total at all.
+//
+// Falls back to the reported aggregate when a provider exposes only PromptTokens
+// without the split, mirroring savedTokensAndCost.
+func promptTokens(resp *pipeline.InferenceExtension) int {
+	if resp == nil {
+		return 0
+	}
+	if n := resp.InputTokens + resp.CacheReadTokens + resp.CacheWriteTokens; n > 0 {
+		return n
+	}
+	return resp.PromptTokens
+}
+
+// savingSign distinguishes a realized saving from a projected one. A projected
+// saving (on_error: observe, where bytes were measured but not removed) uses "~"
+// instead of "−": the money was still spent, and rendering it identically would
+// invite an operator to subtract it twice.
+func savingSign(projected bool) string {
+	if projected {
+		return "~"
+	}
+	return "−"
+}
+
+// formatTokensWithSaving renders "681,300(−9.9k)" — the total this row is
+// responsible for, with what was kept off it in parentheses. A bare total when
+// there was no saving.
+//
+// The total is exact-with-commas and the saving compact, matching how each is
+// already rendered today: the total is a measured count worth reading precisely,
+// the saving a derived estimate where trailing digits would be false precision.
+func formatTokensWithSaving(total int, saved float64, projected bool) string {
+	if total <= 0 {
+		return ""
+	}
+	cell := formatCount(total)
+	if saved <= 0 {
+		return cell
+	}
+	return cell + "(" + savingSign(projected) + formatCompact(saved) + ")"
+}
+
+// formatUSDWithSaving is formatTokensWithSaving for money: "$0.2546(−$0.0037)".
+//
+// Both halves are rendered at a fixed 4 decimal places rather than through
+// formatUSD's variable precision. Stacked in one column, "$0.255" above
+// "−$0.0037" misaligns the decimal point and reads as though the two figures
+// were measured to different accuracy.
+func formatUSDWithSaving(total float64, saved float64, projected bool) string {
+	if total <= 0 {
+		return ""
+	}
+	cell := "$" + formatUSD4(total)
+	if saved <= 0 {
+		return cell
+	}
+	return cell + "(" + savingSign(projected) + "$" + formatUSD4(saved) + ")"
+}

--- a/authbridge/cmd/abctl/tui/cost_event.go
+++ b/authbridge/cmd/abctl/tui/cost_event.go
@@ -139,9 +139,9 @@ func formatUSDWithSaving(total float64, saved float64, projected bool) string {
 	if total <= 0 {
 		return ""
 	}
-	cell := "$" + formatUSD4(total)
+	cell := formatUSDCell(total)
 	if saved <= 0 {
 		return cell
 	}
-	return cell + "(" + savingSign(projected) + "$" + formatUSD4(saved) + ")"
+	return cell + "(" + savingSign(projected) + formatUSDCell(saved) + ")"
 }

--- a/authbridge/cmd/abctl/tui/cost_event_test.go
+++ b/authbridge/cmd/abctl/tui/cost_event_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
@@ -100,10 +101,37 @@ func TestExchangeCellsSumToTotal(t *testing.T) {
 	}
 }
 
+// TestExchangeCellsSurviveAReportedTotalThatDisagrees: TokenUsage.Fill prefers the
+// provider's own total_tokens over the sum of the parts, so the two are not
+// obliged to agree. Each row must keep reporting its own measured half rather than
+// back-deriving anything from the total — otherwise a gateway that rounds, or
+// counts a tier this display does not, would silently corrupt both cells.
+func TestExchangeCellsSurviveAReportedTotalThatDisagrees(t *testing.T) {
+	inf := agentTurn()
+	inf.TotalTokens = 999_999 // a reported total that is not prompt+output
+	req := reqEvent(t, bigPromptWire)
+	req.RequestID = "aaa"
+	resp := respEvent(costWire, inf)
+	resp.RequestID = "aaa"
+	rows := []eventRow{{event: req}, {event: resp}}
+	partner := map[int]int{0: 1, 1: 0}
+	m := &model{}
+
+	if got := m.tokensCell(rows, partner, 0, req); got != "681,300(−9.9k)" {
+		t.Errorf("request TOKENS = %q, want the measured prompt regardless of the reported total", got)
+	}
+	if got := m.tokensCell(rows, partner, 1, resp); got != "1,850" {
+		t.Errorf("response TOKENS = %q, want the measured output regardless of the reported total", got)
+	}
+	if strings.Contains(m.tokensCell(rows, partner, 1, resp), "999") {
+		t.Error("the reported total leaked into a cell")
+	}
+}
+
 // TestCostCellPhases: the request row is a modelled prompt figure, the response
-// row the authoritative exchange total. The response figure INCLUDES the request
-// figure — it is not a generated-token cost, because no plugin publishes an
-// output rate.
+// row the exchange total as budget-track reported it. The response figure
+// INCLUDES the request figure — it is not a generated-token cost, because no
+// plugin publishes an output rate.
 func TestCostCellPhases(t *testing.T) {
 	inf := agentTurn()
 	req := reqEvent(t, bigPromptWire)
@@ -122,8 +150,8 @@ func TestCostCellPhases(t *testing.T) {
 	if got := m.costCell(rows, partner, 1, resp); got != "$0.2824" {
 		t.Errorf("response COST = %q, want %q", got, "$0.2824")
 	}
-	// Without the budget-track event there is no authoritative total, so the
-	// response cost is blank rather than modelled.
+	// Without the budget-track event nobody reported a cost, so the response cell
+	// is blank rather than modelled from the request's rates.
 	if got := m.costCell(rows, partner, 1, respEvent("", inf)); got != "" {
 		t.Errorf("unpriced response COST = %q, want empty", got)
 	}
@@ -154,14 +182,18 @@ func TestPromptCostIsTierWeighted(t *testing.T) {
 	}
 }
 
-// TestGeneratedTokensCellFallsBackToCompletion: providers that report only the
-// aggregate still get a generated count, or the response row would go blank on
-// exactly the dialects that motivated the split.
-func TestGeneratedTokensCellFallsBackToCompletion(t *testing.T) {
-	if got := generatedTokensCell(respEvent("", &pipeline.InferenceExtension{CompletionTokens: 1_850})); got != "1,850" {
+// TestGeneratedTokensCellReadsOutputTokens: the response row shows what was
+// generated, and shows nothing rather than "0" when no usage was reported — a
+// blank cell reads as "not measured", a 0 as "generated nothing".
+//
+// Asserts OutputTokens only. The CompletionTokens fallback in the cell is not
+// exercised because it cannot fire: TokenUsage.Fill sets CompletionTokens from
+// the same Output value, so a test feeding one without the other would pin a
+// shape no parser produces.
+func TestGeneratedTokensCellReadsOutputTokens(t *testing.T) {
+	if got := generatedTokensCell(respEvent("", &pipeline.InferenceExtension{OutputTokens: 1_850})); got != "1,850" {
 		t.Errorf("cell = %q, want 1,850", got)
 	}
-	// No usage at all: blank, not "0".
 	for _, inf := range []*pipeline.InferenceExtension{nil, {}} {
 		if got := generatedTokensCell(respEvent("", inf)); got != "" {
 			t.Errorf("cell = %q, want empty", got)
@@ -169,19 +201,102 @@ func TestGeneratedTokensCellFallsBackToCompletion(t *testing.T) {
 	}
 }
 
-// TestPromptTokensPrefersSplitOverAggregate: the split counters are the
-// authoritative shape; PromptTokens is a fallback for providers that expose only
-// it. Preferring the aggregate would double-count on providers that send both.
-func TestPromptTokensPrefersSplitOverAggregate(t *testing.T) {
-	both := &pipeline.InferenceExtension{InputTokens: 100, CacheReadTokens: 400, PromptTokens: 500}
-	if got := promptTokens(both); got != 500 {
-		t.Errorf("promptTokens = %d, want 500", got)
+// TestPromptTokensSumsTheSplitTiers: the prompt total is the sum of the three
+// prompt-side tiers, which is the only shape parsercommon.TokenUsage.Fill
+// produces. Summing is what lets a request row show a total at all.
+//
+// The PromptTokens fallback is not asserted for a value of its own: Fill sets it
+// to the identical sum, so there is no input where the two disagree.
+func TestPromptTokensSumsTheSplitTiers(t *testing.T) {
+	split := &pipeline.InferenceExtension{
+		InputTokens: 100, CacheReadTokens: 400, CacheWriteTokens: 25, PromptTokens: 525,
 	}
-	only := &pipeline.InferenceExtension{PromptTokens: 500}
-	if got := promptTokens(only); got != 500 {
-		t.Errorf("aggregate-only promptTokens = %d, want 500", got)
+	if got := promptTokens(split); got != 525 {
+		t.Errorf("promptTokens = %d, want 525", got)
+	}
+	// Cache-write tokens are prompt-side and must not be dropped: on a cold cache
+	// they are the bulk of the prompt, and they bill at ~1.25x the input rate.
+	noWrite := &pipeline.InferenceExtension{InputTokens: 100, CacheReadTokens: 400, PromptTokens: 500}
+	if got := promptTokens(noWrite); got != 500 {
+		t.Errorf("promptTokens = %d, want 500", got)
 	}
 	if got := promptTokens(nil); got != 0 {
 		t.Errorf("nil promptTokens = %d, want 0", got)
+	}
+	if got := promptTokens(&pipeline.InferenceExtension{}); got != 0 {
+		t.Errorf("empty promptTokens = %d, want 0", got)
+	}
+}
+
+// TestTokensCellFitsASevenDigitPrompt pins the TOKENS column width against the
+// worst realistic case. Million-token contexts are in service, and bubbles
+// truncates each cell at the column width with an ellipsis — so at 15 this
+// rendered "1,048,576(−1…", silently dropping the saving, which is the half of
+// the cell that appears nowhere else in the UI.
+//
+// Asserts against the column definition rather than a transcribed number, so
+// narrowing the column fails here instead of quietly clipping in production.
+func TestTokensCellFitsASevenDigitPrompt(t *testing.T) {
+	inf := &pipeline.InferenceExtension{
+		InputTokens: 48_576, CacheReadTokens: 1_000_000,
+		OutputTokens: 3_650, TotalTokens: 1_052_226,
+	}
+	req := reqEvent(t, bigPromptWire)
+	req.RequestID = "big"
+	resp := respEvent(costWire, inf)
+	resp.RequestID = "big"
+	rows := []eventRow{{event: req}, {event: resp}}
+	m := &model{}
+
+	cell := m.tokensCell(rows, map[int]int{0: 1, 1: 0}, 0, req)
+	if !strings.HasPrefix(cell, "1,048,576(−") {
+		t.Fatalf("TOKENS cell = %q, want a 7-digit prompt with its saving", cell)
+	}
+	width := columnWidth(t, "TOKENS")
+	if n := len([]rune(cell)); n > width {
+		t.Errorf("TOKENS cell %q is %d cols but the column is %d — bubbles will clip the saving",
+			cell, n, width)
+	}
+	// The same guard for COST, whose widest realistic value is a sub-cent saving
+	// against a dollar total.
+	costStr := m.costCell(rows, map[int]int{0: 1, 1: 0}, 0, req)
+	if n := len([]rune(costStr)); n > columnWidth(t, "COST") {
+		t.Errorf("COST cell %q is %d cols but the column is %d", costStr, n, columnWidth(t, "COST"))
+	}
+}
+
+// columnWidth reads a width off the real events-table definition, so a test
+// cannot drift from the column it is meant to be guarding.
+func columnWidth(t *testing.T, title string) int {
+	t.Helper()
+	for _, c := range newEventsTable().Columns() {
+		if c.Title == title {
+			return c.Width
+		}
+	}
+	t.Fatalf("no %q column", title)
+	return 0
+}
+
+// TestEventMethodSharesTheColumnWidth: eventMethod truncated to a hardcoded 22
+// after the column shrank to 14. bubbles re-truncates and hid it, but that is the
+// drift actionColWidth exists to prevent, so lock the two together.
+func TestEventMethodSharesTheColumnWidth(t *testing.T) {
+	if methodColWidth != columnWidth(t, "METHOD") {
+		t.Errorf("methodColWidth = %d but the METHOD column is %d",
+			methodColWidth, columnWidth(t, "METHOD"))
+	}
+	long := &pipeline.SessionEvent{
+		Inference: &pipeline.InferenceExtension{Model: "claude-sonnet-4-5-20250929"},
+	}
+	if n := len([]rune(eventMethod(*long))); n > methodColWidth {
+		t.Errorf("eventMethod returned %d cols, want <= %d", n, methodColWidth)
+	}
+	// A name that fits must not be truncated.
+	fits := &pipeline.SessionEvent{
+		Inference: &pipeline.InferenceExtension{Model: "claude-opus-5"},
+	}
+	if got := eventMethod(*fits); got != "claude-opus-5" {
+		t.Errorf("eventMethod = %q, want it untouched", got)
 	}
 }

--- a/authbridge/cmd/abctl/tui/cost_event_test.go
+++ b/authbridge/cmd/abctl/tui/cost_event_test.go
@@ -1,0 +1,187 @@
+package tui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// costWire is the exact JSON litellm-budget-track publishes under
+// "litellm-budget-track".
+const costWire = `{"cost_usd":0.2824,"source":"gateway-header",
+  "daily_total_usd":1.4207,"daily_max_usd":5}`
+
+// bigPromptWire is a tool-prune event sized for the cache-heavy agent turn this
+// split exists for: a ~2.4MB body (≈3.5 bytes/token against a 681k-token prompt)
+// with a 34KB tool block removed. The package-level `wire` fixture describes a
+// 90KB body, whose byte ratio against a 681k prompt would imply a 31% saving —
+// arithmetically valid but not a shape that occurs.
+const bigPromptWire = `{"bytesRemoved":34645,"bodyBytesAfter":2384550,
+  "model":"claude-opus-5","rateInput":3.8e-06,"rateCacheWrite":4.75e-06,
+  "rateCacheRead":3.8e-07,"rateSource":"default"}`
+
+// agentTurn is the usage a long-running agent reports: almost entirely cache
+// reads, a small uncached delta, and a modest completion. Sums to TotalTokens so
+// the split invariant is checkable.
+func agentTurn() *pipeline.InferenceExtension {
+	return &pipeline.InferenceExtension{
+		InputTokens: 1_300, CacheReadTokens: 680_000,
+		OutputTokens: 1_850, TotalTokens: 683_150,
+	}
+}
+
+func respEvent(raw string, inf *pipeline.InferenceExtension) *pipeline.SessionEvent {
+	e := &pipeline.SessionEvent{Phase: pipeline.SessionResponse, Inference: inf}
+	if raw != "" {
+		e.Plugins = map[string]json.RawMessage{"litellm-budget-track": json.RawMessage(raw)}
+	}
+	return e
+}
+
+// TestDecodeCostEvent guards the tags against drift with the plugin's struct. A
+// silent decode failure would leave the COST column blank, which is
+// indistinguishable from an unpriced call — so the tags are the only thing
+// standing between "free" and "not reported".
+func TestDecodeCostEvent(t *testing.T) {
+	ce, ok := decodeCostEvent(respEvent(costWire, nil))
+	if !ok {
+		t.Fatal("failed to decode the published event")
+	}
+	if ce.CostUSD != 0.2824 {
+		t.Errorf("CostUSD = %v, want 0.2824", ce.CostUSD)
+	}
+	if ce.Source != "gateway-header" {
+		t.Errorf("Source = %q, want gateway-header", ce.Source)
+	}
+	if ce.DailyTotalUSD != 1.4207 || ce.DailyMaxUSD != 5 {
+		t.Errorf("daily fields did not decode: %+v", ce)
+	}
+	// Absent, malformed, and unpriced all decline rather than render $0.0000,
+	// which would read as a call that cost nothing.
+	for _, bad := range []*pipeline.SessionEvent{
+		nil,
+		{Phase: pipeline.SessionResponse},
+		respEvent(`{"cost_usd":0,"source":"gateway-header"}`, nil),
+		respEvent(`not json`, nil),
+	} {
+		if _, ok := decodeCostEvent(bad); ok {
+			t.Errorf("should not decode: %+v", bad)
+		}
+	}
+}
+
+// TestExchangeCellsSumToTotal is the invariant behind splitting the column: the
+// request row's prompt count plus the response row's generated count equal the
+// billed total. Before the split the response row showed TotalTokens, so the
+// prompt was counted once on each row and the generated tokens were invisible.
+func TestExchangeCellsSumToTotal(t *testing.T) {
+	inf := agentTurn()
+	req := reqEvent(t, bigPromptWire)
+	req.RequestID = "aaa"
+	resp := respEvent(costWire, inf)
+	resp.RequestID = "aaa"
+	rows := []eventRow{{event: req}, {event: resp}}
+	partner := map[int]int{0: 1, 1: 0}
+	m := &model{}
+
+	// 1,300 + 680,000 = 681,300 prompt tokens, with the saving in parens:
+	// 34,645 bytes × 681,300 tokens / 2,384,550 bytes ≈ 9.9k tokens.
+	gotReq := m.tokensCell(rows, partner, 0, req)
+	if gotReq != "681,300(−9.9k)" {
+		t.Errorf("request TOKENS = %q, want %q", gotReq, "681,300(−9.9k)")
+	}
+	gotResp := m.tokensCell(rows, partner, 1, resp)
+	if gotResp != "1,850" {
+		t.Errorf("response TOKENS = %q, want %q", gotResp, "1,850")
+	}
+	if want := promptTokens(inf) + inf.OutputTokens; want != inf.TotalTokens {
+		t.Errorf("the two rows sum to %d but the provider billed %d", want, inf.TotalTokens)
+	}
+}
+
+// TestCostCellPhases: the request row is a modelled prompt figure, the response
+// row the authoritative exchange total. The response figure INCLUDES the request
+// figure — it is not a generated-token cost, because no plugin publishes an
+// output rate.
+func TestCostCellPhases(t *testing.T) {
+	inf := agentTurn()
+	req := reqEvent(t, bigPromptWire)
+	req.RequestID = "aaa"
+	resp := respEvent(costWire, inf)
+	resp.RequestID = "aaa"
+	rows := []eventRow{{event: req}, {event: resp}}
+	partner := map[int]int{0: 1, 1: 0}
+	m := &model{}
+
+	// Prompt: 1,300 × 3.8e-6 + 680,000 × 3.8e-7 = 0.00494 + 0.2584 = 0.26334.
+	// Saving: 9.9k tokens at the cache-read rate = 0.0038.
+	if got := m.costCell(rows, partner, 0, req); got != "$0.2633(−$0.0038)" {
+		t.Errorf("request COST = %q, want %q", got, "$0.2633(−$0.0038)")
+	}
+	if got := m.costCell(rows, partner, 1, resp); got != "$0.2824" {
+		t.Errorf("response COST = %q, want %q", got, "$0.2824")
+	}
+	// Without the budget-track event there is no authoritative total, so the
+	// response cost is blank rather than modelled.
+	if got := m.costCell(rows, partner, 1, respEvent("", inf)); got != "" {
+		t.Errorf("unpriced response COST = %q, want empty", got)
+	}
+}
+
+// TestPromptCostIsTierWeighted: pricing the whole prompt at the uncached input
+// rate overstates a cache-heavy turn by close to an order of magnitude, which is
+// the common shape for a long-running agent. The weighted figure must be well
+// below the flat one.
+func TestPromptCostIsTierWeighted(t *testing.T) {
+	ps := pruneSaving{RateInput: 3.8e-6, RateCacheRead: 3.8e-7, RateCacheWrite: 4.75e-6, RateSource: "default"}
+	inf := &pipeline.InferenceExtension{InputTokens: 1_000, CacheReadTokens: 99_000}
+	got, ok := promptCost(ps, inf)
+	if !ok {
+		t.Fatal("no cost figure")
+	}
+	flat := float64(promptTokens(inf)) * ps.RateInput
+	if got >= flat {
+		t.Errorf("weighted %v should be below flat %v", got, flat)
+	}
+	want := 1_000*3.8e-6 + 99_000*3.8e-7
+	if got < want-1e-12 || got > want+1e-12 {
+		t.Errorf("promptCost = %v, want %v", got, want)
+	}
+	// nil usage yields no figure rather than a zero that reads as free.
+	if _, ok := promptCost(ps, nil); ok {
+		t.Error("nil usage produced a cost figure")
+	}
+}
+
+// TestGeneratedTokensCellFallsBackToCompletion: providers that report only the
+// aggregate still get a generated count, or the response row would go blank on
+// exactly the dialects that motivated the split.
+func TestGeneratedTokensCellFallsBackToCompletion(t *testing.T) {
+	if got := generatedTokensCell(respEvent("", &pipeline.InferenceExtension{CompletionTokens: 1_850})); got != "1,850" {
+		t.Errorf("cell = %q, want 1,850", got)
+	}
+	// No usage at all: blank, not "0".
+	for _, inf := range []*pipeline.InferenceExtension{nil, {}} {
+		if got := generatedTokensCell(respEvent("", inf)); got != "" {
+			t.Errorf("cell = %q, want empty", got)
+		}
+	}
+}
+
+// TestPromptTokensPrefersSplitOverAggregate: the split counters are the
+// authoritative shape; PromptTokens is a fallback for providers that expose only
+// it. Preferring the aggregate would double-count on providers that send both.
+func TestPromptTokensPrefersSplitOverAggregate(t *testing.T) {
+	both := &pipeline.InferenceExtension{InputTokens: 100, CacheReadTokens: 400, PromptTokens: 500}
+	if got := promptTokens(both); got != 500 {
+		t.Errorf("promptTokens = %d, want 500", got)
+	}
+	only := &pipeline.InferenceExtension{PromptTokens: 500}
+	if got := promptTokens(only); got != 500 {
+		t.Errorf("aggregate-only promptTokens = %d, want 500", got)
+	}
+	if got := promptTokens(nil); got != 0 {
+		t.Errorf("nil promptTokens = %d, want 0", got)
+	}
+}

--- a/authbridge/cmd/abctl/tui/cost_event_test.go
+++ b/authbridge/cmd/abctl/tui/cost_event_test.go
@@ -300,3 +300,57 @@ func TestEventMethodSharesTheColumnWidth(t *testing.T) {
 		t.Errorf("eventMethod = %q, want it untouched", got)
 	}
 }
+
+// TestFormatUSDCellNeverRendersAFreeCall: %.4f turns anything under $0.00005 into
+// "$0.0000", which reads as a call that cost nothing. decodeCostEvent declines a
+// zero cost and promptCost declines an unpriced model precisely so that reading
+// never appears, and rounding at the formatting layer would undo both.
+//
+// Reachable: 100 cache-read tokens at a typical rate is $0.000038.
+func TestFormatUSDCellNeverRendersAFreeCall(t *testing.T) {
+	tiny := 100 * 3.8e-7 // $0.000038
+	if got := formatUSDCell(tiny); got != "<$0.0001" {
+		t.Errorf("formatUSDCell(%v) = %q, want %q", tiny, got, "<$0.0001")
+	}
+	// Zero is genuinely zero and keeps its plain rendering: callers already
+	// decline to show a cell at all in that case.
+	if got := formatUSDCell(0); got != "$0.0000" {
+		t.Errorf("formatUSDCell(0) = %q, want %q", got, "$0.0000")
+	}
+	// At and above the floor, exact figures are unchanged.
+	for v, want := range map[float64]string{0.0001: "$0.0001", 0.2633: "$0.2633", 12.5: "$12.5000"} {
+		if got := formatUSDCell(v); got != want {
+			t.Errorf("formatUSDCell(%v) = %q, want %q", v, got, want)
+		}
+	}
+	// A sub-floor saving beside a normal total must not read as "saved nothing".
+	cell := formatUSDWithSaving(0.2633, tiny, false)
+	if !strings.Contains(cell, "(−<$0.0001)") {
+		t.Errorf("cell = %q, want the saving marked as below the floor", cell)
+	}
+	if strings.Contains(cell, "$0.0000") {
+		t.Errorf("cell = %q still rounds a real amount to zero", cell)
+	}
+	// The widest cell the formatter can produce must fit the column.
+	widest := formatUSDWithSaving(tiny, tiny/2, false)
+	if n := len([]rune(widest)); n > columnWidth(t, "COST") {
+		t.Errorf("widest COST cell %q is %d cols but the column is %d",
+			widest, n, columnWidth(t, "COST"))
+	}
+}
+
+// TestMethodColumnDistinguishesDatedModelIDs: the COST column reports a per-row
+// cost, so METHOD has to be able to say which model it belongs to. At 14 the two
+// dated Sonnet IDs both rendered "claude-sonnet…", making the pair unreadable.
+func TestMethodColumnDistinguishesDatedModelIDs(t *testing.T) {
+	a := &pipeline.SessionEvent{Inference: &pipeline.InferenceExtension{Model: "claude-sonnet-4-5-20250929"}}
+	b := &pipeline.SessionEvent{Inference: &pipeline.InferenceExtension{Model: "claude-sonnet-4-20250514"}}
+	if eventMethod(*a) == eventMethod(*b) {
+		t.Errorf("both models render as %q; METHOD cannot say which the COST cell is for", eventMethod(*a))
+	}
+	// A long MCP method name still truncates rather than overflowing.
+	mcp := &pipeline.SessionEvent{MCP: &pipeline.MCPExtension{Method: "notifications/initialized"}}
+	if n := len([]rune(eventMethod(*mcp))); n > methodColWidth {
+		t.Errorf("eventMethod = %d cols, want <= %d", n, methodColWidth)
+	}
+}

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -35,8 +35,10 @@ func newEventsTable() table.Model {
 			// at the column width, so 15 rendered "1,048,576(−1…" — dropping the
 			// saving, which is the half of this cell that appears nowhere else.
 			{Title: "TOKENS", Width: 17},
-			// Wide enough for "$0.2546(−$0.0037)".
-			{Title: "COST", Width: 18},
+			// 19 fits the widest cell the formatter can produce:
+			// "<$0.0001(−<$0.0001)", where both halves fell under the
+			// four-decimal floor. The ordinary shape is "$0.2546(−$0.0037)" at 17.
+			{Title: "COST", Width: 19},
 			{Title: "HOST", Width: 20},
 		}),
 		table.WithFocused(true),
@@ -331,10 +333,17 @@ func shadowFlagged(invs []pipeline.Invocation) bool {
 const actionColWidth = 8
 
 // methodColWidth is the METHOD column's width, shared with eventMethod for the
-// same reason: it holds a model name ("claude-opus-5"), and two independent
-// numbers drifted apart the moment the column was narrowed to pay for the
-// TOKENS/COST split.
-const methodColWidth = 14
+// same reason actionColWidth is named: two independent numbers drifted apart the
+// moment the column was narrowed to pay for the TOKENS/COST split.
+//
+// 18 rather than 14. The values reaching it are wider than a short model alias:
+// eventMethodValue also returns A2A and MCP method names
+// ("notifications/initialized", 25) and dated provider model IDs
+// ("claude-sonnet-4-5-20250929", 26). At 14 both "claude-sonnet-4-5-20250929"
+// and "claude-sonnet-4-20250514" render as "claude-sonnet…", which makes the
+// column unable to say which model the COST cell beside it is reporting — the
+// one thing it most needs to disambiguate now that costs are per-row.
+const methodColWidth = 18
 
 // tunnelAction is the ACTION cell for an opaque CONNECT that no plugin acted on.
 //
@@ -918,7 +927,7 @@ func (m *model) costCell(rows []eventRow, partner map[int]int, i int, ev *pipeli
 		if !ok {
 			return ""
 		}
-		return "$" + formatUSD4(ce.CostUSD)
+		return formatUSDCell(ce.CostUSD)
 	case pipeline.SessionRequest:
 		resp := pairedResponse(rows, partner, i, ev)
 		if resp == nil {

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -24,15 +24,17 @@ func newEventsTable() table.Model {
 			{Title: "PHASE", Width: 7},
 			{Title: "ACTION", Width: actionColWidth},
 			{Title: "PLUGIN", Width: 18},
-			// 14 rather than 22: the widest realistic value is a model name
-			// ("claude-opus-5"), and the 8 columns freed pay for splitting
+			// methodColWidth rather than 22: the widest realistic value is a model
+			// name ("claude-opus-5"), and the columns freed pay for splitting
 			// TOKENS and COST apart below.
-			{Title: "METHOD", Width: 14},
+			{Title: "METHOD", Width: methodColWidth},
 			{Title: "STATUS", Width: 7},
 			{Title: "DURATION", Width: 10},
-			// Wide enough for "681,300(−9.9k)": the prompt total with what
-			// tool-prune kept off it, or a response's generated count.
-			{Title: "TOKENS", Width: 15},
+			// 17, not 15: sized for a SEVEN-digit prompt, "1,048,576(−12.3k)".
+			// Million-token contexts are in service, and bubbles truncates a cell
+			// at the column width, so 15 rendered "1,048,576(−1…" — dropping the
+			// saving, which is the half of this cell that appears nowhere else.
+			{Title: "TOKENS", Width: 17},
 			// Wide enough for "$0.2546(−$0.0037)".
 			{Title: "COST", Width: 18},
 			{Title: "HOST", Width: 20},
@@ -328,6 +330,12 @@ func shadowFlagged(invs []pipeline.Invocation) bool {
 // passing while the label overflowed.
 const actionColWidth = 8
 
+// methodColWidth is the METHOD column's width, shared with eventMethod for the
+// same reason: it holds a model name ("claude-opus-5"), and two independent
+// numbers drifted apart the moment the column was narrowed to pay for the
+// TOKENS/COST split.
+const methodColWidth = 14
+
 // tunnelAction is the ACTION cell for an opaque CONNECT that no plugin acted on.
 //
 // It must fit actionColWidth. Truncation matters more here than on other rows:
@@ -465,8 +473,13 @@ func eventMethodValue(e pipeline.SessionEvent) string {
 
 // eventMethod is the display form of the method/model — truncated to the
 // METHOD column width. Render-only; never compare or search on it.
+//
+// Shares methodColWidth with the column definition rather than repeating the
+// number, the same drift guard actionColWidth provides for ACTION: the two were
+// already 22 and 14 after the column shrank, which bubbles hid by re-truncating
+// each cell at the column width anyway.
 func eventMethod(e pipeline.SessionEvent) string {
-	return truncStr(eventMethodValue(e), 22)
+	return truncStr(eventMethodValue(e), methodColWidth)
 }
 
 func statusCell(e pipeline.SessionEvent) string {
@@ -480,14 +493,23 @@ func statusCell(e pipeline.SessionEvent) string {
 // count and not TotalTokens: for a long-running agent the prompt dominates the
 // aggregate so completely (cache reads in the hundreds of thousands) that
 // TotalTokens barely moves between turns, hiding the one component that actually
-// varies. The prompt side is on the request row, and the two sum to the total.
+// varies. The prompt side is on the request row, so between them the two rows
+// account for the whole exchange without either repeating the other.
+//
+// They usually also ADD UP to TotalTokens, but that is not guaranteed and is not
+// relied on: TokenUsage.Fill prefers the provider's own reported total when it
+// sends one, which need not equal the parts. Each row reports its own measured
+// half, so the display stays honest either way.
+//
+// The CompletionTokens fallback cannot currently fire — Fill sets it from the
+// same Output value read above — and is kept only for symmetry with promptTokens.
 func generatedTokensCell(e *pipeline.SessionEvent) string {
 	if e.Inference == nil {
 		return ""
 	}
 	n := e.Inference.OutputTokens
 	if n == 0 {
-		n = e.Inference.CompletionTokens // provider reported only the aggregate
+		n = e.Inference.CompletionTokens
 	}
 	if n <= 0 {
 		return ""
@@ -871,15 +893,24 @@ func (m *model) tokensCell(rows []eventRow, partner map[int]int, i int, ev *pipe
 //     tool-prune published, with the saving in parentheses. Blank without
 //     tool-prune, which is the only plugin that puts rates on the wire.
 //   - a RESPONSE row shows what the whole exchange cost, as reported by
-//     litellm-budget-track — the authoritative post-discount figure.
+//     litellm-budget-track: the gateway's own post-discount figure when it
+//     stamped one, otherwise the plugin's own per-token pricing. A streamed
+//     response always reports 0 in the header, so for a streaming agent the
+//     modelled path is the common case rather than the exception.
 //
-// The response figure therefore *includes* the request figure. It is not the
-// generated-token cost, because no plugin publishes an output rate: tool-prune
-// deliberately omits one (it only ever shrinks the prompt, so attributing output
-// cost to it would be false) and budget-track emits a finished total rather than
-// its rates. Deriving the completion cost by subtraction would concentrate all of
-// the prompt model's error into it and can go negative, so the real total is
-// shown instead of a computed delta.
+// Both figures in this column can therefore be models, and neither is marked as
+// one. That is deliberate: marking the response cost while leaving the request
+// cost — which is always modelled — unmarked would imply a distinction the column
+// does not actually draw. costEvent.Source carries the provenance for anyone who
+// needs it.
+//
+// The response figure *includes* the request figure. It is not the generated-token
+// cost, because no plugin publishes an output rate: tool-prune deliberately omits
+// one (it only ever shrinks the prompt, so attributing output cost to it would be
+// false) and budget-track emits a finished total rather than its rates. Deriving
+// the completion cost by subtraction would concentrate all of the prompt model's
+// error into it and can go negative, so the reported total is shown instead of a
+// computed delta.
 func (m *model) costCell(rows []eventRow, partner map[int]int, i int, ev *pipeline.SessionEvent) string {
 	switch ev.Phase {
 	case pipeline.SessionResponse:

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -24,12 +24,17 @@ func newEventsTable() table.Model {
 			{Title: "PHASE", Width: 7},
 			{Title: "ACTION", Width: actionColWidth},
 			{Title: "PLUGIN", Width: 18},
-			{Title: "METHOD", Width: 22},
+			// 14 rather than 22: the widest realistic value is a model name
+			// ("claude-opus-5"), and the 8 columns freed pay for splitting
+			// TOKENS and COST apart below.
+			{Title: "METHOD", Width: 14},
 			{Title: "STATUS", Width: 7},
 			{Title: "DURATION", Width: 10},
-			// Wide enough for "33,650  −10.6k  $0.1289": the request total, what
-			// tool-prune removed from it, and what that was worth.
-			{Title: "TOKENS / SAVED", Width: 24},
+			// Wide enough for "681,300(−9.9k)": the prompt total with what
+			// tool-prune kept off it, or a response's generated count.
+			{Title: "TOKENS", Width: 15},
+			// Wide enough for "$0.2546(−$0.0037)".
+			{Title: "COST", Width: 18},
 			{Title: "HOST", Width: 20},
 		}),
 		table.WithFocused(true),
@@ -139,7 +144,8 @@ func (m *model) rebuildEventsTable() {
 			eventMethod(*ev),
 			statusCell(*ev),
 			durationCell(*ev),
-			m.tokensCellWithSaving(eventRows, partner, i, ev),
+			m.tokensCell(eventRows, partner, i, ev),
+			m.costCell(eventRows, partner, i, ev),
 			truncStr(ev.Host, 20),
 		})
 		m.visibleRows = append(m.visibleRows, er)
@@ -470,15 +476,23 @@ func statusCell(e pipeline.SessionEvent) string {
 	return fmt.Sprintf("%d", e.StatusCode)
 }
 
-// tokensCell shows the total token count for inference response rows so
-// operators can spot expensive calls while scrolling. Blank for every
-// other event type (a2a, mcp, inference *request*). Uses the same
-// thousands-separator formatter as the sessions-pane totals.
-func tokensCell(e pipeline.SessionEvent) string {
-	if e.Phase != pipeline.SessionResponse || e.Inference == nil || e.Inference.TotalTokens == 0 {
+// generatedTokensCell shows what a response generated. Deliberately the output
+// count and not TotalTokens: for a long-running agent the prompt dominates the
+// aggregate so completely (cache reads in the hundreds of thousands) that
+// TotalTokens barely moves between turns, hiding the one component that actually
+// varies. The prompt side is on the request row, and the two sum to the total.
+func generatedTokensCell(e *pipeline.SessionEvent) string {
+	if e.Inference == nil {
 		return ""
 	}
-	return formatCount(e.Inference.TotalTokens)
+	n := e.Inference.OutputTokens
+	if n == 0 {
+		n = e.Inference.CompletionTokens // provider reported only the aggregate
+	}
+	if n <= 0 {
+		return ""
+	}
+	return formatCount(n)
 }
 
 func durationCell(e pipeline.SessionEvent) string {
@@ -795,49 +809,101 @@ func truncateScopes(scopes []string, n int) string {
 	return strings.Join(scopes[:n], ", ") + fmt.Sprintf(" +%d more", len(scopes)-n)
 }
 
-// tokensCellWithSaving renders the TOKENS / SAVED cell, splitting the two halves
-// across the rows they actually belong to:
+// pairedResponse resolves the response row belonging to a request row, or nil
+// when there isn't one yet.
 //
-//   - a REQUEST row that tool-prune rewrote shows what was removed from it,
-//     which is where the plugin's own `modify` invocation already sits;
-//   - a RESPONSE row shows the token total the provider billed.
-//
-// The saving deliberately does NOT go on the response row. Nothing about the
-// response was reduced, and showing it there reads as though it were — the
-// pruning happened on the way out. The two rows share a # so they are read
-// together anyway.
-//
-// The response is still what makes the request-side figure computable: it
-// supplies the prompt token total behind the bytes-to-tokens ratio and the tier
-// that sets the rate. So a request row looks forward to its paired response.
-func (m *model) tokensCellWithSaving(rows []eventRow, partner map[int]int, i int, ev *pipeline.SessionEvent) string {
-	if ev.Phase == pipeline.SessionResponse {
-		return tokensCell(*ev)
-	}
-	if ev.Phase != pipeline.SessionRequest {
-		return ""
-	}
-	ps, ok := decodePruneSaving(ev)
-	if !ok {
-		return ""
-	}
+// Extracted because the TOKENS and COST cells both need it and the id guard must
+// not drift between them: only a response that pairs by RequestID may be used. A
+// heuristically-matched response can belong to a different request, and its cache
+// tier would then pick the wrong rate — a 12.5x error presented as a measurement.
+func pairedResponse(rows []eventRow, partner map[int]int, i int, ev *pipeline.SessionEvent) *pipeline.SessionEvent {
 	j, ok := partner[i]
 	if !ok || j < 0 || j >= len(rows) {
-		return "" // no response yet: the ratio and tier are not known
+		return nil // no response yet: the ratio and tier are not known
 	}
 	resp := rows[j].event
 	if resp == nil || resp.Phase != pipeline.SessionResponse {
-		return ""
+		return nil
 	}
-	// Only price against a response that pairs by id. A heuristically-matched
-	// response may belong to a different request, and its cache tier would
-	// then pick the wrong rate — a 12.5x error presented as a measurement.
 	if ev.RequestID == "" || resp.RequestID != ev.RequestID {
+		return nil
+	}
+	return resp
+}
+
+// tokensCell renders the TOKENS column, split so the two rows of an exchange sum
+// to the billed total rather than one repeating the other:
+//
+//   - a REQUEST row shows the prompt tokens it sent, with what tool-prune kept
+//     off them in parentheses — which is where the plugin's `modify` invocation
+//     already sits;
+//   - a RESPONSE row shows the tokens generated.
+//
+// The prompt count lives on the response event because the provider is the only
+// party that tokenizes, but it is a request-side quantity — which is what lets a
+// request row show a total at all. So a request row looks forward to its pair.
+func (m *model) tokensCell(rows []eventRow, partner map[int]int, i int, ev *pipeline.SessionEvent) string {
+	switch ev.Phase {
+	case pipeline.SessionResponse:
+		return generatedTokensCell(ev)
+	case pipeline.SessionRequest:
+		resp := pairedResponse(rows, partner, i, ev)
+		if resp == nil {
+			return ""
+		}
+		var saved float64
+		var projected bool
+		if ps, ok := decodePruneSaving(ev); ok {
+			saved, _, _ = savedTokensAndCost(ps, resp.Inference)
+			projected = ps.Projected
+		}
+		return formatTokensWithSaving(promptTokens(resp.Inference), saved, projected)
+	default:
 		return ""
 	}
-	tokens, usd, ok := savedTokensAndCost(ps, resp.Inference)
-	if !ok {
+}
+
+// costCell renders the COST column.
+//
+// The two rows are NOT two halves of one sum, unlike TOKENS:
+//
+//   - a REQUEST row shows what its prompt cost, modelled per-tier from the rates
+//     tool-prune published, with the saving in parentheses. Blank without
+//     tool-prune, which is the only plugin that puts rates on the wire.
+//   - a RESPONSE row shows what the whole exchange cost, as reported by
+//     litellm-budget-track — the authoritative post-discount figure.
+//
+// The response figure therefore *includes* the request figure. It is not the
+// generated-token cost, because no plugin publishes an output rate: tool-prune
+// deliberately omits one (it only ever shrinks the prompt, so attributing output
+// cost to it would be false) and budget-track emits a finished total rather than
+// its rates. Deriving the completion cost by subtraction would concentrate all of
+// the prompt model's error into it and can go negative, so the real total is
+// shown instead of a computed delta.
+func (m *model) costCell(rows []eventRow, partner map[int]int, i int, ev *pipeline.SessionEvent) string {
+	switch ev.Phase {
+	case pipeline.SessionResponse:
+		ce, ok := decodeCostEvent(ev)
+		if !ok {
+			return ""
+		}
+		return "$" + formatUSD4(ce.CostUSD)
+	case pipeline.SessionRequest:
+		resp := pairedResponse(rows, partner, i, ev)
+		if resp == nil {
+			return ""
+		}
+		ps, ok := decodePruneSaving(ev)
+		if !ok {
+			return ""
+		}
+		total, ok := promptCost(ps, resp.Inference)
+		if !ok {
+			return ""
+		}
+		_, savedUSD, _ := savedTokensAndCost(ps, resp.Inference)
+		return formatUSDWithSaving(total, savedUSD, ps.Projected)
+	default:
 		return ""
 	}
-	return formatSavedOnly(tokens, usd, ps.RateSource, ps.Projected)
 }

--- a/authbridge/cmd/abctl/tui/local_preview_test.go
+++ b/authbridge/cmd/abctl/tui/local_preview_test.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/sessionapi"
+)
+
+// seedAgentTurns appends n request/response pairs shaped like a long-running
+// agent's traffic: a cache-heavy prompt that tool-prune trimmed, and a priced
+// response. Shared by the rendering check and the manual preview so what CI
+// asserts and what an operator eyeballs cannot drift.
+func seedAgentTurns(store *session.Store, sid string, n int) {
+	durations := []time.Duration{
+		23_970 * time.Millisecond, 9_460 * time.Millisecond,
+		53_660 * time.Millisecond, 25_500 * time.Millisecond,
+	}
+	for i := range n {
+		rid := fmt.Sprintf("turn-%02d", i)
+		// Prompt grows a little each turn, as a conversation does.
+		cacheRead := 680_000 + i*1_000
+		output := 1_850 + i*600
+		store.Append(sid, pipeline.SessionEvent{
+			At:        time.Now().Add(time.Duration(i) * 2 * time.Minute),
+			Direction: pipeline.Outbound,
+			Phase:     pipeline.SessionRequest,
+			RequestID: rid,
+			Host:      "ete-litellm.ai-mode.svc.cluster.local",
+			Inference: &pipeline.InferenceExtension{Model: "claude-opus-5"},
+			Plugins: map[string]json.RawMessage{
+				"tool-prune": json.RawMessage(bigPromptWire),
+			},
+			Invocations: &pipeline.Invocations{Outbound: []pipeline.Invocation{
+				{Plugin: "tool-prune", Action: pipeline.ActionModify, Reason: "tools_pruned"},
+			}},
+		})
+		cost := 0.2824 + float64(i)*0.03
+		store.Append(sid, pipeline.SessionEvent{
+			At:         time.Now().Add(time.Duration(i)*2*time.Minute + durations[i%len(durations)]),
+			Direction:  pipeline.Outbound,
+			Phase:      pipeline.SessionResponse,
+			RequestID:  rid,
+			Host:       "ete-litellm.ai-mode.svc.cluster.local",
+			StatusCode: 200,
+			Duration:   durations[i%len(durations)],
+			Inference: &pipeline.InferenceExtension{
+				Model: "claude-opus-5", InputTokens: 1_300, CacheReadTokens: cacheRead,
+				OutputTokens: output, TotalTokens: 1_300 + cacheRead + output,
+			},
+			Plugins: map[string]json.RawMessage{
+				"litellm-budget-track": json.RawMessage(fmt.Sprintf(
+					`{"cost_usd":%.4f,"source":"gateway-header","daily_total_usd":%.4f,"daily_max_usd":5}`,
+					cost, cost*float64(i+1))),
+			},
+			Invocations: &pipeline.Invocations{Outbound: []pipeline.Invocation{
+				{Plugin: "inference-parser", Action: pipeline.ActionObserve, Reason: "parsed"},
+			}},
+		})
+	}
+}
+
+// TestSplitColumnsRender drives the real row builder over seeded traffic and
+// asserts the TOKENS and COST cells land on the rows they belong to. This is the
+// regression guard for the split: a request row must carry a prompt total with
+// its saving, a response row the generated count and the exchange cost.
+func TestSplitColumnsRender(t *testing.T) {
+	store := session.New(5*time.Minute, 100, 0)
+	defer store.Close()
+	seedAgentTurns(store, "preview", 1)
+
+	view := store.View("preview")
+	if view == nil || len(view.Events) != 2 {
+		t.Fatalf("seeded view = %+v, want 2 events", view)
+	}
+	evs := view.Events
+	rows := []eventRow{{event: &evs[0]}, {event: &evs[1]}}
+	partner := map[int]int{0: 1, 1: 0}
+	m := &model{}
+
+	reqTokens := m.tokensCell(rows, partner, 0, &evs[0])
+	reqCost := m.costCell(rows, partner, 0, &evs[0])
+	respTokens := m.tokensCell(rows, partner, 1, &evs[1])
+	respCost := m.costCell(rows, partner, 1, &evs[1])
+
+	// Request: prompt total (1,300 + 680,000) with the saving in parentheses.
+	if reqTokens != "681,300(−9.9k)" {
+		t.Errorf("request TOKENS = %q, want %q", reqTokens, "681,300(−9.9k)")
+	}
+	if !strings.HasPrefix(reqCost, "$0.2633(−$") {
+		t.Errorf("request COST = %q, want a prompt total with a saving", reqCost)
+	}
+	// Response: generated tokens only, and the authoritative exchange cost.
+	if respTokens != "1,850" {
+		t.Errorf("response TOKENS = %q, want %q", respTokens, "1,850")
+	}
+	if respCost != "$0.2824" {
+		t.Errorf("response COST = %q, want %q", respCost, "$0.2824")
+	}
+	// The halves must not both claim the prompt: that was the pre-split bug.
+	if reqTokens == respTokens {
+		t.Error("both rows show the same token figure")
+	}
+}
+
+// TestLocalPreview is a manual affordance, not a CI test: it serves seeded
+// traffic on a fixed port so `abctl observe --endpoint` can render it without a
+// cluster, Keycloak, or a live LLM. Skipped unless ABCTL_PREVIEW is set.
+//
+//	ABCTL_PREVIEW=1 go test ./tui/ -run TestLocalPreview -v -timeout 0
+//	go run . observe --endpoint http://127.0.0.1:47699
+func TestLocalPreview(t *testing.T) {
+	if os.Getenv("ABCTL_PREVIEW") == "" {
+		t.Skip("manual preview; set ABCTL_PREVIEW=1 to serve seeded traffic")
+	}
+	const addr = "127.0.0.1:47699"
+	store := session.New(30*time.Minute, 100, 0)
+	defer store.Close()
+	seedAgentTurns(store, "preview", 4)
+
+	// Bind synchronously rather than inside the serving goroutine. Handing the
+	// address to ListenAndServe and only logging its error makes a bind failure
+	// — a stale server still holding the port is the common one — look identical
+	// to a healthy start: the test blocks below either way, and the operator
+	// sees "connection refused" from abctl with no hint why.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("cannot bind %s: %v\n"+
+			"Something else holds the port. Find it with: lsof -nP -iTCP:47699", addr, err)
+	}
+	srv := sessionapi.New(addr, store)
+	go func() {
+		if err := srv.Server().Serve(ln); err != nil {
+			t.Logf("preview server stopped: %v", err)
+		}
+	}()
+	t.Logf("READY: seeded 4 turns, serving http://%s", addr)
+	t.Logf("Now run:  GOWORK=off go run . observe --endpoint http://%s", addr)
+	t.Log("Ctrl-C to stop.")
+	select {} //nolint:staticcheck // blocks until the operator interrupts
+}

--- a/authbridge/cmd/abctl/tui/prune_saving.go
+++ b/authbridge/cmd/abctl/tui/prune_saving.go
@@ -107,3 +107,23 @@ func formatUSD(v float64) string {
 // Neither returns a "$" — the caller places it, since a saving needs it inside
 // the parentheses.
 func formatUSD4(v float64) string { return fmt.Sprintf("%.4f", v) }
+
+// usdFloor is the smallest amount four decimal places can state. Anything
+// positive below half of it rounds to "0.0000".
+const usdFloor = 0.0001
+
+// formatUSDCell renders a dollar amount for a table cell, with the "$" attached
+// and a floor below which it says so rather than rounding to zero.
+//
+// The floor exists because %.4f renders anything under $0.00005 as "$0.0000",
+// which reads as "this was free" — the exact reading decodeCostEvent (declining a
+// cost of 0) and promptCost (declining an unpriced model rather than showing
+// $0.00) both go out of their way to avoid. Reintroducing it at the formatting
+// layer would undo both. Reachable on a small cache-read-only request: 100
+// cache-read tokens at a typical rate is $0.000038.
+func formatUSDCell(v float64) string {
+	if v > 0 && v < usdFloor/2 {
+		return "<$" + formatUSD4(usdFloor)
+	}
+	return "$" + formatUSD4(v)
+}

--- a/authbridge/cmd/abctl/tui/prune_saving.go
+++ b/authbridge/cmd/abctl/tui/prune_saving.go
@@ -76,28 +76,6 @@ func savedTokensAndCost(ps pruneSaving, resp *pipeline.InferenceExtension) (toke
 	return tokens, tokens * rate, true
 }
 
-// formatSavedOnly renders a request row's saving: what was removed and what it
-// was worth. No total, because a request has no billed token count — that
-// belongs to the response, on its own row.
-//
-// A projected saving (on_error: observe, where the bytes were measured but not
-// removed) is prefixed "~" and drops the "−". Rendering it identically to a real
-// saving would invite an operator to add up money that was still spent, and
-// observe mode exists precisely to be trusted while it is not yet enforcing.
-func formatSavedOnly(tokens, usd float64, rateSource string, projected bool) string {
-	if tokens <= 0 {
-		return ""
-	}
-	cell := "−" + formatCompact(tokens)
-	if projected {
-		cell = "~" + formatCompact(tokens)
-	}
-	if usd > 0 && rateSource != "none" {
-		cell += fmt.Sprintf("  $%s", formatUSD(usd))
-	}
-	return cell
-}
-
 // formatCompact renders a token count tersely enough for a table cell: 10577
 // becomes "10.6k". Exact below 1000, where the extra digits still fit.
 func formatCompact(v float64) string {
@@ -123,3 +101,9 @@ func formatUSD(v float64) string {
 		return fmt.Sprintf("%.4f", v)
 	}
 }
+
+// formatUSD4 is formatUSD at fixed precision, for the case where two amounts of
+// different magnitude share one column and their decimal points must line up.
+// Neither returns a "$" — the caller places it, since a saving needs it inside
+// the parentheses.
+func formatUSD4(v float64) string { return fmt.Sprintf("%.4f", v) }

--- a/authbridge/cmd/abctl/tui/prune_saving_test.go
+++ b/authbridge/cmd/abctl/tui/prune_saving_test.go
@@ -88,31 +88,79 @@ func TestSavedTokensAndCost_TierDecidesTheValue(t *testing.T) {
 	}
 }
 
-// TestFormatSavedOnly: a request row carries the saving, not a total — the
-// billed token count belongs to the response, on its own row. Showing a saving
-// beside a response total read as though the response had shrunk, which it had
-// not.
-func TestFormatSavedOnly(t *testing.T) {
-	got := formatSavedOnly(10577.5, 0.05024, "default", false)
-	for _, want := range []string{"−10.6k", "$0.050"} {
+// TestFormatTokensWithSaving: a request row carries its prompt total with the
+// saving in parentheses. The total is exact-with-commas (a measured count) and
+// the saving compact (a derived estimate), so the two are not read as equally
+// precise.
+func TestFormatTokensWithSaving(t *testing.T) {
+	got := formatTokensWithSaving(681300, 10577.5, false)
+	for _, want := range []string{"681,300", "(−10.6k)"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("cell %q missing %q", got, want)
 		}
 	}
-	if strings.Contains(got, ",") {
-		t.Errorf("cell %q should carry no billed total", got)
+	// Nothing saved: a bare total, no empty parentheses.
+	if got := formatTokensWithSaving(681300, 0, false); got != "681,300" {
+		t.Errorf("no-saving cell = %q, want %q", got, "681,300")
 	}
-	// Nothing saved: an empty cell, so unrelated request rows stay blank.
-	if got := formatSavedOnly(0, 0, "default", false); got != "" {
-		t.Errorf("no-saving cell = %q, want empty", got)
+	// No total: blank, so rows without a paired response stay empty rather than
+	// rendering a lone "0".
+	if got := formatTokensWithSaving(0, 10577.5, false); got != "" {
+		t.Errorf("no-total cell = %q, want empty", got)
 	}
-	// Unpriced model: tokens shown, no dollar figure invented.
-	got = formatSavedOnly(10577.5, 0, "none", false)
-	if strings.Contains(got, "$") {
-		t.Errorf("cell %q shows a price for an unpriced model", got)
+}
+
+// TestFormatUSDWithSaving: both halves at fixed 4dp. formatUSD's variable
+// precision would render the total at 3dp and the saving at 4dp, misaligning the
+// decimal point in a single column and implying different accuracy.
+func TestFormatUSDWithSaving(t *testing.T) {
+	got := formatUSDWithSaving(0.2546, 0.0037, false)
+	if got != "$0.2546(−$0.0037)" {
+		t.Errorf("cell = %q, want %q", got, "$0.2546(−$0.0037)")
 	}
-	if !strings.Contains(got, "−10.6k") {
-		t.Errorf("cell %q should still show the token saving", got)
+	if got := formatUSDWithSaving(0.2546, 0, false); got != "$0.2546" {
+		t.Errorf("no-saving cell = %q, want %q", got, "$0.2546")
+	}
+	if got := formatUSDWithSaving(0, 0.0037, false); got != "" {
+		t.Errorf("no-total cell = %q, want empty", got)
+	}
+}
+
+// TestSavingSignProjected: an observe-mode figure must be visually distinct from
+// a realized one, or an operator adds up money that was still spent.
+func TestSavingSignProjected(t *testing.T) {
+	real := formatTokensWithSaving(681300, 10577.5, false)
+	proj := formatTokensWithSaving(681300, 10577.5, true)
+	if real == proj {
+		t.Fatalf("projected renders identically to realized: %q", real)
+	}
+	if !strings.Contains(proj, "(~") {
+		t.Errorf("projected cell %q should mark the saving with ~", proj)
+	}
+	if strings.Contains(proj, "−") {
+		t.Errorf("projected = %q, must not claim bytes were removed", proj)
+	}
+	realUSD := formatUSDWithSaving(0.2546, 0.0037, false)
+	projUSD := formatUSDWithSaving(0.2546, 0.0037, true)
+	if realUSD == projUSD {
+		t.Fatalf("projected cost renders identically to realized: %q", realUSD)
+	}
+	if strings.Contains(projUSD, "−") {
+		t.Errorf("projected cost = %q, must not claim money was not spent", projUSD)
+	}
+}
+
+// TestUnpricedModelShowsNoCost: RateSource "none" means no rate was resolvable,
+// so the COST cell must stay blank rather than invent a $0.00 that reads as a
+// free prompt. The tokens cell is unaffected — the count is still real.
+func TestUnpricedModelShowsNoCost(t *testing.T) {
+	resp := &pipeline.InferenceExtension{InputTokens: 100, CacheReadTokens: 500}
+	if _, ok := promptCost(pruneSaving{RateSource: "none", RateInput: 1e-6}, resp); ok {
+		t.Error("an unpriced model produced a cost figure")
+	}
+	// A resolved rate does price.
+	if _, ok := promptCost(pruneSaving{RateSource: "default", RateInput: 1e-6, RateCacheRead: 1e-7}, resp); !ok {
+		t.Error("a priced model produced no cost figure")
 	}
 }
 
@@ -161,10 +209,11 @@ func TestComputeEventPairs_DuplicateResponseStaysUnpaired(t *testing.T) {
 	}
 }
 
-// TestTokensCellWithSaving_RequiresAnIDMatch: pricing against a heuristically
-// matched response could take its cache tier from a different request, and the
-// tiers are ~12.5x apart — a wrong figure presented as a measurement.
-func TestTokensCellWithSaving_RequiresAnIDMatch(t *testing.T) {
+// TestRequestCells_RequireAnIDMatch: pricing against a heuristically matched
+// response could take its cache tier from a different request, and the tiers are
+// ~12.5x apart — a wrong figure presented as a measurement. Both request-side
+// cells must enforce it, since both read the paired response.
+func TestRequestCells_RequireAnIDMatch(t *testing.T) {
 	req := reqEvent(t, wire)
 	req.RequestID = "aaa"
 	resp := &pipeline.SessionEvent{
@@ -172,30 +221,21 @@ func TestTokensCellWithSaving_RequiresAnIDMatch(t *testing.T) {
 		Inference: &pipeline.InferenceExtension{CacheWriteTokens: 24701, TotalTokens: 33582},
 	}
 	rows := []eventRow{{event: req}, {event: resp}}
+	partner := map[int]int{0: 1, 1: 0}
 	m := &model{}
-	if got := m.tokensCellWithSaving(rows, map[int]int{0: 1, 1: 0}, 0, req); got != "" {
-		t.Errorf("priced against a mismatched response: %q", got)
+	if got := m.tokensCell(rows, partner, 0, req); got != "" {
+		t.Errorf("tokens priced against a mismatched response: %q", got)
+	}
+	if got := m.costCell(rows, partner, 0, req); got != "" {
+		t.Errorf("cost priced against a mismatched response: %q", got)
 	}
 	// Matching ids do price.
 	resp.RequestID = "aaa"
-	if got := m.tokensCellWithSaving(rows, map[int]int{0: 1, 1: 0}, 0, req); got == "" {
-		t.Error("an id-matched pair should price")
+	if got := m.tokensCell(rows, partner, 0, req); got == "" {
+		t.Error("an id-matched pair should show tokens")
 	}
-}
-
-// TestFormatSavedOnlyProjected: an observe-mode figure must be visually distinct
-// from a realized one, or an operator adds up money that was still spent.
-func TestFormatSavedOnlyProjected(t *testing.T) {
-	real := formatSavedOnly(10577.5, 0.05024, "default", false)
-	proj := formatSavedOnly(10577.5, 0.05024, "default", true)
-	if real == proj {
-		t.Fatalf("projected renders identically to realized: %q", real)
-	}
-	if !strings.HasPrefix(proj, "~") {
-		t.Errorf("projected = %q, want a leading ~", proj)
-	}
-	if strings.Contains(proj, "−") {
-		t.Errorf("projected = %q, must not claim bytes were removed", proj)
+	if got := m.costCell(rows, partner, 0, req); got == "" {
+		t.Error("an id-matched pair should show a cost")
 	}
 }
 


### PR DESCRIPTION
## Summary

The events pane packed three figures into one 24-wide `TOKENS / SAVED` cell, and put them on rows that didn't match what they described. A response row carried `TotalTokens`; a request row carried tool-prune's saving in both tokens and dollars.

Two problems with that:

- **`TotalTokens` conflates prompt and completion.** For a long-running agent the prompt dominates so completely (cache reads in the hundreds of thousands) that the column barely moves between turns, hiding the one component that actually varies. Real traffic: `683,150 → 683,349 → 686,335` across turns whose durations ranged 9s–54s.
- **The only dollar figure in the table was money _not_ spent**, with no per-request cost to compare it against.

Split into two columns, each row carrying the half it's responsible for:

```
#   TIME         DIR  PHASE  ACTION   PLUGIN            STATUS  DURATION  TOKENS           COST
1   17:20:29.88  out  req    modify   tool-prune                          681,300(−9.9k)   $0.2633(−$0.0038)
1   17:20:53.85  out  resp   observe  inference-parser  200     23.97s    1,850            $0.2824
2   17:22:29.88  out  req    modify   tool-prune                          682,300(−9.9k)   $0.2637(−$0.0038)
2   17:22:39.34  out  resp   observe  inference-parser  200     9.46s     2,450            $0.3124
```

Generated tokens now vary visibly turn to turn, which was the point.

## Design notes

**A request row can honestly show a total.** The prompt token count is a request-side quantity — it's merely _transported_ on the response, since the provider is the only party that tokenizes. So the request row reaches forward to its id-matched pair for it. Prompt + generated now sum to the billed total instead of one row repeating the other.

**Request-side cost is modelled per-tier** from the rates tool-prune already publishes (`rateInput` / `rateCacheRead` / `rateCacheWrite`). Flat prompt × single-rate would overstate cache-heavy traffic by close to an order of magnitude — ~$0.26 vs ~$2.59 on the traffic that motivated this.

**The response row shows the authoritative figure, so it _includes_ the request row's.** The two columns are deliberately not two halves of a sum. No plugin publishes an output rate: tool-prune omits one by design ("pruning only ever shrinks the prompt, so attributing output cost to it would be false"), and budget-track emits a finished total rather than its rates. Deriving completion cost by subtraction would concentrate all of the prompt model's error into it and can go negative. Documented on `costCell` so nobody adds the column up.

`METHOD` shrinks 22→14 to pay for the split; its widest realistic value is a model name.

## Dependency

**Response-side `COST` stays blank until #907 merges** — that's what puts `cost_usd` on the session event. Token columns and request-side cost work today, so 3 of the 4 cells are live on merge. Request-side cost also requires tool-prune in the pipeline, as it's the only plugin putting rates on the wire.

## Testing

```bash
cd authbridge/cmd/abctl
GOWORK=off go test -race ./...
```

Also adds a preview harness (skipped unless `ABCTL_PREVIEW=1`, so CI never runs it) that seeds a store and serves the real session API, letting the columns be driven through the real TUI with no cluster, Keycloak, or live LLM:

```bash
ABCTL_PREVIEW=1 GOWORK=off go test ./tui/ -run TestLocalPreview -v -timeout 0
GOWORK=off go run . observe --endpoint http://127.0.0.1:47699
```

It binds synchronously and fails loudly — logging the bind error from inside the serving goroutine made a port conflict look identical to a healthy start, which cost real debugging time.

Verified: `go vet` clean, `gofmt` clean, `go test -race ./...` green across the abctl module, and the full path exercised through the real `apiclient` against a live session API.

Tests cover the wire tags for #907's payload, the prompt+generated=total invariant, tier-weighting vs flat pricing, the projected-saving (`~` vs `−`) distinction, and the RequestID guard on both request-side cells.

## Related issue(s)

Builds on #907 (cost emission on the event stream) for the response-side cost.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events now display request and response details in separate rows.
  * Added distinct token and cost columns for clearer usage visibility.
  * Request rows show prompt tokens and estimated savings.
  * Response rows show generated tokens and exchange costs.
  * Note (corrected): daily cost totals and limits are decoded from the plugin event for wire
    coverage but are NOT displayed by this change.

* **Bug Fixes**
  * Improved handling of unpriced responses and unavailable cost data.
  * Corrected token and cost calculations for cache-heavy and tool-trimmed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
