### PR TITLE
Fix: Trust the bridge CA where it matters, and stop intercepting dev tooling

### DIFF
--- a/authbridge/authlib/listener/forwardproxy/tlsbridge_integration_test.go
+++ b/authbridge/authlib/listener/forwardproxy/tlsbridge_integration_test.go
@@ -20,6 +20,18 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
+// mustBridgeDecision builds a Decision for a single port. NewDecision grew an
+// error return when passthrough_hosts gained glob support; these tests pass no
+// patterns, so the only way it can fail is a bug in the shipped defaults.
+func mustBridgeDecision(t *testing.T, port int) *tlsbridge.Decision {
+	t.Helper()
+	d, err := tlsbridge.NewDecision(tlsbridge.DecisionOpts{Ports: map[int]bool{port: true}})
+	if err != nil {
+		t.Fatalf("NewDecision: %v", err)
+	}
+	return d
+}
+
 // bridgeProbePlugin records the decrypted request method/path/headers it sees.
 // It proves the UNCHANGED outbound pipeline runs on the plaintext request the
 // TLS bridge produced after terminating the agent's TLS — i.e. the bridge
@@ -107,9 +119,7 @@ func TestTransparentBridge(t *testing.T) {
 		t.Fatalf("NewUpstreamClient: %v", err)
 	}
 	engine := &tlsbridge.Engine{
-		Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-			Ports: map[int]bool{portOf(originHostPort): true},
-		}),
+		Decision: mustBridgeDecision(t, portOf(originHostPort)),
 		Term:     tlsbridge.NewTerminator(minter),
 		Skip:     tlsbridge.NewSkipSet(),
 		Upstream: up,
@@ -265,9 +275,7 @@ func TestTransparentBridge_CustomPort(t *testing.T) {
 	engine := &tlsbridge.Engine{
 		// Only the custom port is configured — proves both that it IS bridged
 		// (despite shouldSniff not knowing it) and that the default set is replaced.
-		Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-			Ports: map[int]bool{customPort: true},
-		}),
+		Decision: mustBridgeDecision(t, customPort),
 		Term:     tlsbridge.NewTerminator(minter),
 		Skip:     tlsbridge.NewSkipSet(),
 		Upstream: up,
@@ -379,9 +387,7 @@ func TestConnectBridge(t *testing.T) {
 		t.Fatalf("NewUpstreamClient: %v", err)
 	}
 	engine := &tlsbridge.Engine{
-		Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-			Ports: map[int]bool{portOf(originHostPort): true},
-		}),
+		Decision: mustBridgeDecision(t, portOf(originHostPort)),
 		Term:     tlsbridge.NewTerminator(minter),
 		Skip:     tlsbridge.NewSkipSet(),
 		Upstream: up,
@@ -570,9 +576,7 @@ func TestBridge_UnverifiableUpstream_FallsOpenToTunnel(t *testing.T) {
 		t.Fatalf("NewUpstreamClient: %v", err)
 	}
 	engine := &tlsbridge.Engine{
-		Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-			Ports: map[int]bool{portOf(originHostPort): true},
-		}),
+		Decision: mustBridgeDecision(t, portOf(originHostPort)),
 		Term:     tlsbridge.NewTerminator(minter),
 		Skip:     tlsbridge.NewSkipSet(),
 		Upstream: up,
@@ -708,9 +712,7 @@ func TestBridge_PinnedClient_AutoSkipsThenTunnels(t *testing.T) {
 		t.Fatalf("NewUpstreamClient: %v", err)
 	}
 	engine := &tlsbridge.Engine{
-		Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-			Ports: map[int]bool{portOf(originHostPort): true},
-		}),
+		Decision: mustBridgeDecision(t, portOf(originHostPort)),
 		Term:     tlsbridge.NewTerminator(minter),
 		Skip:     tlsbridge.NewSkipSet(),
 		Upstream: up,
@@ -872,9 +874,7 @@ func TestBridge_NonTLS_Passthrough(t *testing.T) {
 		t.Fatalf("NewUpstreamClient: %v", err)
 	}
 	engine := &tlsbridge.Engine{
-		Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-			Ports: map[int]bool{portOf(originHostPort): true},
-		}),
+		Decision: mustBridgeDecision(t, portOf(originHostPort)),
 		Term:     tlsbridge.NewTerminator(minter),
 		Skip:     tlsbridge.NewSkipSet(),
 		Upstream: up,

--- a/authbridge/authlib/tlsbridge/bundle.go
+++ b/authbridge/authlib/tlsbridge/bundle.go
@@ -2,6 +2,7 @@ package tlsbridge
 
 import (
 	"bytes"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"os"
@@ -88,8 +89,23 @@ func EnsureTrustBundle(caDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("tlsbridge: read bridge CA %s: %w", caPath, err)
 	}
+	bundlePath := filepath.Join(caDir, TrustBundleName)
 	rootsPath, rootsPEM, err := findSystemRoots()
 	if err != nil {
+		// A bundle from an earlier boot is deliberately LEFT IN PLACE, and the
+		// error names it so the caller's warning can too.
+		//
+		// Deleting it would be worse than the staleness it removes. Four env vars
+		// point at this file, and each REPLACES its tool's trust store, so an
+		// absent bundle does not fall back to the platform roots — git, curl and
+		// Python fail every TLS call outright ("error setting certificate verify
+		// locations"). That trades a slightly outdated root list for total loss of
+		// egress, on a path that is already only reached when the host's own root
+		// store cannot be found.
+		if _, serr := os.Stat(bundlePath); serr == nil {
+			return "", fmt.Errorf("%w; keeping the existing %s, whose platform roots are now "+
+				"unverifiable and may include roots this host no longer trusts", err, bundlePath)
+		}
 		return "", err
 	}
 
@@ -101,7 +117,6 @@ func EnsureTrustBundle(caDir string) (string, error) {
 	buf.WriteString("# --- platform roots from " + rootsPath + " ---\n")
 	buf.Write(ensureTrailingNewline(rootsPEM))
 
-	bundlePath := filepath.Join(caDir, TrustBundleName)
 	if existing, rerr := os.ReadFile(bundlePath); rerr == nil && bytes.Equal(existing, buf.Bytes()) {
 		return bundlePath, nil
 	}
@@ -113,17 +128,23 @@ func EnsureTrustBundle(caDir string) (string, error) {
 	return bundlePath, nil
 }
 
-// findSystemRoots returns the first readable entry in systemRootFiles along with
-// its contents. A file that exists but holds no certificate is skipped rather
-// than accepted: some minimal images ship an empty placeholder, and treating
-// that as success would produce a CA-only bundle by a different route.
+// findSystemRoots returns the first entry in systemRootFiles that is readable
+// AND holds at least one certificate Go can parse.
+//
+// Parsing, rather than looking for the BEGIN line: a file containing the header
+// but truncated or corrupt body would pass a substring check and produce a
+// bundle with the bridge CA and no usable public roots — which is the CA-only
+// trust store this whole mechanism exists to avoid, arrived at by a different
+// route. AppendCertsFromPEM reports whether anything parsed, which is exactly
+// the question. Some minimal images also ship an empty placeholder at a
+// well-known path, and that is caught by the same check.
 func findSystemRoots() (string, []byte, error) {
 	for _, p := range systemRootFiles {
 		data, err := os.ReadFile(p) //nolint:gosec // fixed list of well-known paths
 		if err != nil {
 			continue
 		}
-		if !bytes.Contains(data, []byte("-----BEGIN CERTIFICATE-----")) {
+		if !x509.NewCertPool().AppendCertsFromPEM(data) {
 			continue
 		}
 		return p, data, nil

--- a/authbridge/authlib/tlsbridge/bundle.go
+++ b/authbridge/authlib/tlsbridge/bundle.go
@@ -1,0 +1,132 @@
+package tlsbridge
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// TrustBundleName is the file EnsureTrustBundle writes inside a CA dir. It holds
+// the bridge CA followed by the platform's trusted roots.
+//
+// It exists because ca.crt on its own is only usable by tools whose CA setting
+// is ADDITIVE. Node's NODE_EXTRA_CA_CERTS is — the name says so — but almost
+// every other tool REPLACES its trust store with what you point it at:
+//
+//	SSL_CERT_FILE      Go (gh, abctl, any Go CLI)
+//	GIT_SSL_CAINFO     git
+//	REQUESTS_CA_BUNDLE Python requests
+//	CURL_CA_BUNDLE     curl
+//
+// Pointing those at ca.crt makes the process trust the bridge CA and NOTHING
+// else, so every direct (unproxied) TLS connection fails. Go's own loader is
+// explicit about it — crypto/x509 root_unix.go does `files = []string{f}` when
+// SSL_CERT_FILE is set, discarding the defaults. The failure is platform-split
+// and therefore easy to ship by accident: macOS uses root_darwin.go and the
+// platform verifier, so a bare ca.crt appears to work there while breaking
+// every Linux machine and CI runner.
+const TrustBundleName = "bundle.crt"
+
+// systemRootFiles are the locations that ship a concatenated PEM of the
+// platform's trusted roots. Mirrors the list crypto/x509, OpenSSL, curl and git
+// probe, so the bundle we assemble is the same trust set the tool would have
+// used had we not overridden it.
+//
+// macOS has no such file for its keychain, but Apple ships LibreSSL's copy at
+// /etc/ssl/cert.pem, which is the same list — and the tools that need this
+// bundle (git, curl, Python) are the ones that read files rather than the
+// keychain anyway.
+var systemRootFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian, Ubuntu, Gentoo, Alpine
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora, RHEL 6
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // RHEL 7+, CentOS
+	"/etc/ssl/ca-bundle.pem",                            // openSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/ssl/cert.pem",                                 // macOS (LibreSSL), Alpine, OpenBSD
+	"/usr/local/etc/ssl/cert.pem",                       // FreeBSD
+}
+
+// ErrNoSystemRoots means no platform root bundle could be located, so no trust
+// bundle was written.
+//
+// Deliberately an error rather than a fallback to "the bridge CA alone": that
+// file is the dangerous artifact this whole mechanism exists to avoid, and
+// writing it would hand every tool a trust store containing one private CA. A
+// missing bundle degrades to "tools keep their own trust and cannot verify the
+// bridge", which is a visible, recoverable failure. The inverse — silently
+// distrusting the public internet — is neither.
+var ErrNoSystemRoots = errors.New("tlsbridge: no system root bundle found")
+
+// EnsureTrustBundle writes <caDir>/bundle.crt as the bridge CA (<caDir>/ca.crt)
+// followed by the platform's trusted roots, and returns its path.
+//
+// Idempotent: a bundle whose content already matches is left alone, so calling
+// this on every boot neither churns the file nor disturbs a process that has it
+// open. Rewrites when the CA has rotated or the system roots have been updated.
+//
+// Callers must treat failure as non-fatal. The bridge itself works without a
+// bundle — only the clients' ability to verify it is affected — so a boot that
+// cannot assemble one should warn and continue, not exit.
+func EnsureTrustBundle(caDir string) (string, error) {
+	if caDir == "" {
+		return "", errors.New("tlsbridge: empty ca_dir")
+	}
+	caPath := filepath.Join(caDir, "ca.crt")
+	caPEM, err := os.ReadFile(caPath) //nolint:gosec // operator-supplied ca_dir
+	if err != nil {
+		return "", fmt.Errorf("tlsbridge: read bridge CA %s: %w", caPath, err)
+	}
+	rootsPath, rootsPEM, err := findSystemRoots()
+	if err != nil {
+		return "", err
+	}
+
+	// CA first: a verifier that stops at the first match spends no time walking
+	// the public roots to find ours, and a human running `head` on the file sees
+	// which CA was grafted in.
+	var buf bytes.Buffer
+	buf.Write(ensureTrailingNewline(caPEM))
+	buf.WriteString("# --- platform roots from " + rootsPath + " ---\n")
+	buf.Write(ensureTrailingNewline(rootsPEM))
+
+	bundlePath := filepath.Join(caDir, TrustBundleName)
+	if existing, rerr := os.ReadFile(bundlePath); rerr == nil && bytes.Equal(existing, buf.Bytes()) {
+		return bundlePath, nil
+	}
+	// 0644 like ca.crt: this is public trust material, and every tool reading it
+	// runs as the user or as another service account.
+	if werr := atomicWriteFile(bundlePath, buf.Bytes(), 0o644); werr != nil {
+		return "", fmt.Errorf("tlsbridge: write trust bundle %s: %w", bundlePath, werr)
+	}
+	return bundlePath, nil
+}
+
+// findSystemRoots returns the first readable entry in systemRootFiles along with
+// its contents. A file that exists but holds no certificate is skipped rather
+// than accepted: some minimal images ship an empty placeholder, and treating
+// that as success would produce a CA-only bundle by a different route.
+func findSystemRoots() (string, []byte, error) {
+	for _, p := range systemRootFiles {
+		data, err := os.ReadFile(p) //nolint:gosec // fixed list of well-known paths
+		if err != nil {
+			continue
+		}
+		if !bytes.Contains(data, []byte("-----BEGIN CERTIFICATE-----")) {
+			continue
+		}
+		return p, data, nil
+	}
+	return "", nil, ErrNoSystemRoots
+}
+
+// ensureTrailingNewline guards the concatenation boundary: a PEM file whose last
+// line lacks a newline would otherwise splice its END line onto the next BEGIN,
+// and every certificate after that point silently fails to parse.
+func ensureTrailingNewline(b []byte) []byte {
+	if len(b) == 0 || b[len(b)-1] == '\n' {
+		return b
+	}
+	return append(append([]byte(nil), b...), '\n')
+}

--- a/authbridge/authlib/tlsbridge/bundle.go
+++ b/authbridge/authlib/tlsbridge/bundle.go
@@ -64,7 +64,17 @@ var ErrNoSystemRoots = errors.New("tlsbridge: no system root bundle found")
 //
 // Idempotent: a bundle whose content already matches is left alone, so calling
 // this on every boot neither churns the file nor disturbs a process that has it
-// open. Rewrites when the CA has rotated or the system roots have been updated.
+// open. It re-reads both inputs, so a rotated CA or an updated root store is
+// picked up — but only AT A CALL, and the only caller is the proxy at startup.
+// For a service documented to run for weeks, that makes this a snapshot taken at
+// boot, not a view of the store.
+//
+// The direction that matters is root REMOVAL: once the OS distrusts a root,
+// every tool pointed at bundle.crt keeps trusting it until the proxy restarts,
+// and nothing surfaces that. Addition is the benign half — a root added after
+// boot is simply absent, and absence fails closed. Re-assembling on an interval
+// would close the gap, and the content comparison above already makes that free
+// of churn; it is not done yet because nothing has needed it.
 //
 // Callers must treat failure as non-fatal. The bridge itself works without a
 // bundle — only the clients' ability to verify it is affected — so a boot that

--- a/authbridge/authlib/tlsbridge/bundle.go
+++ b/authbridge/authlib/tlsbridge/bundle.go
@@ -5,8 +5,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // TrustBundleName is the file EnsureTrustBundle writes inside a CA dir. It holds
@@ -16,7 +18,7 @@ import (
 // is ADDITIVE. Node's NODE_EXTRA_CA_CERTS is — the name says so — but almost
 // every other tool REPLACES its trust store with what you point it at:
 //
-//	SSL_CERT_FILE      Go (gh, abctl, any Go CLI)
+//	SSL_CERT_FILE      Go (gh, abctl, any Go CLI) — Linux/CI only, see below
 //	GIT_SSL_CAINFO     git
 //	REQUESTS_CA_BUNDLE Python requests
 //	CURL_CA_BUNDLE     curl
@@ -24,10 +26,24 @@ import (
 // Pointing those at ca.crt makes the process trust the bridge CA and NOTHING
 // else, so every direct (unproxied) TLS connection fails. Go's own loader is
 // explicit about it — crypto/x509 root_unix.go does `files = []string{f}` when
-// SSL_CERT_FILE is set, discarding the defaults. The failure is platform-split
-// and therefore easy to ship by accident: macOS uses root_darwin.go and the
-// platform verifier, so a bare ca.crt appears to work there while breaking
-// every Linux machine and CI runner.
+// SSL_CERT_FILE is set, discarding the defaults.
+//
+// SSL_CERT_FILE DOES NOTHING ON macOS, so on that platform this bundle serves
+// git, curl and Python but not Go. root_unix.go, the file quoted above, is built
+// for `linux || freebsd || …` and excludes darwin; darwin's loadSystemRoots
+// returns a `systemPool: true` sentinel that reads no file at all, and verify.go
+// then routes any program that has not set RootCAs to systemVerify —
+// Security.framework, keychain only. No environment variable reaches it.
+//
+// That is worth stating precisely because the obvious reading is the wrong way
+// round: it is NOT that darwin honours the variable and a bare CA happens to be
+// harmless there. The variable is ignored outright, which is why a bare ca.crt
+// looks fine on a Mac and breaks every Linux machine and CI runner.
+//
+// A Go program that wants the bridge CA on macOS has to opt in in-process, via
+// x509.SystemCertPool() plus AppendCertsFromPEM — verify.go falls through to the
+// pure-Go verifier with those extra roots when the platform verifier fails. That
+// is available to code we compile and not to a third-party binary like gh.
 const TrustBundleName = "bundle.crt"
 
 // systemRootFiles are the locations that ship a concatenated PEM of the
@@ -59,6 +75,18 @@ var systemRootFiles = []string{
 // bridge", which is a visible, recoverable failure. The inverse — silently
 // distrusting the public internet — is neither.
 var ErrNoSystemRoots = errors.New("tlsbridge: no system root bundle found")
+
+// ErrCADirNotWritable means the bundle could not be written because ca_dir is
+// read-only or otherwise not writable by this process.
+//
+// Distinguished from every other failure because it is the NORMAL, expected
+// outcome in-cluster and must not be reported as a problem there. In a cluster
+// ca_dir is an operator-mounted cert-manager Secret, and Kubernetes mounts Secret
+// volumes read-only, so the write cannot succeed — while a sidecar has no use for
+// the bundle anyway: it exists so a developer's git/curl/Python can verify a
+// laptop bridge. Without this distinction the caller warns about four
+// laptop-only environment variables on every production boot.
+var ErrCADirNotWritable = errors.New("tlsbridge: ca_dir is not writable")
 
 // EnsureTrustBundle writes <caDir>/bundle.crt as the bridge CA (<caDir>/ca.crt)
 // followed by the platform's trusted roots, and returns its path.
@@ -123,9 +151,25 @@ func EnsureTrustBundle(caDir string) (string, error) {
 	// 0644 like ca.crt: this is public trust material, and every tool reading it
 	// runs as the user or as another service account.
 	if werr := atomicWriteFile(bundlePath, buf.Bytes(), 0o644); werr != nil {
+		// A read-only ca_dir is the in-cluster norm, not a fault: classify it so
+		// the caller can report it at the right level instead of warning about
+		// laptop tooling on every production start.
+		if isNotWritable(werr) {
+			return "", fmt.Errorf("%w: %s: %w", ErrCADirNotWritable, bundlePath, werr)
+		}
 		return "", fmt.Errorf("tlsbridge: write trust bundle %s: %w", bundlePath, werr)
 	}
 	return bundlePath, nil
+}
+
+// isNotWritable reports whether err is the filesystem refusing the write, as
+// opposed to any other I/O failure.
+//
+// EROFS covers a read-only mount (a Kubernetes Secret volume), EACCES/EPERM a
+// directory this user cannot write. fs.ErrPermission catches the latter pair
+// portably; EROFS has no fs sentinel and is matched directly.
+func isNotWritable(err error) bool {
+	return errors.Is(err, fs.ErrPermission) || errors.Is(err, syscall.EROFS)
 }
 
 // findSystemRoots returns the first entry in systemRootFiles that is readable

--- a/authbridge/authlib/tlsbridge/bundle.go
+++ b/authbridge/authlib/tlsbridge/bundle.go
@@ -8,6 +8,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"syscall"
 )
 
@@ -47,9 +49,10 @@ import (
 const TrustBundleName = "bundle.crt"
 
 // systemRootFiles are the locations that ship a concatenated PEM of the
-// platform's trusted roots. Mirrors the list crypto/x509, OpenSSL, curl and git
-// probe, so the bundle we assemble is the same trust set the tool would have
-// used had we not overridden it.
+// platform's trusted roots: the concatenated bundles distributions ship. Consulted
+// AFTER SSL_CERT_FILE and BEFORE the cert directories, matching the order
+// crypto/x509 and OpenSSL use — see findSystemRootsFrom, which owns that order and
+// is where the claim about matching the tools' own trust set actually holds.
 //
 // macOS has no such file for its keychain, but Apple ships LibreSSL's copy at
 // /etc/ssl/cert.pem, which is the same list — and the tools that need this
@@ -118,7 +121,7 @@ func EnsureTrustBundle(caDir string) (string, error) {
 		return "", fmt.Errorf("tlsbridge: read bridge CA %s: %w", caPath, err)
 	}
 	bundlePath := filepath.Join(caDir, TrustBundleName)
-	rootsPath, rootsPEM, err := findSystemRoots()
+	rootsPath, rootsPEM, err := findSystemRootsFrom(bundlePath)
 	if err != nil {
 		// A bundle from an earlier boot is deliberately LEFT IN PLACE, and the
 		// error names it so the caller's warning can too.
@@ -183,17 +186,119 @@ func isNotWritable(err error) bool {
 // the question. Some minimal images also ship an empty placeholder at a
 // well-known path, and that is caught by the same check.
 func findSystemRoots() (string, []byte, error) {
+	return findSystemRootsFrom("")
+}
+
+// findSystemRootsFrom is findSystemRoots with the bundle path we are about to write,
+// so it can refuse to treat its own output as a platform root source. Pass "" when
+// there is nothing to exclude.
+//
+// Order matters and mirrors the consumers rather than convenience:
+//
+//  1. SSL_CERT_FILE — crypto/x509 does `files = []string{f}` when it is set
+//     (root_unix.go), replacing the built-in list entirely; OpenSSL and LibreSSL
+//     honour it too. A host that sets it has told every tool where its trust lives.
+//  2. systemRootFiles — the concatenated bundles distributions ship.
+//  3. SSL_CERT_DIR, else the standard cert directories — hosts that populate
+//     /etc/ssl/certs/ as hashed symlinks WITHOUT also shipping
+//     ca-certificates.crt match nothing in step 2. Before this, such a host got
+//     ErrNoSystemRoots and a warning that there was "no safe file to point at",
+//     on a machine with a complete trust store — which reads as a Cortex bug.
+func findSystemRootsFrom(exclude string) (string, []byte, error) {
+	if f := os.Getenv("SSL_CERT_FILE"); f != "" && !sameFile(f, exclude) {
+		if data, err := os.ReadFile(f); err == nil && parseable(data) { //nolint:gosec // operator-supplied
+			return f, data, nil
+		}
+	}
 	for _, p := range systemRootFiles {
-		data, err := os.ReadFile(p) //nolint:gosec // fixed list of well-known paths
-		if err != nil {
+		if sameFile(p, exclude) {
 			continue
 		}
-		if !x509.NewCertPool().AppendCertsFromPEM(data) {
+		data, err := os.ReadFile(p) //nolint:gosec // fixed list of well-known paths
+		if err != nil || !parseable(data) {
 			continue
 		}
 		return p, data, nil
 	}
+	dirs := certDirectories
+	if d := os.Getenv("SSL_CERT_DIR"); d != "" {
+		// OpenSSL and BoringSSL both split on ":", and so does crypto/x509.
+		dirs = strings.Split(d, ":")
+	}
+	for _, dir := range dirs {
+		if data, err := concatCertDir(dir, exclude); err == nil && parseable(data) {
+			return dir, data, nil
+		}
+	}
 	return "", nil, ErrNoSystemRoots
+}
+
+// certDirectories mirrors crypto/x509's list for the same platforms. Only consulted
+// when no concatenated bundle was found.
+var certDirectories = []string{
+	"/etc/ssl/certs",               // SLES10/11, Debian, Ubuntu, Alpine
+	"/etc/pki/tls/certs",           // Fedora, RHEL
+	"/system/etc/security/cacerts", // Android
+}
+
+// concatCertDir joins every parseable certificate file in dir. Files are sorted so
+// the output is stable across boots — the caller skips the write when content is
+// unchanged, and an unstable order would rewrite the bundle on every start.
+func concatCertDir(dir, exclude string) ([]byte, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	var buf bytes.Buffer
+	for _, name := range names {
+		full := filepath.Join(dir, name)
+		if sameFile(full, exclude) {
+			continue
+		}
+		data, rerr := os.ReadFile(full) //nolint:gosec // operator-supplied directory
+		if rerr != nil || !parseable(data) {
+			// Hashed-symlink dirs also hold .0 CRL files and dangling links.
+			continue
+		}
+		buf.Write(ensureTrailingNewline(data))
+	}
+	if buf.Len() == 0 {
+		return nil, ErrNoSystemRoots
+	}
+	return buf.Bytes(), nil
+}
+
+// parseable reports whether data holds at least one certificate x509 can use.
+func parseable(data []byte) bool {
+	return x509.NewCertPool().AppendCertsFromPEM(data)
+}
+
+// sameFile reports whether a and b name the same file, so the bundle we are about to
+// write is never read back in as a "platform root" source. Without this, a proxy
+// started with SSL_CERT_FILE pointing at its own bundle.crt would re-embed the
+// previous bundle on every boot, and a CA rotated out of ca.crt would stay trusted
+// indefinitely — the one trust-lifetime bug this file exists to prevent.
+func sameFile(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	fa, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fa, fb)
 }
 
 // ensureTrailingNewline guards the concatenation boundary: a PEM file whose last

--- a/authbridge/authlib/tlsbridge/bundle_sources_test.go
+++ b/authbridge/authlib/tlsbridge/bundle_sources_test.go
@@ -1,0 +1,111 @@
+package tlsbridge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFindSystemRoots_HonoursSSLCertFile: crypto/x509 does `files = []string{f}` when
+// SSL_CERT_FILE is set, replacing its built-in list; OpenSSL honours it too. A host
+// that sets it has told every tool where its trust lives, so assembling a bundle from
+// a different list would hand tools a trust set they were not using.
+func TestFindSystemRoots_HonoursSSLCertFile(t *testing.T) {
+	pem := realPEM(t)
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "custom-roots.pem")
+	if err := os.WriteFile(custom, pem, 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("SSL_CERT_FILE", custom)
+	t.Setenv("SSL_CERT_DIR", "")
+	withSystemRoots(t, nil) // outcome must not depend on the host's own store
+
+	path, data, err := findSystemRootsFrom("")
+	if err != nil {
+		t.Fatalf("findSystemRootsFrom: %v", err)
+	}
+	if path != custom {
+		t.Errorf("path = %q, want the SSL_CERT_FILE path %q", path, custom)
+	}
+	if len(data) == 0 {
+		t.Error("no data returned")
+	}
+}
+
+// TestFindSystemRoots_HonoursSSLCertDir covers the case that previously failed on a
+// complete host: hashed-symlink directories with no concatenated ca-certificates.crt
+// matched nothing, produced ErrNoSystemRoots, and warned there was "no safe file to
+// point at" — which reads as a Cortex bug.
+func TestFindSystemRoots_HonoursSSLCertDir(t *testing.T) {
+	pem := realPEM(t)
+	dir := t.TempDir()
+	for _, n := range []string{"aaa.pem", "bbb.pem"} {
+		if err := os.WriteFile(filepath.Join(dir, n), pem, 0o644); err != nil { //nolint:gosec
+			t.Fatal(err)
+		}
+	}
+	// A CRL-ish file and an unparseable one must be skipped, not fatal.
+	if err := os.WriteFile(filepath.Join(dir, "junk.0"), []byte("not a cert"), 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("SSL_CERT_FILE", "")
+	t.Setenv("SSL_CERT_DIR", dir)
+	withSystemRoots(t, nil) // force the directory path to be the one that answers
+
+	path, data, err := findSystemRootsFrom("")
+	if err != nil {
+		t.Fatalf("findSystemRootsFrom: %v", err)
+	}
+	if path != dir {
+		t.Errorf("path = %q, want the SSL_CERT_DIR %q", path, dir)
+	}
+	if !parseable(data) {
+		t.Error("concatenated directory output is not parseable")
+	}
+}
+
+// TestFindSystemRoots_NeverReadsItsOwnBundle is the trust-lifetime guard. A proxy
+// started with SSL_CERT_FILE pointing at its own bundle.crt would otherwise re-embed
+// the previous bundle every boot, so a CA rotated out of ca.crt would stay trusted
+// indefinitely.
+func TestFindSystemRoots_NeverReadsItsOwnBundle(t *testing.T) {
+	pem := realPEM(t)
+	dir := t.TempDir()
+	bundle := filepath.Join(dir, TrustBundleName)
+	if err := os.WriteFile(bundle, pem, 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("SSL_CERT_FILE", bundle)
+	t.Setenv("SSL_CERT_DIR", filepath.Join(dir, "nonexistent"))
+	withSystemRoots(t, nil)
+
+	path, _, err := findSystemRootsFrom(bundle)
+	if err == nil && path == bundle {
+		t.Fatal("read its own bundle back as a platform root source")
+	}
+	// Either it found a real platform bundle on this host, or it found none. Both
+	// are acceptable; returning OUR bundle is not.
+	if path == bundle {
+		t.Errorf("path = %q, which is the bundle being written", path)
+	}
+}
+
+// TestFindSystemRoots_SkipsUnparseableSSLCertFile: a set-but-broken SSL_CERT_FILE must
+// fall through to the platform list rather than producing a bundle with no usable
+// roots, which would fail every public TLS call.
+func TestFindSystemRoots_SkipsUnparseableSSLCertFile(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(bad, []byte("-----BEGIN CERTIFICATE-----\nnope\n"), 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("SSL_CERT_FILE", bad)
+	t.Setenv("SSL_CERT_DIR", "")
+	withSystemRoots(t, nil)
+
+	path, _, err := findSystemRootsFrom("")
+	if err == nil && path == bad {
+		t.Error("accepted an unparseable SSL_CERT_FILE")
+	}
+}

--- a/authbridge/authlib/tlsbridge/bundle_sources_test.go
+++ b/authbridge/authlib/tlsbridge/bundle_sources_test.go
@@ -17,9 +17,9 @@ func TestFindSystemRoots_HonoursSSLCertFile(t *testing.T) {
 	if err := os.WriteFile(custom, pem, 0o644); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
+	isolateRootSources(t) // outcome must not depend on the host's own store
 	t.Setenv("SSL_CERT_FILE", custom)
 	t.Setenv("SSL_CERT_DIR", "")
-	withSystemRoots(t, nil) // outcome must not depend on the host's own store
 
 	path, data, err := findSystemRootsFrom("")
 	if err != nil {
@@ -49,9 +49,9 @@ func TestFindSystemRoots_HonoursSSLCertDir(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "junk.0"), []byte("not a cert"), 0o644); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
+	isolateRootSources(t) // force the directory path to be the one that answers
 	t.Setenv("SSL_CERT_FILE", "")
 	t.Setenv("SSL_CERT_DIR", dir)
-	withSystemRoots(t, nil) // force the directory path to be the one that answers
 
 	path, data, err := findSystemRootsFrom("")
 	if err != nil {
@@ -76,9 +76,9 @@ func TestFindSystemRoots_NeverReadsItsOwnBundle(t *testing.T) {
 	if err := os.WriteFile(bundle, pem, 0o644); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
+	isolateRootSources(t)
 	t.Setenv("SSL_CERT_FILE", bundle)
 	t.Setenv("SSL_CERT_DIR", filepath.Join(dir, "nonexistent"))
-	withSystemRoots(t, nil)
 
 	path, _, err := findSystemRootsFrom(bundle)
 	if err == nil && path == bundle {
@@ -100,9 +100,9 @@ func TestFindSystemRoots_SkipsUnparseableSSLCertFile(t *testing.T) {
 	if err := os.WriteFile(bad, []byte("-----BEGIN CERTIFICATE-----\nnope\n"), 0o644); err != nil { //nolint:gosec
 		t.Fatal(err)
 	}
+	isolateRootSources(t)
 	t.Setenv("SSL_CERT_FILE", bad)
 	t.Setenv("SSL_CERT_DIR", "")
-	withSystemRoots(t, nil)
 
 	path, _, err := findSystemRootsFrom("")
 	if err == nil && path == bad {

--- a/authbridge/authlib/tlsbridge/bundle_test.go
+++ b/authbridge/authlib/tlsbridge/bundle_test.go
@@ -1,0 +1,215 @@
+package tlsbridge
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeCA and fakeRoots stand in for real PEM: EnsureTrustBundle concatenates
+// rather than parses, so the bytes only need the BEGIN marker findSystemRoots
+// looks for.
+const (
+	fakeCA    = "-----BEGIN CERTIFICATE-----\nCORTEXCA\n-----END CERTIFICATE-----\n"
+	fakeRoots = "-----BEGIN CERTIFICATE-----\nPUBLICROOT\n-----END CERTIFICATE-----\n"
+)
+
+// withSystemRoots points the package at a temp root store for the duration of a
+// test, so a test's outcome does not depend on what the host happens to ship.
+func withSystemRoots(t *testing.T, contents string) {
+	t.Helper()
+	orig := systemRootFiles
+	t.Cleanup(func() { systemRootFiles = orig })
+	if contents == "" {
+		systemRootFiles = []string{filepath.Join(t.TempDir(), "absent.pem")}
+		return
+	}
+	p := filepath.Join(t.TempDir(), "roots.pem")
+	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	systemRootFiles = []string{p}
+}
+
+func caDirWith(t *testing.T, ca string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if ca != "" {
+		if err := os.WriteFile(filepath.Join(dir, "ca.crt"), []byte(ca), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// TestEnsureTrustBundle_ContainsBothTrustSets is the whole point: a tool pointed
+// at this file must trust the bridge AND the public internet. A bundle holding
+// only one of them is the bug.
+func TestEnsureTrustBundle_ContainsBothTrustSets(t *testing.T) {
+	withSystemRoots(t, fakeRoots)
+	dir := caDirWith(t, fakeCA)
+
+	path, err := EnsureTrustBundle(dir)
+	if err != nil {
+		t.Fatalf("EnsureTrustBundle: %v", err)
+	}
+	if got := filepath.Base(path); got != TrustBundleName {
+		t.Errorf("bundle name = %q, want %q", got, TrustBundleName)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("CORTEXCA")) {
+		t.Error("bundle is missing the bridge CA")
+	}
+	if !bytes.Contains(data, []byte("PUBLICROOT")) {
+		t.Error("bundle is missing the platform roots — every direct TLS call would fail")
+	}
+	if n := strings.Count(string(data), "BEGIN CERTIFICATE"); n != 2 {
+		t.Errorf("certificate count = %d, want 2", n)
+	}
+	// CA first, so a verifier finds it without walking the public roots.
+	if bytes.Index(data, []byte("CORTEXCA")) > bytes.Index(data, []byte("PUBLICROOT")) {
+		t.Error("bridge CA should precede the platform roots")
+	}
+}
+
+// TestEnsureTrustBundle_NoSystemRootsWritesNothing: the failure mode that matters.
+// Falling back to a CA-only bundle would hand every tool a trust store containing
+// one private CA — silently distrusting the public internet, which is far worse
+// than not being able to verify the bridge.
+func TestEnsureTrustBundle_NoSystemRootsWritesNothing(t *testing.T) {
+	withSystemRoots(t, "")
+	dir := caDirWith(t, fakeCA)
+
+	_, err := EnsureTrustBundle(dir)
+	if !errors.Is(err, ErrNoSystemRoots) {
+		t.Fatalf("error = %v, want ErrNoSystemRoots", err)
+	}
+	if _, serr := os.Stat(filepath.Join(dir, TrustBundleName)); serr == nil {
+		t.Fatal("a CA-only bundle was written; it must not exist at all")
+	}
+}
+
+// TestEnsureTrustBundle_EmptyRootFileIsSkipped: some minimal images ship an empty
+// placeholder at a well-known path. Accepting it would produce a CA-only bundle
+// by a different route than the check above.
+func TestEnsureTrustBundle_EmptyRootFileIsSkipped(t *testing.T) {
+	orig := systemRootFiles
+	t.Cleanup(func() { systemRootFiles = orig })
+	empty := filepath.Join(t.TempDir(), "empty.pem")
+	if err := os.WriteFile(empty, []byte("# no certs here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(t.TempDir(), "real.pem")
+	if err := os.WriteFile(real, []byte(fakeRoots), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	systemRootFiles = []string{empty, real}
+
+	dir := caDirWith(t, fakeCA)
+	path, err := EnsureTrustBundle(dir)
+	if err != nil {
+		t.Fatalf("EnsureTrustBundle: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !bytes.Contains(data, []byte("PUBLICROOT")) {
+		t.Error("skipped past the empty placeholder to the real store, but the roots are absent")
+	}
+}
+
+// TestEnsureTrustBundle_Idempotent: called on every boot, so an unchanged bundle
+// must not be rewritten — that would churn the mtime and disturb a reader holding
+// it open.
+func TestEnsureTrustBundle_Idempotent(t *testing.T) {
+	withSystemRoots(t, fakeRoots)
+	dir := caDirWith(t, fakeCA)
+
+	path, err := EnsureTrustBundle(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = EnsureTrustBundle(dir); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.ModTime().Equal(second.ModTime()) {
+		t.Error("unchanged bundle was rewritten")
+	}
+}
+
+// TestEnsureTrustBundle_RewritesAfterCARotation: the flip side of idempotency. A
+// stale bundle after the CA is regenerated would leave every tool unable to verify
+// the bridge, with a file that looks present and correct.
+func TestEnsureTrustBundle_RewritesAfterCARotation(t *testing.T) {
+	withSystemRoots(t, fakeRoots)
+	dir := caDirWith(t, fakeCA)
+
+	path, err := EnsureTrustBundle(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotated := "-----BEGIN CERTIFICATE-----\nROTATEDCA\n-----END CERTIFICATE-----\n"
+	if werr := os.WriteFile(filepath.Join(dir, "ca.crt"), []byte(rotated), 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	if _, err = EnsureTrustBundle(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	if !bytes.Contains(data, []byte("ROTATEDCA")) {
+		t.Error("bundle still holds the old CA after rotation")
+	}
+	if bytes.Contains(data, []byte("CORTEXCA")) {
+		t.Error("bundle kept the superseded CA")
+	}
+}
+
+// TestEnsureTrustBundle_MissingCAFails: without ca.crt there is nothing to graft
+// in, and writing the platform roots alone would produce a file that verifies
+// everything EXCEPT the bridge — passing silently while parsing nothing.
+func TestEnsureTrustBundle_MissingCAFails(t *testing.T) {
+	withSystemRoots(t, fakeRoots)
+	dir := caDirWith(t, "")
+
+	if _, err := EnsureTrustBundle(dir); err == nil {
+		t.Fatal("missing ca.crt should be an error")
+	}
+	if _, serr := os.Stat(filepath.Join(dir, TrustBundleName)); serr == nil {
+		t.Error("a roots-only bundle was written")
+	}
+	if _, err := EnsureTrustBundle(""); err == nil {
+		t.Error("empty ca_dir should be an error")
+	}
+}
+
+// TestEnsureTrustBundle_SplicesPEMSafely: a CA file whose last line lacks a
+// newline would otherwise join its END line to the next BEGIN, and every
+// certificate after the splice silently fails to parse.
+func TestEnsureTrustBundle_SplicesPEMSafely(t *testing.T) {
+	withSystemRoots(t, fakeRoots)
+	dir := caDirWith(t, strings.TrimSuffix(fakeCA, "\n")) // no trailing newline
+
+	path, err := EnsureTrustBundle(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	if bytes.Contains(data, []byte("-----END CERTIFICATE-------")) {
+		t.Fatalf("PEM boundaries were spliced:\n%s", data)
+	}
+	if n := strings.Count(string(data), "BEGIN CERTIFICATE"); n != 2 {
+		t.Errorf("certificate count = %d, want 2", n)
+	}
+}

--- a/authbridge/authlib/tlsbridge/bundle_test.go
+++ b/authbridge/authlib/tlsbridge/bundle_test.go
@@ -2,6 +2,7 @@ package tlsbridge
 
 import (
 	"bytes"
+	"crypto/x509"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,48 +10,81 @@ import (
 	"testing"
 )
 
-// fakeCA and fakeRoots stand in for real PEM: EnsureTrustBundle concatenates
-// rather than parses, so the bytes only need the BEGIN marker findSystemRoots
-// looks for.
-const (
-	fakeCA    = "-----BEGIN CERTIFICATE-----\nCORTEXCA\n-----END CERTIFICATE-----\n"
-	fakeRoots = "-----BEGIN CERTIFICATE-----\nPUBLICROOT\n-----END CERTIFICATE-----\n"
-)
+// realPEM mints an actual certificate, because findSystemRoots parses rather
+// than pattern-matches: a stand-in with the right BEGIN line no longer passes,
+// which is the point of that check. Each call has its own key, so two results are
+// distinguishable by bytes without re-parsing.
+func realPEM(t *testing.T) []byte {
+	t.Helper()
+	_, _, certPEM, _, err := genSelfSignedCA()
+	if err != nil {
+		t.Fatalf("genSelfSignedCA: %v", err)
+	}
+	return certPEM
+}
 
 // withSystemRoots points the package at a temp root store for the duration of a
-// test, so a test's outcome does not depend on what the host happens to ship.
-func withSystemRoots(t *testing.T, contents string) {
+// test, so an outcome never depends on what the host happens to ship. Passing nil
+// means "no root store on this machine".
+func withSystemRoots(t *testing.T, pem []byte) {
 	t.Helper()
 	orig := systemRootFiles
 	t.Cleanup(func() { systemRootFiles = orig })
-	if contents == "" {
+	if pem == nil {
 		systemRootFiles = []string{filepath.Join(t.TempDir(), "absent.pem")}
 		return
 	}
 	p := filepath.Join(t.TempDir(), "roots.pem")
-	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+	if err := os.WriteFile(p, pem, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	systemRootFiles = []string{p}
 }
 
-func caDirWith(t *testing.T, ca string) string {
+// caDirWith builds a ca_dir holding ca.crt, or an empty one when pem is nil.
+func caDirWith(t *testing.T, pem []byte) string {
 	t.Helper()
 	dir := t.TempDir()
-	if ca != "" {
-		if err := os.WriteFile(filepath.Join(dir, "ca.crt"), []byte(ca), 0o644); err != nil {
+	if pem != nil {
+		if err := os.WriteFile(filepath.Join(dir, "ca.crt"), pem, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 	return dir
 }
 
+func countCerts(t *testing.T, pem []byte) int {
+	t.Helper()
+	var n int
+	rest := pem
+	for {
+		var block []byte
+		block, rest = nextCertBlock(rest)
+		if block == nil {
+			return n
+		}
+		n++
+	}
+}
+
+// nextCertBlock is a minimal PEM scanner: enough to count CERTIFICATE blocks
+// without pulling encoding/pem semantics into an assertion.
+func nextCertBlock(b []byte) (block, rest []byte) {
+	const begin = "-----BEGIN CERTIFICATE-----"
+	i := bytes.Index(b, []byte(begin))
+	if i < 0 {
+		return nil, nil
+	}
+	return b[i : i+len(begin)], b[i+len(begin):]
+}
+
 // TestEnsureTrustBundle_ContainsBothTrustSets is the whole point: a tool pointed
 // at this file must trust the bridge AND the public internet. A bundle holding
 // only one of them is the bug.
 func TestEnsureTrustBundle_ContainsBothTrustSets(t *testing.T) {
-	withSystemRoots(t, fakeRoots)
-	dir := caDirWith(t, fakeCA)
+	ca, roots := realPEM(t), realPEM(t)
+	withSystemRoots(t, roots)
+	dir := caDirWith(t, ca)
 
 	path, err := EnsureTrustBundle(dir)
 	if err != nil {
@@ -63,18 +97,22 @@ func TestEnsureTrustBundle_ContainsBothTrustSets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(data, []byte("CORTEXCA")) {
+	if !bytes.Contains(data, ca) {
 		t.Error("bundle is missing the bridge CA")
 	}
-	if !bytes.Contains(data, []byte("PUBLICROOT")) {
+	if !bytes.Contains(data, roots) {
 		t.Error("bundle is missing the platform roots — every direct TLS call would fail")
 	}
-	if n := strings.Count(string(data), "BEGIN CERTIFICATE"); n != 2 {
+	if n := countCerts(t, data); n != 2 {
 		t.Errorf("certificate count = %d, want 2", n)
 	}
 	// CA first, so a verifier finds it without walking the public roots.
-	if bytes.Index(data, []byte("CORTEXCA")) > bytes.Index(data, []byte("PUBLICROOT")) {
+	if bytes.Index(data, ca) > bytes.Index(data, roots) {
 		t.Error("bridge CA should precede the platform roots")
+	}
+	// The result must be usable as a trust store, not merely well-formed text.
+	if !x509.NewCertPool().AppendCertsFromPEM(data) {
+		t.Error("assembled bundle does not parse as a cert pool")
 	}
 }
 
@@ -83,8 +121,8 @@ func TestEnsureTrustBundle_ContainsBothTrustSets(t *testing.T) {
 // one private CA — silently distrusting the public internet, which is far worse
 // than not being able to verify the bridge.
 func TestEnsureTrustBundle_NoSystemRootsWritesNothing(t *testing.T) {
-	withSystemRoots(t, "")
-	dir := caDirWith(t, fakeCA)
+	withSystemRoots(t, nil)
+	dir := caDirWith(t, realPEM(t))
 
 	_, err := EnsureTrustBundle(dir)
 	if !errors.Is(err, ErrNoSystemRoots) {
@@ -95,30 +133,89 @@ func TestEnsureTrustBundle_NoSystemRootsWritesNothing(t *testing.T) {
 	}
 }
 
-// TestEnsureTrustBundle_EmptyRootFileIsSkipped: some minimal images ship an empty
-// placeholder at a well-known path. Accepting it would produce a CA-only bundle
-// by a different route than the check above.
-func TestEnsureTrustBundle_EmptyRootFileIsSkipped(t *testing.T) {
+// TestEnsureTrustBundle_KeepsAStaleBundleAndSaysSo: when the root store vanishes
+// but a bundle from an earlier boot exists, that bundle is LEFT IN PLACE and the
+// error names it.
+//
+// Deleting it would be worse than the staleness: four env vars point at this file
+// and each replaces its tool's trust store, so an absent bundle does not fall back
+// to the platform roots — it fails every TLS call. The error text is the only
+// signal an operator gets, so it has to mention the file.
+func TestEnsureTrustBundle_KeepsAStaleBundleAndSaysSo(t *testing.T) {
+	ca, roots := realPEM(t), realPEM(t)
+	withSystemRoots(t, roots)
+	dir := caDirWith(t, ca)
+
+	path, err := EnsureTrustBundle(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The host's root store disappears.
+	withSystemRoots(t, nil)
+	_, err = EnsureTrustBundle(dir)
+	if !errors.Is(err, ErrNoSystemRoots) {
+		t.Fatalf("error = %v, want it to wrap ErrNoSystemRoots", err)
+	}
+	if !strings.Contains(err.Error(), TrustBundleName) {
+		t.Errorf("error does not name the stale bundle, so nothing surfaces it: %v", err)
+	}
+	after, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatalf("the stale bundle was removed, which breaks every tool pointed at it: %v", rerr)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("the stale bundle was modified")
+	}
+}
+
+// TestEnsureTrustBundle_SkipsUnparseableRootFiles: a file carrying the BEGIN line
+// but a corrupt body passed the old substring check and produced a bundle with no
+// usable public roots — the CA-only trust store by another route. Some minimal
+// images also ship an empty placeholder at a well-known path.
+func TestEnsureTrustBundle_SkipsUnparseableRootFiles(t *testing.T) {
 	orig := systemRootFiles
 	t.Cleanup(func() { systemRootFiles = orig })
-	empty := filepath.Join(t.TempDir(), "empty.pem")
+	dir := t.TempDir()
+
+	empty := filepath.Join(dir, "empty.pem")
 	if err := os.WriteFile(empty, []byte("# no certs here\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	real := filepath.Join(t.TempDir(), "real.pem")
-	if err := os.WriteFile(real, []byte(fakeRoots), 0o644); err != nil {
+	// Header present, body garbage: the case a substring check accepts.
+	corrupt := filepath.Join(dir, "corrupt.pem")
+	corruptPEM := "-----BEGIN CERTIFICATE-----\nnot base64 at all!!\n-----END CERTIFICATE-----\n"
+	if err := os.WriteFile(corrupt, []byte(corruptPEM), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	systemRootFiles = []string{empty, real}
+	roots := realPEM(t)
+	good := filepath.Join(dir, "good.pem")
+	if err := os.WriteFile(good, roots, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	systemRootFiles = []string{empty, corrupt, good}
 
-	dir := caDirWith(t, fakeCA)
-	path, err := EnsureTrustBundle(dir)
+	ca := realPEM(t)
+	path, err := EnsureTrustBundle(caDirWith(t, ca))
 	if err != nil {
 		t.Fatalf("EnsureTrustBundle: %v", err)
 	}
 	data, _ := os.ReadFile(path)
-	if !bytes.Contains(data, []byte("PUBLICROOT")) {
-		t.Error("skipped past the empty placeholder to the real store, but the roots are absent")
+	if !bytes.Contains(data, roots) {
+		t.Error("skipped past the unusable files but the real roots are absent")
+	}
+	if bytes.Contains(data, []byte("not base64 at all")) {
+		t.Error("the corrupt file was accepted as a root store")
+	}
+
+	// With ONLY unusable candidates, nothing is written.
+	systemRootFiles = []string{empty, corrupt}
+	if _, err := EnsureTrustBundle(caDirWith(t, ca)); !errors.Is(err, ErrNoSystemRoots) {
+		t.Errorf("error = %v, want ErrNoSystemRoots when every candidate is unparseable", err)
 	}
 }
 
@@ -126,8 +223,8 @@ func TestEnsureTrustBundle_EmptyRootFileIsSkipped(t *testing.T) {
 // must not be rewritten — that would churn the mtime and disturb a reader holding
 // it open.
 func TestEnsureTrustBundle_Idempotent(t *testing.T) {
-	withSystemRoots(t, fakeRoots)
-	dir := caDirWith(t, fakeCA)
+	withSystemRoots(t, realPEM(t))
+	dir := caDirWith(t, realPEM(t))
 
 	path, err := EnsureTrustBundle(dir)
 	if err != nil {
@@ -153,25 +250,26 @@ func TestEnsureTrustBundle_Idempotent(t *testing.T) {
 // stale bundle after the CA is regenerated would leave every tool unable to verify
 // the bridge, with a file that looks present and correct.
 func TestEnsureTrustBundle_RewritesAfterCARotation(t *testing.T) {
-	withSystemRoots(t, fakeRoots)
-	dir := caDirWith(t, fakeCA)
+	withSystemRoots(t, realPEM(t))
+	first := realPEM(t)
+	dir := caDirWith(t, first)
 
 	path, err := EnsureTrustBundle(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	rotated := "-----BEGIN CERTIFICATE-----\nROTATEDCA\n-----END CERTIFICATE-----\n"
-	if werr := os.WriteFile(filepath.Join(dir, "ca.crt"), []byte(rotated), 0o644); werr != nil {
+	rotated := realPEM(t)
+	if werr := os.WriteFile(filepath.Join(dir, "ca.crt"), rotated, 0o644); werr != nil {
 		t.Fatal(werr)
 	}
 	if _, err = EnsureTrustBundle(dir); err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(path)
-	if !bytes.Contains(data, []byte("ROTATEDCA")) {
+	if !bytes.Contains(data, rotated) {
 		t.Error("bundle still holds the old CA after rotation")
 	}
-	if bytes.Contains(data, []byte("CORTEXCA")) {
+	if bytes.Contains(data, first) {
 		t.Error("bundle kept the superseded CA")
 	}
 }
@@ -180,8 +278,8 @@ func TestEnsureTrustBundle_RewritesAfterCARotation(t *testing.T) {
 // in, and writing the platform roots alone would produce a file that verifies
 // everything EXCEPT the bridge — passing silently while parsing nothing.
 func TestEnsureTrustBundle_MissingCAFails(t *testing.T) {
-	withSystemRoots(t, fakeRoots)
-	dir := caDirWith(t, "")
+	withSystemRoots(t, realPEM(t))
+	dir := caDirWith(t, nil)
 
 	if _, err := EnsureTrustBundle(dir); err == nil {
 		t.Fatal("missing ca.crt should be an error")
@@ -198,18 +296,26 @@ func TestEnsureTrustBundle_MissingCAFails(t *testing.T) {
 // newline would otherwise join its END line to the next BEGIN, and every
 // certificate after the splice silently fails to parse.
 func TestEnsureTrustBundle_SplicesPEMSafely(t *testing.T) {
-	withSystemRoots(t, fakeRoots)
-	dir := caDirWith(t, strings.TrimSuffix(fakeCA, "\n")) // no trailing newline
+	roots := realPEM(t)
+	withSystemRoots(t, roots)
+	ca := realPEM(t)
+	dir := caDirWith(t, bytes.TrimRight(ca, "\n")) // no trailing newline
 
 	path, err := EnsureTrustBundle(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(path)
-	if bytes.Contains(data, []byte("-----END CERTIFICATE-------")) {
-		t.Fatalf("PEM boundaries were spliced:\n%s", data)
-	}
-	if n := strings.Count(string(data), "BEGIN CERTIFICATE"); n != 2 {
+	if n := countCerts(t, data); n != 2 {
 		t.Errorf("certificate count = %d, want 2", n)
+	}
+	// The real check: both certs still load. A splice leaves valid-looking text
+	// that parses to fewer certs than it appears to hold.
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		t.Fatal("spliced bundle does not parse at all")
+	}
+	if !bytes.Contains(data, roots) {
+		t.Error("roots lost across the splice boundary")
 	}
 }

--- a/authbridge/authlib/tlsbridge/bundle_test.go
+++ b/authbridge/authlib/tlsbridge/bundle_test.go
@@ -319,3 +319,47 @@ func TestEnsureTrustBundle_SplicesPEMSafely(t *testing.T) {
 		t.Error("roots lost across the splice boundary")
 	}
 }
+
+// TestEnsureTrustBundle_ReadOnlyCADirIsClassified: in a cluster ca_dir is a
+// mounted cert-manager Secret and Kubernetes mounts those read-only, so the write
+// cannot succeed there. That is the normal outcome, not a fault — the caller keys
+// off ErrCADirNotWritable to log it at Debug rather than warning about four
+// laptop-only environment variables on every production boot.
+func TestEnsureTrustBundle_ReadOnlyCADirIsClassified(t *testing.T) {
+	withSystemRoots(t, realPEM(t))
+	dir := caDirWith(t, realPEM(t))
+
+	// 0500: readable and traversable, not writable — what a Secret mount looks
+	// like to this process. Restored in cleanup so t.TempDir can remove it.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	_, err := EnsureTrustBundle(dir)
+	if err == nil {
+		t.Skip("write succeeded despite a 0500 ca_dir (running as root?)")
+	}
+	if !errors.Is(err, ErrCADirNotWritable) {
+		t.Errorf("error = %v, want it to wrap ErrCADirNotWritable so the caller can "+
+			"demote it; otherwise every in-cluster boot warns", err)
+	}
+	// It must NOT be mistaken for the missing-roots case, which is a real problem.
+	if errors.Is(err, ErrNoSystemRoots) {
+		t.Error("a read-only ca_dir must not report as missing system roots")
+	}
+}
+
+// TestEnsureTrustBundle_OtherWriteErrorsStayLoud is the other side: only the
+// filesystem refusing the write is demoted. A missing root store is a genuine
+// misconfiguration and must keep warning.
+func TestEnsureTrustBundle_OtherWriteErrorsStayLoud(t *testing.T) {
+	withSystemRoots(t, nil)
+	_, err := EnsureTrustBundle(caDirWith(t, realPEM(t)))
+	if errors.Is(err, ErrCADirNotWritable) {
+		t.Errorf("missing roots misclassified as unwritable ca_dir: %v", err)
+	}
+	if !errors.Is(err, ErrNoSystemRoots) {
+		t.Errorf("error = %v, want ErrNoSystemRoots", err)
+	}
+}

--- a/authbridge/authlib/tlsbridge/bundle_test.go
+++ b/authbridge/authlib/tlsbridge/bundle_test.go
@@ -26,13 +26,33 @@ func realPEM(t *testing.T) []byte {
 // withSystemRoots points the package at a temp root store for the duration of a
 // test, so an outcome never depends on what the host happens to ship. Passing nil
 // means "no root store on this machine".
+// isolateRootSources detaches the package from the host's trust store for one test.
+//
+// findSystemRootsFrom consults three sources — SSL_CERT_FILE, systemRootFiles, then
+// SSL_CERT_DIR or certDirectories — and a test that neutralises only one of them is
+// at the mercy of whatever the runner ships. Overriding just systemRootFiles let a
+// Linux runner's populated /etc/ssl/certs satisfy four tests that assert "no roots on
+// this machine": they passed on macOS, where that directory holds nothing parseable,
+// and failed in CI.
+//
+// Every test that pins root discovery calls this, so there is one place to extend
+// when a fourth source appears.
+func isolateRootSources(t *testing.T) {
+	t.Helper()
+	origFiles := systemRootFiles
+	origDirs := certDirectories
+	t.Cleanup(func() { systemRootFiles = origFiles; certDirectories = origDirs })
+	certDirectories = []string{filepath.Join(t.TempDir(), "absent-dir")}
+	systemRootFiles = []string{filepath.Join(t.TempDir(), "absent.pem")}
+	t.Setenv("SSL_CERT_FILE", "")
+	t.Setenv("SSL_CERT_DIR", "")
+}
+
 func withSystemRoots(t *testing.T, pem []byte) {
 	t.Helper()
-	orig := systemRootFiles
-	t.Cleanup(func() { systemRootFiles = orig })
+	isolateRootSources(t)
 	if pem == nil {
-		systemRootFiles = []string{filepath.Join(t.TempDir(), "absent.pem")}
-		return
+		return // isolateRootSources already pointed every source at nothing
 	}
 	p := filepath.Join(t.TempDir(), "roots.pem")
 	if err := os.WriteFile(p, pem, 0o644); err != nil {
@@ -178,8 +198,11 @@ func TestEnsureTrustBundle_KeepsAStaleBundleAndSaysSo(t *testing.T) {
 // usable public roots — the CA-only trust store by another route. Some minimal
 // images also ship an empty placeholder at a well-known path.
 func TestEnsureTrustBundle_SkipsUnparseableRootFiles(t *testing.T) {
-	orig := systemRootFiles
-	t.Cleanup(func() { systemRootFiles = orig })
+	// Isolate first: this test sets systemRootFiles by hand to control the candidate
+	// ORDER, which withSystemRoots cannot express — but it still needs the env vars
+	// and cert directories detached, or SSL_CERT_FILE from the host wins ahead of all
+	// three candidates and the assertion tests nothing.
+	isolateRootSources(t)
 	dir := t.TempDir()
 
 	empty := filepath.Join(dir, "empty.pem")

--- a/authbridge/authlib/tlsbridge/decision.go
+++ b/authbridge/authlib/tlsbridge/decision.go
@@ -1,8 +1,11 @@
 package tlsbridge
 
 import (
+	"fmt"
 	"sync"
 	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/skiphost"
 )
 
 type Verdict int
@@ -13,24 +16,94 @@ const (
 )
 
 type DecisionOpts struct {
-	Ports     map[int]bool
+	Ports map[int]bool
+	// SkipHosts are host patterns to tunnel. NIL means "unset", and
+	// DefaultPassthroughHosts is used; an EMPTY non-nil slice means the operator
+	// explicitly wants nothing skipped. YAML distinguishes the two (absent key
+	// vs `passthrough_hosts: []`), which is what makes the default overridable
+	// without a second config field.
 	SkipHosts []string
 }
 
 type Decision struct {
 	ports map[int]bool
-	skip  map[string]bool
+	skip  *skiphost.Matcher
 }
 
-func NewDecision(o DecisionOpts) *Decision {
-	d := &Decision{ports: o.Ports, skip: map[string]bool{}}
+// DefaultPassthroughHosts are the hosts the bridge does not intercept unless the
+// operator sets passthrough_hosts explicitly.
+//
+// Every entry is developer tooling, and the reasoning is the same for all of
+// them: no plugin can read this traffic. inference-parser, the MCP/A2A parsers
+// and tool-prune all act on agent↔LLM and agent↔tool messages, and none of them
+// has anything to say about a module download or a REST call to a forge. So
+// forging a leaf for these hosts buys nothing — and costs a great deal, because
+// the tools that talk to them are overwhelmingly Go binaries, and a Go binary
+// cannot be pointed at a CA file by environment on macOS (no SSL_CERT_FILE
+// support in root_darwin.go). `gh` in particular has no CA option at all
+// (cli/cli#1735, open since 2020), so intercepting api.github.com breaks it with
+// no configuration available to fix it.
+//
+// The list is grounded in observed failures — every host here appeared in a real
+// proxy log as `reason=handshake-fail` — plus the sibling registries that fail
+// the same way for the same reason.
+//
+// NEVER add an inference or tool endpoint here. api.anthropic.com,
+// api.openai.com, generativelanguage.googleapis.com, a LiteLLM gateway, an MCP
+// server: those are the entire point of the bridge, and skipping one silently
+// removes the parsing and the tool-prune savings with no error anywhere. Note
+// this is why the Go-module hosts are listed one family at a time rather than as
+// a blanket `*.googleapis.com` — Gemini lives under that domain.
+var DefaultPassthroughHosts = []string{
+	// GitHub: gh (no CA option), git, Actions, container pulls.
+	"github.com",
+	"*.github.com", // api., codeload., uploads.
+	"*.githubusercontent.com",
+	"ghcr.io",
+	// Go toolchain: module proxy, checksum DB, VCS, common module hosts.
+	"golang.org",
+	"*.golang.org", // proxy., sum., google.
+	"go.dev",       // golang.org redirects here; the toolchain's version check hits it
+	"*.go.dev",
+	"go.googlesource.com",
+	// proxy.golang.org redirects module zips here, so omitting it left `go mod
+	// download` still failing on one host after everything else was skipped.
+	// Named explicitly rather than as *.googleapis.com: Gemini
+	// (generativelanguage.googleapis.com) and Vertex live under that domain and
+	// must stay bridged.
+	"storage.googleapis.com",
+	// GOTOOLCHAIN fetches a newer toolchain from here when go.mod asks for one.
+	"dl.google.com",
+	"go.opentelemetry.io",
+	"go.yaml.in",
+	"gopkg.in",
+	// Package registries.
+	"pypi.org",
+	"*.pythonhosted.org",
+	"registry.npmjs.org",
+	"crates.io",
+	"static.crates.io",
+}
+
+// NewDecision compiles the interception policy. It returns an error for an
+// unusable skip pattern rather than ignoring it: a pattern that silently fails
+// to match presents as "the bridge broke my tool", with nothing connecting the
+// symptom to the typo.
+func NewDecision(o DecisionOpts) (*Decision, error) {
+	d := &Decision{ports: o.Ports}
 	if d.ports == nil {
 		d.ports = map[int]bool{443: true, 8443: true}
 	}
-	for _, h := range o.SkipHosts {
-		d.skip[h] = true
+	patterns := o.SkipHosts
+	if patterns == nil {
+		patterns = DefaultPassthroughHosts
 	}
-	return d
+	m, err := skiphost.New(patterns)
+	if err != nil {
+		return nil, fmt.Errorf("tlsbridge: passthrough_hosts: %w", err)
+	}
+	d.skip = m
+	return d, nil
 }
 
 // HandlesPort reports whether port is in the bridge's interception set. It is
@@ -50,7 +123,10 @@ func (d *Decision) Classify(host string, port int, first []byte) (Verdict, strin
 	if !looksLikeTLSRecord(first) {
 		return Passthrough, "non-tls"
 	}
-	if d.skip[host] {
+	// Glob, not exact match: the tooling hosts this skips come in families
+	// (api./codeload./uploads.github.com), and Match strips the port so a caller
+	// may pass either host or host:port.
+	if d.skip.Match(host) {
 		return Passthrough, "skip"
 	}
 	return Terminate, ""

--- a/authbridge/authlib/tlsbridge/decision.go
+++ b/authbridge/authlib/tlsbridge/decision.go
@@ -48,6 +48,26 @@ type Decision struct {
 // proxy log as `reason=handshake-fail` — plus the sibling registries that fail
 // the same way for the same reason.
 //
+// What this costs, stated plainly because "no plugin can read it" is only the
+// upside half of the ledger: several of these hosts accept arbitrary uploads.
+// *.github.com globs gist. and uploads.; *.githubusercontent.com is user
+// content; ghcr.io takes blob pushes; storage.googleapis.com is object storage.
+// Those are exactly where an agent would put data it wanted to exfiltrate, and
+// terminating TLS was the only point at which such a payload was ever visible.
+// After this change they are opaque tunnels: a session event still records the
+// CONNECT host and byte counts, but not one byte of the body.
+//
+// That is accepted rather than overlooked. The traffic could not be inspected
+// reliably anyway — before this list, an untrusting client's first request to any
+// of these hosts failed and the host was then auto-skipped for ten minutes (see
+// SkipSet below), so interception was intermittent and its absence silent. The
+// control that actually remains for egress is allow-listing which hosts a
+// workload may reach at all — iptables / NetworkPolicy in-cluster, and
+// listener.skip_hosts plus the egress gate for the proxy — not TLS inspection of
+// hosts whose bodies no plugin parses. A deployment that needs payload
+// visibility on a specific host should set passthrough_hosts explicitly and
+// arrange for its clients to trust the CA.
+//
 // NEVER add an inference or tool endpoint here. api.anthropic.com,
 // api.openai.com, generativelanguage.googleapis.com, a LiteLLM gateway, an MCP
 // server: those are the entire point of the bridge, and skipping one silently
@@ -81,8 +101,17 @@ var DefaultPassthroughHosts = []string{
 	"pypi.org",
 	"*.pythonhosted.org",
 	"registry.npmjs.org",
+	// crates.io is the exact host; the glob covers index. (the sparse index, the
+	// default registry protocol since Rust 1.70 — so `cargo build` hits it on
+	// every resolve) and static. (the .crate downloads).
 	"crates.io",
-	"static.crates.io",
+	"*.crates.io",
+	// Docker Hub, for parity with ghcr.io above: registry-1. and auth. under the
+	// glob, and the blob CDN, which is a separate domain in the same way
+	// storage.googleapis.com is for Go modules.
+	"docker.io",
+	"*.docker.io",
+	"production.cloudflare.docker.com",
 }
 
 // NewDecision compiles the interception policy. It returns an error for an

--- a/authbridge/authlib/tlsbridge/decision_test.go
+++ b/authbridge/authlib/tlsbridge/decision_test.go
@@ -5,8 +5,19 @@ import (
 	"time"
 )
 
+// mustDecision fails the test on an invalid pattern list, so each case reads as
+// the single call it was before NewDecision grew an error return.
+func mustDecision(t *testing.T, o DecisionOpts) *Decision {
+	t.Helper()
+	d, err := NewDecision(o)
+	if err != nil {
+		t.Fatalf("NewDecision(%+v): %v", o, err)
+	}
+	return d
+}
+
 func TestDecision_Classify(t *testing.T) {
-	d := NewDecision(DecisionOpts{
+	d := mustDecision(t, DecisionOpts{
 		Ports:     map[int]bool{443: true, 8443: true},
 		SkipHosts: []string{"pinned.example.com"},
 	})
@@ -37,7 +48,7 @@ func TestDecision_Classify(t *testing.T) {
 }
 
 func TestDecision_DefaultPortsWhenNil(t *testing.T) {
-	d := NewDecision(DecisionOpts{}) // nil Ports -> {443,8443}
+	d := mustDecision(t, DecisionOpts{}) // nil Ports -> {443,8443}
 	tlsHello := []byte{0x16, 0x03, 0x01, 0x00, 0x05}
 	if v, reason := d.Classify("api.example.com", 443, tlsHello); v != Terminate || reason != "" {
 		t.Errorf("port 443: got (%v,%q), want (%v,%q)", v, reason, Terminate, "")
@@ -84,7 +95,7 @@ func TestSkipSet_Bounded(t *testing.T) {
 
 func TestDecision_HandlesPort(t *testing.T) {
 	// Default set when Ports is nil.
-	d := NewDecision(DecisionOpts{})
+	d := mustDecision(t, DecisionOpts{})
 	if !d.HandlesPort(443) || !d.HandlesPort(8443) {
 		t.Error("default set must handle 443 and 8443")
 	}
@@ -92,11 +103,118 @@ func TestDecision_HandlesPort(t *testing.T) {
 		t.Error("default set must not handle 9443")
 	}
 	// Custom set replaces the default.
-	c := NewDecision(DecisionOpts{Ports: map[int]bool{9443: true}})
+	c := mustDecision(t, DecisionOpts{Ports: map[int]bool{9443: true}})
 	if !c.HandlesPort(9443) {
 		t.Error("custom set must handle 9443")
 	}
 	if c.HandlesPort(443) {
 		t.Error("custom set must not handle 443 (it replaces, not augments, the default)")
+	}
+}
+
+// TestDefaultPassthrough_CoversTheToolsThatCannotBeConfigured is the point of the
+// default list: `gh` has no CA option at all and Go on macOS honours no CA
+// environment variable, so intercepting these hosts breaks them with no fix
+// available to the user. Every host below appeared in a real proxy log as
+// reason=handshake-fail.
+func TestDefaultPassthrough_CoversTheToolsThatCannotBeConfigured(t *testing.T) {
+	d := mustDecision(t, DecisionOpts{}) // nil SkipHosts -> defaults
+	tlsHello := []byte{0x16, 0x03, 0x01, 0x00, 0x05}
+	for _, host := range []string{
+		"api.github.com", "github.com", "raw.githubusercontent.com",
+		"codeload.github.com", "uploads.github.com", "cafe.github.com",
+		"ghcr.io",
+		"proxy.golang.org", "sum.golang.org", "google.golang.org", "golang.org",
+		"go.googlesource.com", "go.opentelemetry.io", "go.yaml.in", "gopkg.in",
+		"pypi.org", "files.pythonhosted.org", "registry.npmjs.org", "crates.io",
+		// proxy.golang.org redirects module zips here; without it `go mod download`
+		// still failed on one host after every other Go host was skipped.
+		"storage.googleapis.com",
+	} {
+		if v, reason := d.Classify(host, 443, tlsHello); v != Passthrough || reason != "skip" {
+			t.Errorf("%s: got (%v,%q), want (Passthrough,\"skip\")", host, v, reason)
+		}
+	}
+	// Ports are still honoured ahead of the host check.
+	if v, reason := d.Classify("api.github.com", 9999, tlsHello); reason != "port" {
+		t.Errorf("port gate should win: got (%v,%q)", v, reason)
+	}
+	// The matcher strips the port, so host:port forms skip too.
+	if v, _ := d.Classify("api.github.com:443", 443, tlsHello); v != Passthrough {
+		t.Error("host:port form should still match the skip list")
+	}
+}
+
+// TestDefaultPassthrough_NeverSkipsInferenceOrToolEndpoints is the guard that
+// matters most. A default that quietly stopped bridging an LLM endpoint would
+// remove the parsing and the tool-prune savings — the whole reason the bridge
+// exists — with no error anywhere to notice it by.
+//
+// generativelanguage.googleapis.com is listed explicitly: it is why the Go module
+// hosts are enumerated per-family instead of as a blanket *.googleapis.com.
+func TestDefaultPassthrough_NeverSkipsInferenceOrToolEndpoints(t *testing.T) {
+	d := mustDecision(t, DecisionOpts{})
+	tlsHello := []byte{0x16, 0x03, 0x01, 0x00, 0x05}
+	for _, host := range []string{
+		"api.anthropic.com",
+		"api.openai.com",
+		"generativelanguage.googleapis.com",
+		"us-central1-aiplatform.googleapis.com",
+		"ete-litellm.ai-models.vpc-int.res.ibm.com",
+		"github-tool-mcp",
+		"github-tool-mcp.team1.svc.cluster.local",
+		"weather-agent.team1.svc.cluster.local",
+	} {
+		if v, reason := d.Classify(host, 443, tlsHello); v != Terminate {
+			t.Errorf("%s must stay bridged, got (%v,%q)", host, v, reason)
+		}
+	}
+}
+
+// TestDecisionOpts_ExplicitEmptyDisablesDefaults: nil means "unset, use the
+// defaults" and an empty non-nil slice means "skip nothing". YAML distinguishes an
+// absent key from `passthrough_hosts: []`, which is what lets an operator bridge
+// everything without needing a second config field to turn defaults off.
+func TestDecisionOpts_ExplicitEmptyDisablesDefaults(t *testing.T) {
+	tlsHello := []byte{0x16, 0x03, 0x01, 0x00, 0x05}
+
+	def := mustDecision(t, DecisionOpts{SkipHosts: nil})
+	if v, _ := def.Classify("api.github.com", 443, tlsHello); v != Passthrough {
+		t.Error("nil SkipHosts should apply the defaults")
+	}
+	none := mustDecision(t, DecisionOpts{SkipHosts: []string{}})
+	if v, _ := none.Classify("api.github.com", 443, tlsHello); v != Terminate {
+		t.Error("explicit empty SkipHosts should skip nothing, not fall back to defaults")
+	}
+	// An explicit list replaces the defaults rather than adding to them.
+	own := mustDecision(t, DecisionOpts{SkipHosts: []string{"pinned.example.com"}})
+	if v, _ := own.Classify("api.github.com", 443, tlsHello); v != Terminate {
+		t.Error("an explicit list should replace the defaults")
+	}
+	if v, _ := own.Classify("pinned.example.com", 443, tlsHello); v != Passthrough {
+		t.Error("an explicit list should still be honoured")
+	}
+}
+
+// TestNewDecision_RejectsUnusablePatterns: a pattern that cannot match is a typo,
+// and ignoring it presents as "the bridge broke my tool" with nothing connecting
+// the symptom to the cause. Match-all is rejected for a different reason — it
+// would disable interception wholesale while looking like a narrowing.
+func TestNewDecision_RejectsUnusablePatterns(t *testing.T) {
+	for _, bad := range [][]string{
+		{"*"},                  // match-all
+		{"**"},                 // match-all, other spelling
+		{"api.github.com:443"}, // port-bearing: Match strips ports, so it could never fire
+		{""},                   // empty
+		{"github.com", "  "},   // one good, one blank
+	} {
+		if _, err := NewDecision(DecisionOpts{SkipHosts: bad}); err == nil {
+			t.Errorf("NewDecision(%q) should have failed", bad)
+		}
+	}
+	// The shipped defaults must themselves compile — a bad entry here would be
+	// a fatal boot error for every user.
+	if _, err := NewDecision(DecisionOpts{SkipHosts: DefaultPassthroughHosts}); err != nil {
+		t.Fatalf("DefaultPassthroughHosts does not compile: %v", err)
 	}
 }

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
-// The three variables Claude Code needs to route through Cortex. Claude Code
+// The variables Claude Code needs to route through Cortex. Claude Code
 // reads env vars from its own settings file, which is not merely more convenient
 // than exporting them in a shell — it is more correct. The supervisor is one
 // process shared by every terminal and inherits the environment of whichever
@@ -26,11 +27,27 @@ import (
 const exitDeclined = 3
 
 const (
-	envProxy     = "HTTPS_PROXY"
-	envCACerts   = "NODE_EXTRA_CA_CERTS"
-	envNoTelem   = "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
-	settingsRel  = ".claude/settings.json"
-	cortexCfgRel = ".cortex/config.yaml"
+	envProxy   = "HTTPS_PROXY"
+	envCACerts = "NODE_EXTRA_CA_CERTS"
+	// The CA variables below take a bundle, not ca.crt. Unlike Node's, each of
+	// these REPLACES the process's trust store with the file named, so pointing
+	// them at the bare CA leaves the tool trusting one private CA and nothing
+	// else — every unproxied TLS call then fails. Go is explicit about it:
+	// crypto/x509 root_unix.go does `files = []string{f}` when SSL_CERT_FILE is
+	// set. That failure is platform-split and so easy to ship blind: macOS goes
+	// through root_darwin.go's platform verifier and keeps working, while every
+	// Linux box and CI runner breaks.
+	//
+	// HTTPS_PROXY reaches these tools whether or not they were the target — a
+	// Go or Python program spawned by Claude Code inherits the proxy and must be
+	// able to verify the bridge's forged leaf.
+	envSSLCert    = "SSL_CERT_FILE"      // Go: gh, abctl, any Go CLI
+	envGitCA      = "GIT_SSL_CAINFO"     // git (incl. the fetches `go mod` makes)
+	envRequestsCA = "REQUESTS_CA_BUNDLE" // Python requests: keycloak_sync, setup scripts
+	envCurlCA     = "CURL_CA_BUNDLE"     // curl
+	envNoTelem    = "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"
+	settingsRel   = ".claude/settings.json"
+	cortexCfgRel  = ".cortex/config.yaml"
 	// stateRel records what each managed key looked like BEFORE enable, so disable
 	// can put it back. Without it, disable deleted every managed key it found —
 	// including one the user had set themselves, which is indistinguishable by
@@ -99,7 +116,15 @@ func writeState(path string, st managedState) error {
 // managedKeys is exactly what enable writes and disable removes. Nothing else in
 // the file is touched — notably not ANTHROPIC_BASE_URL or any auth token, which
 // commonly live in the same env block.
-var managedKeys = []string{envProxy, envCACerts, envNoTelem}
+var managedKeys = []string{
+	envProxy, envCACerts, envSSLCert, envGitCA, envRequestsCA, envCurlCA, envNoTelem,
+}
+
+// bundleKeys are the managed keys that must point at the CA+roots bundle rather
+// than at ca.crt. Kept as its own list so wanted() and the existence check
+// cannot disagree about which variables carry which file — getting one of these
+// pointed at ca.crt is the exact bug this grouping prevents.
+var bundleKeys = []string{envSSLCert, envGitCA, envRequestsCA, envCurlCA}
 
 const claudeCodeUsage = `abctl claude-code — route Claude Code through Cortex without shell env vars
 
@@ -108,15 +133,23 @@ Usage:
   abctl claude-code disable [--yes] [--settings PATH]
   abctl claude-code status  [--settings PATH]
 
-enable writes HTTPS_PROXY, NODE_EXTRA_CA_CERTS and
-CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC into the "env" block of
-~/.claude/settings.json, reading the addresses from ~/.cortex/config.yaml so they
-always match the running proxy. Afterwards, plain "claude" goes through Cortex.
+enable writes HTTPS_PROXY, CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC and a set of
+CA variables into the "env" block of ~/.claude/settings.json, reading the
+addresses from ~/.cortex/config.yaml so they always match the running proxy.
+Afterwards, plain "claude" goes through Cortex.
 
-Only those three keys are added; every other setting, including any other env
-entry, is left exactly as it was. The first run copies the original file to
+The CA variables cover the tools Claude Code spawns, not just Claude Code
+itself: anything it runs inherits HTTPS_PROXY and so must be able to verify the
+bridge. NODE_EXTRA_CA_CERTS (Node) gets ca.crt because it EXTENDS the trust
+store; SSL_CERT_FILE (go, gh), GIT_SSL_CAINFO (git), REQUESTS_CA_BUNDLE (Python)
+and CURL_CA_BUNDLE (curl) get bundle.crt, because each REPLACES the trust store
+and ca.crt alone would leave them trusting one private CA and nothing else.
+
+Only those keys are added; every other setting, including any other env entry,
+is left exactly as it was. The first run copies the original file to
 settings.json.bak and never overwrites that copy, so the pristine version
-survives later runs. disable removes only those three keys.
+survives later runs. disable removes only the keys it added, restoring any
+prior value it recorded.
 
 Note: while enabled, Claude Code needs Cortex running — its requests go to the
 proxy address. "abctl claude-code disable" is the off switch.
@@ -212,6 +245,14 @@ func wanted(cortexCfgPath string) (map[string]string, error) {
 			return nil, aerr
 		}
 		out[envCACerts] = ca
+		// Everything else gets the bundle, never ca.crt — see bundleKeys.
+		bundle, berr := filepath.Abs(filepath.Join(cfg.TLSBridge.CADir, tlsbridge.TrustBundleName))
+		if berr != nil {
+			return nil, berr
+		}
+		for _, k := range bundleKeys {
+			out[k] = bundle
+		}
 	}
 	return out, nil
 }
@@ -258,6 +299,18 @@ func claudeCodeEnable2(settingsPath, cortexCfgPath, statePath string, yes bool, 
 			"  bridge and every request tunnels through unparsed — which looks like nothing\n"+
 			"  is wrong. Start Cortex, then check with: abctl claude-code status\n\n",
 			want[envCACerts])
+	}
+	// The bundle is checked separately: it is written by a LATER step than ca.crt
+	// (the proxy assembles it from the CA plus the platform roots), and on a host
+	// where no root store could be located it never appears at all. A tool whose
+	// CA variable points at a missing file fails closed with a certificate error
+	// rather than silently, so say which tools are affected and why.
+	if _, serr := os.Stat(want[envSSLCert]); serr != nil {
+		fmt.Fprintf(stdout, "Note: %s does not exist yet.\n"+
+			"  Cortex assembles it on start from the CA plus this machine's root store; go,\n"+
+			"  gh, git, curl and Python read it. If it is still missing after a start, Cortex\n"+
+			"  could not find a system root bundle — check the proxy log for \"trust bundle\".\n\n",
+			want[envSSLCert])
 	}
 
 	var changes []string
@@ -414,7 +467,7 @@ func isCortexValue(key, val string) bool {
 	switch key {
 	case envNoTelem:
 		return val == "1"
-	case envCACerts:
+	case envCACerts, envSSLCert, envGitCA, envRequestsCA, envCurlCA:
 		return strings.Contains(val, ".cortex"+string(os.PathSeparator)) || strings.Contains(val, "cortex-ca")
 	case envProxy:
 		return strings.Contains(val, "localhost:476") || strings.Contains(val, "127.0.0.1:476")

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -34,14 +35,24 @@ const (
 	// them at the bare CA leaves the tool trusting one private CA and nothing
 	// else — every unproxied TLS call then fails. Go is explicit about it:
 	// crypto/x509 root_unix.go does `files = []string{f}` when SSL_CERT_FILE is
-	// set. That failure is platform-split and so easy to ship blind: macOS goes
-	// through root_darwin.go's platform verifier and keeps working, while every
-	// Linux box and CI runner breaks.
+	// set.
 	//
 	// HTTPS_PROXY reaches these tools whether or not they were the target — a
 	// Go or Python program spawned by Claude Code inherits the proxy and must be
 	// able to verify the bridge's forged leaf.
-	envSSLCert    = "SSL_CERT_FILE"      // Go: gh, abctl, any Go CLI
+	//
+	// SSL_CERT_FILE DOES NOTHING ON macOS. root_unix.go, which honours it, is
+	// built for `linux || freebsd || …` and excludes darwin; darwin's
+	// loadSystemRoots returns a `systemPool: true` sentinel that reads no files
+	// at all, and verify.go then routes any program that has not set RootCAs
+	// straight to systemVerify — Security.framework, keychain only. So on macOS
+	// a Go tool cannot be pointed at a CA file by environment; the CA has to go
+	// into the keychain instead (see darwinGoNote). It is still written here
+	// because it is correct and necessary everywhere else, including CI.
+	//
+	// The other three are unaffected: git, curl and Python read their bundles
+	// through OpenSSL/LibreSSL, which honours these variables on macOS too.
+	envSSLCert    = "SSL_CERT_FILE"      // Go: gh, abctl, any Go CLI — Linux only, see above
 	envGitCA      = "GIT_SSL_CAINFO"     // git (incl. the fetches `go mod` makes)
 	envRequestsCA = "REQUESTS_CA_BUNDLE" // Python requests: keycloak_sync, setup scripts
 	envCurlCA     = "CURL_CA_BUNDLE"     // curl
@@ -126,6 +137,27 @@ var managedKeys = []string{
 // pointed at ca.crt is the exact bug this grouping prevents.
 var bundleKeys = []string{envSSLCert, envGitCA, envRequestsCA, envCurlCA}
 
+// darwinGoNote is printed on macOS, where SSL_CERT_FILE is inert: Go resolves
+// roots through Security.framework and reads no CA file, so no environment
+// variable can make `go`, `gh` or any other Go tool trust the bridge. Only the
+// keychain can. git, curl and Python are unaffected — they read their bundles
+// through OpenSSL/LibreSSL, which honours the variables on macOS.
+//
+// Said at enable time rather than left to documentation because the failure it
+// predicts is a bare "x509: certificate signed by unknown authority" from a tool
+// the user has just been told is configured — the same "no error points at the
+// cause" problem this command exists to remove.
+func darwinGoNote(caPath string) string {
+	return "Note: on macOS, SSL_CERT_FILE cannot make Go tools (go, gh) trust the bridge.\n" +
+		"  Go reads roots from the keychain, not from any CA file, so that one variable is\n" +
+		"  inert here — git, curl and Python are fine. To cover the Go tools, trust the CA\n" +
+		"  in your login keychain:\n\n" +
+		"    security add-trusted-cert -k ~/Library/Keychains/login.keychain-db \\\n" +
+		"      -p ssl " + caPath + "\n\n" +
+		"  Undo with: security delete-certificate -c authbridge-tls-bridge-ca \\\n" +
+		"    ~/Library/Keychains/login.keychain-db\n\n"
+}
+
 const claudeCodeUsage = `abctl claude-code — route Claude Code through Cortex without shell env vars
 
 Usage:
@@ -144,6 +176,11 @@ bridge. NODE_EXTRA_CA_CERTS (Node) gets ca.crt because it EXTENDS the trust
 store; SSL_CERT_FILE (go, gh), GIT_SSL_CAINFO (git), REQUESTS_CA_BUNDLE (Python)
 and CURL_CA_BUNDLE (curl) get bundle.crt, because each REPLACES the trust store
 and ca.crt alone would leave them trusting one private CA and nothing else.
+
+macOS caveat: SSL_CERT_FILE has no effect there. Go resolves roots through the
+keychain and reads no CA file, so no environment variable can make go or gh
+trust the bridge; enable prints the "security add-trusted-cert" command that
+does. git, curl and Python are unaffected on macOS.
 
 Only those keys are added; every other setting, including any other env entry,
 is left exactly as it was. The first run copies the original file to
@@ -288,29 +325,38 @@ func claudeCodeEnable2(settingsPath, cortexCfgPath, statePath string, yes bool, 
 		}
 	}
 
-	// The CA path is written whether or not the file exists, because enabling
-	// before the first start is legitimate — the proxy generates it on boot. But a
-	// NODE_EXTRA_CA_CERTS pointing at a missing file fails SILENTLY: requests keep
-	// working, every one tunnels through opaquely, and nothing is parsed. Say so
-	// now rather than let that be discovered later.
-	if _, serr := os.Stat(want[envCACerts]); serr != nil {
-		fmt.Fprintf(stdout, "Note: %s does not exist yet.\n"+
-			"  Cortex creates it on first start. Until then Claude Code cannot verify the\n"+
-			"  bridge and every request tunnels through unparsed — which looks like nothing\n"+
-			"  is wrong. Start Cortex, then check with: abctl claude-code status\n\n",
-			want[envCACerts])
-	}
-	// The bundle is checked separately: it is written by a LATER step than ca.crt
-	// (the proxy assembles it from the CA plus the platform roots), and on a host
-	// where no root store could be located it never appears at all. A tool whose
-	// CA variable points at a missing file fails closed with a certificate error
-	// rather than silently, so say which tools are affected and why.
-	if _, serr := os.Stat(want[envSSLCert]); serr != nil {
-		fmt.Fprintf(stdout, "Note: %s does not exist yet.\n"+
-			"  Cortex assembles it on start from the CA plus this machine's root store; go,\n"+
-			"  gh, git, curl and Python read it. If it is still missing after a start, Cortex\n"+
-			"  could not find a system root bundle — check the proxy log for \"trust bundle\".\n\n",
-			want[envSSLCert])
+	// Both trust files are reported only when a ca_dir was configured at all.
+	// wanted() populates these keys under `if cfg.TLSBridge.CADir != ""`, so
+	// without one the paths are "" and an unguarded Stat printed
+	// "Note:  does not exist yet." with a blank path — a note about no file.
+	if want[envCACerts] != "" {
+		// The CA path is written whether or not the file exists, because enabling
+		// before the first start is legitimate — the proxy generates it on boot. But
+		// a NODE_EXTRA_CA_CERTS pointing at a missing file fails SILENTLY: requests
+		// keep working, every one tunnels through opaquely, and nothing is parsed.
+		// Say so now rather than let that be discovered later.
+		if _, serr := os.Stat(want[envCACerts]); serr != nil {
+			fmt.Fprintf(stdout, "Note: %s does not exist yet.\n"+
+				"  Cortex creates it on first start. Until then Claude Code cannot verify the\n"+
+				"  bridge and every request tunnels through unparsed — which looks like nothing\n"+
+				"  is wrong. Start Cortex, then check with: abctl claude-code status\n\n",
+				want[envCACerts])
+		}
+		// The bundle is checked separately: it is written by a LATER step than
+		// ca.crt (the proxy assembles it from the CA plus the platform roots), and
+		// on a host where no root store could be located it never appears at all. A
+		// tool whose CA variable points at a missing file fails closed with a
+		// certificate error rather than silently, so say which tools are affected.
+		if _, serr := os.Stat(want[envSSLCert]); serr != nil {
+			fmt.Fprintf(stdout, "Note: %s does not exist yet.\n"+
+				"  Cortex assembles it on start from the CA plus this machine's root store;\n"+
+				"  git, curl and Python read it. If it is still missing after a start, Cortex\n"+
+				"  could not find a system root bundle — check the proxy log for \"trust bundle\".\n\n",
+				want[envSSLCert])
+		}
+		if runtime.GOOS == "darwin" {
+			fmt.Fprint(stdout, darwinGoNote(want[envCACerts]))
+		}
 	}
 
 	var changes []string

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -148,10 +148,15 @@ var bundleKeys = []string{envSSLCert, envGitCA, envRequestsCA, envCurlCA}
 // the user has just been told is configured — the same "no error points at the
 // cause" problem this command exists to remove.
 func darwinGoNote(caPath string) string {
-	return "Note: on macOS, SSL_CERT_FILE cannot make Go tools (go, gh) trust the bridge.\n" +
-		"  Go reads roots from the keychain, not from any CA file, so that one variable is\n" +
-		"  inert here — git, curl and Python are fine. To cover the Go tools, trust the CA\n" +
-		"  in your login keychain:\n\n" +
+	return "Note: on macOS, SSL_CERT_FILE is inert. Go reads roots from the keychain, not\n" +
+		"  from any CA file, so that one variable does nothing here (git, curl and Python\n" +
+		"  are unaffected — they honour theirs on every platform).\n\n" +
+		"  Nothing to do in the common case: gh, go, pip and npm are not intercepted at\n" +
+		"  all, because the bridge tunnels GitHub, the Go module proxy and the package\n" +
+		"  registries by default. Their traffic holds nothing a parser can read.\n\n" +
+		"  Only if you add a host to tls_bridge.passthrough_hosts' replacement list, or\n" +
+		"  point a Go program at a bridged host, does that program need the CA — and on\n" +
+		"  macOS only the keychain can give it one:\n\n" +
 		"    security add-trusted-cert -k ~/Library/Keychains/login.keychain-db \\\n" +
 		"      -p ssl " + caPath + "\n\n" +
 		"  Undo with: security delete-certificate -c authbridge-tls-bridge-ca \\\n" +

--- a/authbridge/cmd/abctl/cmd_claudecode_test.go
+++ b/authbridge/cmd/abctl/cmd_claudecode_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 )
 
 // settingsWithSecret is shaped like a real settings.json: unrelated top-level
@@ -380,15 +382,25 @@ func TestClaudeCodeEnable_SilentWhenCAPresent(t *testing.T) {
 	if code := claudeCodeEnable(settings, cfg, true, &out, &errb); code != 0 {
 		t.Fatalf("first pass: %s", errb.String())
 	}
-	caPath := readEnv(t, settings)[envCACerts]
+	envAfter := readEnv(t, settings)
+	caPath := envAfter[envCACerts]
 	if caPath == "" {
 		t.Fatal("no CA path was written")
 	}
 	if err := os.MkdirAll(filepath.Dir(caPath), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(caPath, []byte("-----BEGIN CERTIFICATE-----\n"), 0o600); err != nil {
-		t.Fatal(err)
+	// Both trust files must exist to silence the notes: ca.crt for Node, and the
+	// bundle for the tools whose CA variable replaces their trust store. They are
+	// written by different steps, so each gets its own note and each must be
+	// created here.
+	for _, p := range []string{caPath, envAfter[envSSLCert]} {
+		if p == "" {
+			t.Fatal("no trust path was written")
+		}
+		if err := os.WriteFile(p, []byte("-----BEGIN CERTIFICATE-----\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Re-run against a clean settings file, same config, now that the CA exists.
@@ -648,5 +660,62 @@ func TestWriteState_RefusesToOverwriteAnUnreadableRecord(t *testing.T) {
 	b, _ := os.ReadFile(path)
 	if string(b) != `{"settings":"` {
 		t.Errorf("the unreadable record was modified: %q", b)
+	}
+}
+
+// TestClaudeCodeEnable_ReplacingVarsGetTheBundleNotTheCA is the regression guard
+// for the bug this set of keys exists to fix. NODE_EXTRA_CA_CERTS EXTENDS Node's
+// trust store, so ca.crt is right for it. Every other CA variable REPLACES the
+// trust store, so ca.crt would leave that tool trusting one private CA and
+// nothing else — breaking all unproxied TLS. The failure is platform-split
+// (macOS keeps working via root_darwin.go, Linux and CI break), so a human is
+// unlikely to catch a regression here by running it locally.
+func TestClaudeCodeEnable_ReplacingVarsGetTheBundleNotTheCA(t *testing.T) {
+	settings, cfg := fixture(t, "{}")
+	var out, errb bytes.Buffer
+	if code := claudeCodeEnable(settings, cfg, true, &out, &errb); code != 0 {
+		t.Fatalf("enable: %s", errb.String())
+	}
+	env := readEnv(t, settings)
+
+	if got := filepath.Base(env[envCACerts]); got != "ca.crt" {
+		t.Errorf("%s = %q, want ca.crt (Node's setting is additive)", envCACerts, got)
+	}
+	for _, k := range bundleKeys {
+		got := env[k]
+		if got == "" {
+			t.Errorf("%s was not written", k)
+			continue
+		}
+		if filepath.Base(got) != tlsbridge.TrustBundleName {
+			t.Errorf("%s = %q, want %s — this variable replaces the trust store, so "+
+				"the bare CA would break every direct TLS call", k, got, tlsbridge.TrustBundleName)
+		}
+	}
+	// All four must agree; a split would trust different sets per tool.
+	for _, k := range bundleKeys[1:] {
+		if env[k] != env[bundleKeys[0]] {
+			t.Errorf("%s = %q disagrees with %s = %q", k, env[k], bundleKeys[0], env[bundleKeys[0]])
+		}
+	}
+}
+
+// TestClaudeCodeDisable_RestoresNewCAKeys: adding keys to managedKeys is only
+// safe if disable's restore bookkeeping covers them too. A user who had their own
+// SSL_CERT_FILE (corporate CA) must get it back, not lose it.
+func TestClaudeCodeDisable_RestoresNewCAKeys(t *testing.T) {
+	const prior = `{"env":{"SSL_CERT_FILE":"/corp/ca.pem"}}`
+	settings, cfg := fixture(t, prior)
+	var out, errb bytes.Buffer
+
+	// A foreign value must not be silently replaced in the first place.
+	if code := claudeCodeEnable(settings, cfg, true, &out, &errb); code == 0 {
+		t.Fatalf("enable overwrote a user-set %s; stdout:\n%s", envSSLCert, out.String())
+	}
+	if !strings.Contains(errb.String(), envSSLCert) {
+		t.Errorf("refusal did not name %s: %s", envSSLCert, errb.String())
+	}
+	if env := readEnv(t, settings); env[envSSLCert] != "/corp/ca.pem" {
+		t.Errorf("%s = %q, want the user's value untouched", envSSLCert, env[envSSLCert])
 	}
 }

--- a/authbridge/cmd/abctl/cmd_claudecode_test.go
+++ b/authbridge/cmd/abctl/cmd_claudecode_test.go
@@ -700,15 +700,18 @@ func TestClaudeCodeEnable_ReplacingVarsGetTheBundleNotTheCA(t *testing.T) {
 	}
 }
 
-// TestClaudeCodeDisable_RestoresNewCAKeys: adding keys to managedKeys is only
-// safe if disable's restore bookkeeping covers them too. A user who had their own
-// SSL_CERT_FILE (corporate CA) must get it back, not lose it.
-func TestClaudeCodeDisable_RestoresNewCAKeys(t *testing.T) {
-	const prior = `{"env":{"SSL_CERT_FILE":"/corp/ca.pem"}}`
-	settings, cfg := fixture(t, prior)
+// TestClaudeCodeEnable_RefusesToClobberUserSSLCertFile: someone behind a
+// corporate CA already has SSL_CERT_FILE set. Replacing it would break their TLS
+// and give no clue why — the same property TestClaudeCodeEnable_
+// RefusesToClobberForeignProxy asserts for HTTPS_PROXY, now that the CA keys are
+// managed too.
+//
+// A foreign value can only ever reach the refusal, never the restore path, which
+// is why the round-trip below needs a cortex-shaped prior value instead.
+func TestClaudeCodeEnable_RefusesToClobberUserSSLCertFile(t *testing.T) {
+	settings, cfg := fixture(t, `{"env":{"SSL_CERT_FILE":"/corp/ca.pem"}}`)
 	var out, errb bytes.Buffer
 
-	// A foreign value must not be silently replaced in the first place.
 	if code := claudeCodeEnable(settings, cfg, true, &out, &errb); code == 0 {
 		t.Fatalf("enable overwrote a user-set %s; stdout:\n%s", envSSLCert, out.String())
 	}
@@ -717,5 +720,72 @@ func TestClaudeCodeDisable_RestoresNewCAKeys(t *testing.T) {
 	}
 	if env := readEnv(t, settings); env[envSSLCert] != "/corp/ca.pem" {
 		t.Errorf("%s = %q, want the user's value untouched", envSSLCert, env[envSSLCert])
+	}
+}
+
+// TestClaudeCodeDisable_RestoresPriorCAValues is the restore path for the CA keys
+// this change added to managedKeys. Both the capture in enable and the loop in
+// disable iterate managedKeys, so the new keys come along for free — but nothing
+// pinned that, and the bookkeeping is where a partial addition would go wrong
+// silently: a key added to the write path but missed by the restore path deletes
+// something the user owned.
+//
+// Uses a cortex-SHAPED prior value (a stale bundle path under ~/.cortex), because
+// isCortexValue accepts it and enable proceeds to overwrite. A foreign value is
+// refused outright and never reaches the state file, so it cannot exercise this.
+func TestClaudeCodeDisable_RestoresPriorCAValues(t *testing.T) {
+	stale := filepath.Join("/somewhere", ".cortex", "ca", "old-bundle.crt")
+	settings, cfg := fixture(t, `{"env":{
+	  "SSL_CERT_FILE":"`+stale+`",
+	  "GIT_SSL_CAINFO":"`+stale+`",
+	  "ANTHROPIC_AUTH_TOKEN":"sk-x"
+	}}`)
+	state := filepath.Join(t.TempDir(), "claude-code-state.json")
+	var out, errb bytes.Buffer
+
+	if code := claudeCodeEnable2(settings, cfg, state, true, &out, &errb); code != 0 {
+		t.Fatalf("enable: %s", errb.String())
+	}
+	// Enable replaced them with the current bundle path.
+	if got := readEnv(t, settings)[envSSLCert]; got == stale {
+		t.Fatalf("%s was not updated, so the restore below proves nothing", envSSLCert)
+	}
+	if code := claudeCodeDisable2(settings, state, true, &out, &errb); code != 0 {
+		t.Fatalf("disable: %s", errb.String())
+	}
+
+	env := readEnv(t, settings)
+	for _, k := range []string{envSSLCert, envGitCA} {
+		if got := env[k]; got != stale {
+			t.Errorf("%s = %q, want the prior value %q restored", k, got, stale)
+		}
+	}
+	// Keys the user did NOT have are still removed rather than left behind.
+	for _, k := range []string{envRequestsCA, envCurlCA, envProxy, envCACerts} {
+		if _, ok := env[k]; ok {
+			t.Errorf("%s survived disable although we added it", k)
+		}
+	}
+	if env["ANTHROPIC_AUTH_TOKEN"] != "sk-x" {
+		t.Error("unrelated entry lost")
+	}
+}
+
+// TestDarwinGoNoteNamesTheKeychainRemedy: SSL_CERT_FILE is inert on macOS, so the
+// note is the only place a user learns that the Go tools need the keychain. If it
+// stops naming the command, the gap goes back to being silent.
+func TestDarwinGoNoteNamesTheKeychainRemedy(t *testing.T) {
+	note := darwinGoNote("/Users/x/.cortex/ca/ca.crt")
+	for _, want := range []string{
+		"security add-trusted-cert", "login.keychain-db",
+		"/Users/x/.cortex/ca/ca.crt", "inert",
+	} {
+		if !strings.Contains(note, want) {
+			t.Errorf("note is missing %q:\n%s", want, note)
+		}
+	}
+	// It must not claim the other tools are broken — they are not.
+	if strings.Contains(note, "git, curl and Python are broken") {
+		t.Error("note overstates the scope")
 	}
 }

--- a/authbridge/cmd/abctl/cmd_claudecode_test.go
+++ b/authbridge/cmd/abctl/cmd_claudecode_test.go
@@ -789,3 +789,34 @@ func TestDarwinGoNoteNamesTheKeychainRemedy(t *testing.T) {
 		t.Error("note overstates the scope")
 	}
 }
+
+// TestManualUninstallDocListsEveryManagedKey pins docs/laptop-service.md against
+// managedKeys.
+//
+// The doc's manual-uninstall fallback tells a user which keys to delete by hand. It
+// said "three" while managedKeys held seven, and four of the missing ones point at
+// bundle.crt — which the same procedure deletes a step earlier. Since those four
+// REPLACE their tool's trust store rather than extending it, following the doc left
+// git, curl and Python failing every TLS call. The count had already drifted once, so
+// it is pinned rather than trusted.
+func TestManualUninstallDocListsEveryManagedKey(t *testing.T) {
+	doc, err := os.ReadFile(filepath.Join("..", "..", "docs", "laptop-service.md"))
+	if err != nil {
+		t.Fatalf("cannot read the laptop-service doc: %v", err)
+	}
+	body := string(doc)
+	for _, k := range managedKeys {
+		if !strings.Contains(body, k) {
+			t.Errorf("laptop-service.md does not mention %s; a user following the "+
+				"manual-uninstall steps would leave it behind", k)
+		}
+	}
+	// And it must not still claim a count, which is what went stale. Naming the
+	// number in prose invites exactly this drift.
+	for _, stale := range []string{"the three Cortex keys", "three keys"} {
+		if strings.Contains(body, stale) {
+			t.Errorf("laptop-service.md still says %q; managedKeys has %d entries",
+				stale, len(managedKeys))
+		}
+	}
+}

--- a/authbridge/cmd/authbridge-proxy/local.go
+++ b/authbridge/cmd/authbridge-proxy/local.go
@@ -100,6 +100,20 @@ tls_bridge:
   mode: enabled
   ca_dir: "` + caDir + `"
   generate_ca: true
+  # passthrough_hosts is deliberately absent. Left unset, the bridge tunnels a
+  # built-in list of developer-tooling hosts — GitHub, the Go module proxy, the
+  # package registries (tlsbridge.DefaultPassthroughHosts) — so gh, go, pip and
+  # npm keep working without being told to trust anything.
+  #
+  # That is not a compromise: no plugin can read that traffic anyway. The parsers
+  # and tool-prune act on agent<->LLM and agent<->tool messages, so forging a leaf
+  # for a module download buys nothing and breaks every Go tool, which on macOS
+  # cannot be pointed at a CA file by environment at all.
+  #
+  # Setting the key here REPLACES that list rather than adding to it, and an
+  # explicit empty list means "intercept everything". Never list an inference
+  # endpoint: skipping one silently removes the parsing and the token savings,
+  # with no error to notice it by.
 pipeline:
   outbound:
     plugins:

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -432,19 +433,31 @@ func main() {
 		// REPLACES their trust store rather than extending it (Go's SSL_CERT_FILE,
 		// GIT_SSL_CAINFO, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE). Pointing those at
 		// ca.crt alone leaves the process trusting this CA and nothing else, which
-		// breaks every unproxied TLS connection it makes. Refreshed on each boot so
-		// a rotated CA or an updated system store is picked up.
+		// breaks every unproxied TLS connection it makes.
 		//
-		// Non-fatal: the bridge works without the bundle — only a client's ability
-		// to verify it is affected — so a host with no locatable root store warns
-		// and carries on rather than failing to start.
-		if bundlePath, berr := tlsbridge.EnsureTrustBundle(cfg.TLSBridge.CADir); berr != nil {
+		// This runs per boot and is a snapshot, not a subscription — see
+		// EnsureTrustBundle's doc for what that costs, notably that a root the OS
+		// distrusts after this point keeps being trusted until the next restart.
+		//
+		// Non-fatal in every case: the bridge works without the bundle, only a
+		// client's ability to verify it is affected.
+		bundlePath, berr := tlsbridge.EnsureTrustBundle(cfg.TLSBridge.CADir)
+		switch {
+		case berr == nil:
+			slog.Info("tls-bridge: CA trust bundle ready", "path", bundlePath)
+		case errors.Is(berr, tlsbridge.ErrCADirNotWritable):
+			// The in-cluster norm: ca_dir is a read-only cert-manager Secret mount,
+			// and a sidecar has no use for the bundle anyway — it exists so a
+			// developer's git/curl/Python can verify a laptop bridge. Warning here
+			// would name four laptop-only variables on every production boot.
+			slog.Debug("tls-bridge: no CA trust bundle (ca_dir is read-only, normal for a "+
+				"mounted Secret); in-cluster clients trust the CA through their own config",
+				"ca_dir", cfg.TLSBridge.CADir)
+		default:
 			slog.Warn("tls-bridge: no CA trust bundle written; tools whose CA setting replaces the "+
 				"trust store (SSL_CERT_FILE, GIT_SSL_CAINFO, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE) "+
 				"have no safe file to point at",
 				"ca_dir", cfg.TLSBridge.CADir, "error", berr)
-		} else {
-			slog.Info("tls-bridge: CA trust bundle ready", "path", bundlePath)
 		}
 		var extra []byte
 		if cfg.TLSBridge.UpstreamCABundle != "" {

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -428,6 +428,24 @@ func main() {
 				"ca_dir", cfg.TLSBridge.CADir,
 				"hint", "clients must trust it, e.g. NODE_EXTRA_CA_CERTS="+cfg.TLSBridge.CADir+"/ca.crt")
 		}
+		// Assemble the CA + platform-roots bundle for tools whose CA setting
+		// REPLACES their trust store rather than extending it (Go's SSL_CERT_FILE,
+		// GIT_SSL_CAINFO, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE). Pointing those at
+		// ca.crt alone leaves the process trusting this CA and nothing else, which
+		// breaks every unproxied TLS connection it makes. Refreshed on each boot so
+		// a rotated CA or an updated system store is picked up.
+		//
+		// Non-fatal: the bridge works without the bundle — only a client's ability
+		// to verify it is affected — so a host with no locatable root store warns
+		// and carries on rather than failing to start.
+		if bundlePath, berr := tlsbridge.EnsureTrustBundle(cfg.TLSBridge.CADir); berr != nil {
+			slog.Warn("tls-bridge: no CA trust bundle written; tools whose CA setting replaces the "+
+				"trust store (SSL_CERT_FILE, GIT_SSL_CAINFO, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE) "+
+				"have no safe file to point at",
+				"ca_dir", cfg.TLSBridge.CADir, "error", berr)
+		} else {
+			slog.Info("tls-bridge: CA trust bundle ready", "path", bundlePath)
+		}
 		var extra []byte
 		if cfg.TLSBridge.UpstreamCABundle != "" {
 			if extra, err = os.ReadFile(cfg.TLSBridge.UpstreamCABundle); err != nil {

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -464,10 +464,17 @@ func main() {
 				ports[p] = true
 			}
 		}
+		// A bad passthrough pattern is fatal rather than ignored: silently not
+		// matching presents as "the bridge broke my tool", with nothing tying the
+		// symptom back to the typo.
+		decision, derr := tlsbridge.NewDecision(tlsbridge.DecisionOpts{
+			Ports: ports, SkipHosts: cfg.TLSBridge.PassthroughHosts,
+		})
+		if derr != nil {
+			log.Fatalf("tls-bridge: %v", derr)
+		}
 		bridge = &tlsbridge.Engine{
-			Decision: tlsbridge.NewDecision(tlsbridge.DecisionOpts{
-				Ports: ports, SkipHosts: cfg.TLSBridge.PassthroughHosts,
-			}),
+			Decision: decision,
 			Term:     tlsbridge.NewTerminator(minter),
 			Skip:     tlsbridge.NewSkipSet(),
 			Upstream: up,

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -135,10 +135,19 @@ process within seconds, which looks like it refusing to die.
 abctl claude-code disable
 ```
 
-This removes only the three keys Cortex added to `~/.claude/settings.json`
-(`HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`)
-and leaves anything else in that file alone. Claude Code goes straight to the API
-again. Restart `claude` to pick it up.
+This removes only the keys Cortex added to `~/.claude/settings.json`
+(`HTTPS_PROXY`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, and the CA variables
+`NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE` / `GIT_SSL_CAINFO` / `REQUESTS_CA_BUNDLE` /
+`CURL_CA_BUNDLE`) and leaves anything else in that file alone. Claude Code goes
+straight to the API again. Restart `claude` to pick it up.
+
+There are several CA variables because anything Claude Code spawns inherits
+`HTTPS_PROXY` and so must also be able to verify the bridge. They do not all get
+the same file: `NODE_EXTRA_CA_CERTS` **extends** Node's trust store, so it gets
+`ca.crt`, while the rest **replace** the trust store and get `bundle.crt` — the CA
+followed by this machine's public roots. Pointing a replacing variable at `ca.crt`
+would leave that tool trusting one private CA and nothing else, which breaks every
+direct TLS call it makes.
 
 Cortex keeps running; nothing sends traffic to it. `abctl claude-code enable` puts it
 back.
@@ -163,9 +172,11 @@ pgrep -fl authbridge-prox                   # should print nothing
 ls ~/.cortex 2>/dev/null                    # should print nothing
 ```
 
-The CA that step 3 removes was only ever trusted through `NODE_EXTRA_CA_CERTS` in
+The CA that step 3 removes was only ever trusted through the CA variables in
 `~/.claude/settings.json` — Cortex never adds it to the system or login keychain, so
-there is nothing to clean up there.
+there is nothing to clean up there. `bundle.crt` lives in the same directory and is
+derived from `ca.crt` plus a copy of the public roots, so removing `~/.cortex` takes
+it with them; it holds no private key and grants nothing on its own.
 
 #### If `abctl` is already gone
 

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -259,5 +259,24 @@ systemctl --user disable --now cortex.service
 rm -f ~/.config/systemd/user/cortex.service
 ```
 
-Then delete the three Cortex keys from the `env` block of
-`~/.claude/settings.json` yourself.
+Then delete the Cortex keys from the `env` block of `~/.claude/settings.json`
+yourself. There are **seven**:
+
+```
+HTTPS_PROXY
+NODE_EXTRA_CA_CERTS
+SSL_CERT_FILE
+GIT_SSL_CAINFO
+REQUESTS_CA_BUNDLE
+CURL_CA_BUNDLE
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC
+```
+
+**Remove all seven, and do it before `rm -rf ~/.cortex`.** The middle four point at
+`~/.cortex/ca/bundle.crt`, and unlike `NODE_EXTRA_CA_CERTS` each of them *replaces*
+its tool's trust store rather than adding to it. Leave them behind with the file
+deleted and git, curl and Python fail **every** TLS call — including calls that have
+nothing to do with Cortex — with `error setting certificate verify locations`, on a
+machine you believe you have just cleaned. `abctl claude-code disable` removes all
+seven in the right order, which is why it is step 1 above; this list is only for when
+that binary is already gone.

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -149,6 +149,23 @@ followed by this machine's public roots. Pointing a replacing variable at `ca.cr
 would leave that tool trusting one private CA and nothing else, which breaks every
 direct TLS call it makes.
 
+### Developer tooling is not intercepted at all
+
+`gh`, `go`, `pip` and `npm` work out of the box, without trusting anything. The
+bridge ships a default `passthrough_hosts` list — GitHub, the Go module proxy and
+checksum DB, the package registries — and tunnels them rather than forging a leaf.
+
+That costs nothing. `inference-parser`, the MCP/A2A parsers and `tool-prune` all act
+on agent↔LLM and agent↔tool messages; none of them has anything to say about a
+module download. Intercepting those hosts produced no observability and broke every
+Go tool, which is the worst of both.
+
+To see the list, or to override it, set `tls_bridge.passthrough_hosts` in
+`~/.cortex/config.yaml`. An explicit list **replaces** the default rather than adding
+to it, and `passthrough_hosts: []` intercepts everything. Never list an inference
+endpoint there: it would silently remove the parsing and the token savings, with no
+error anywhere to notice it by.
+
 ### Go tools on macOS need the keychain, not a variable
 
 `SSL_CERT_FILE` — the Go one, covering `go`, `gh` and `abctl` itself — **does

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -149,6 +149,36 @@ followed by this machine's public roots. Pointing a replacing variable at `ca.cr
 would leave that tool trusting one private CA and nothing else, which breaks every
 direct TLS call it makes.
 
+### Go tools on macOS need the keychain, not a variable
+
+`SSL_CERT_FILE` — the Go one, covering `go`, `gh` and `abctl` itself — **does
+nothing on macOS**. Go's `crypto/x509` honours it only in `root_unix.go`, which is
+built for `linux || freebsd || …` and excludes darwin; darwin's `loadSystemRoots`
+returns a sentinel that reads no files, and verification is then handed to
+Security.framework, which consults the keychain alone. No environment variable can
+change that.
+
+So on a Mac, when the bridge decrypts a host a Go tool is talking to, that tool
+fails with a bare `x509: certificate signed by unknown authority`. To cover them,
+trust the CA in your login keychain:
+
+```sh
+security add-trusted-cert -k ~/Library/Keychains/login.keychain-db \
+  -p ssl ~/.cortex/ca/ca.crt
+```
+
+Undo with:
+
+```sh
+security delete-certificate -c authbridge-tls-bridge-ca \
+  ~/Library/Keychains/login.keychain-db
+```
+
+`git`, `curl` and Python are **not** affected on macOS — they read their bundles
+through OpenSSL/LibreSSL, which honours the variables on every platform. And on
+Linux `SSL_CERT_FILE` works normally, so nothing extra is needed there.
+`abctl claude-code enable` prints this note when it runs on macOS.
+
 Cortex keeps running; nothing sends traffic to it. `abctl claude-code enable` puts it
 back.
 

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -203,10 +203,30 @@ ls ~/.cortex 2>/dev/null                    # should print nothing
 ```
 
 The CA that step 3 removes was only ever trusted through the CA variables in
-`~/.claude/settings.json` — Cortex never adds it to the system or login keychain, so
-there is nothing to clean up there. `bundle.crt` lives in the same directory and is
-derived from `ca.crt` plus a copy of the public roots, so removing `~/.cortex` takes
-it with them; it holds no private key and grants nothing on its own.
+`~/.claude/settings.json` — *Cortex* never adds it to the system or login keychain.
+`bundle.crt` lives in the same directory and is derived from `ca.crt` plus a copy of
+the public roots, so removing `~/.cortex` takes it with them; it holds no private
+key and grants nothing on its own.
+
+**On macOS, if you followed the Go-tools step above** and ran
+`security add-trusted-cert` yourself, that trust setting is the one thing outside
+`~/.cortex` and outside `~/.claude/settings.json`, so it outlives both. Deleting the
+CA file does not withdraw it — the keychain holds its own copy. Remove it too:
+
+```sh
+security delete-certificate -c authbridge-tls-bridge-ca \
+  ~/Library/Keychains/login.keychain-db
+```
+
+Check whether it is there at all with:
+
+```sh
+security find-certificate -c authbridge-tls-bridge-ca ~/Library/Keychains/login.keychain-db
+```
+
+Leaving it behind means a CA whose private key you have deleted stays trusted for
+TLS — harmless in itself, since nothing can sign with it any more, but it is trust
+you did not intend to keep.
 
 #### If `abctl` is already gone
 

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -718,10 +718,19 @@ info ""
 # bare CA is correct for `claude`. Every other tool's CA variable REPLACES the
 # trust store, so pointing those at ca.crt leaves them trusting this CA and
 # nothing else — they need the CA+roots bundle instead.
-info "  Other tools (go, gh, git, curl, python) need bundle.crt, not ca.crt:"
-info "    SSL_CERT_FILE=${ca_dir}/bundle.crt"
-info "      (also GIT_SSL_CAINFO / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE;"
+info "  Other tools (git, curl, python) need bundle.crt, not ca.crt:"
+info "    GIT_SSL_CAINFO=${ca_dir}/bundle.crt"
+info "      (also REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE / SSL_CERT_FILE;"
 info "       \"${abctl_cmd}\" claude-code enable sets all of them for you)"
 info ""
+# SSL_CERT_FILE is the Go one, and Go on macOS reads roots from the keychain
+# rather than any CA file, so the variable is inert there. Only the keychain can
+# make go/gh trust the bridge on a Mac; on Linux SSL_CERT_FILE is enough.
+if [ "$(uname -s)" = "Darwin" ]; then
+	info "  On macOS, Go tools (go, gh) ignore SSL_CERT_FILE — trust the CA instead:"
+	info "    security add-trusted-cert -k ~/Library/Keychains/login.keychain-db \\"
+	info "      -p ssl ${ca_dir}/ca.crt"
+	info ""
+fi
 info "  Stop it:         \"${abctl_cmd}\" service stop      (start / restart / status too)"
 info ""

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -714,5 +714,14 @@ info "    HTTPS_PROXY=http://localhost:${DEMO_FORWARD_PORT} \\"
 info "      NODE_EXTRA_CA_CERTS=${ca_dir}/ca.crt \\"
 info "      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 claude"
 info ""
+# NODE_EXTRA_CA_CERTS above is Node-specific and EXTENDS the trust store, so the
+# bare CA is correct for `claude`. Every other tool's CA variable REPLACES the
+# trust store, so pointing those at ca.crt leaves them trusting this CA and
+# nothing else — they need the CA+roots bundle instead.
+info "  Other tools (go, gh, git, curl, python) need bundle.crt, not ca.crt:"
+info "    SSL_CERT_FILE=${ca_dir}/bundle.crt"
+info "      (also GIT_SSL_CAINFO / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE;"
+info "       \"${abctl_cmd}\" claude-code enable sets all of them for you)"
+info ""
 info "  Stop it:         \"${abctl_cmd}\" service stop      (start / restart / status too)"
 info ""


### PR DESCRIPTION
## Summary

Two complementary changes so that **everything a developer runs behind the bridge works, and everything the bridge can parse stays parseable**.

1. **Developer tooling is no longer intercepted at all.** `gh`, `go`, `pip` and `npm` work out of the box, with nothing to trust and nothing to configure.
2. **Non-Node clients whose traffic we *do* want to parse can verify the bridge**, via a CA+roots bundle and the CA variables their TLS stacks actually read.

They cover opposite populations, which is why both are here: passthrough is for traffic no plugin can read; the variables are for traffic we want to read from clients that aren't Node.

## 1. Default `passthrough_hosts`

The bridge terminated everything on 443 that wasn't skip-listed, and `passthrough_hosts` shipped empty. So a dev tool's first request to any host got a forged leaf, rejected it, and hard-failed — and for most of those tools **no fix was available**: `gh` has no CA option (cli/cli#1735, open since 2020), and a Go binary on macOS can't be pointed at a CA file by environment (`root_unix.go`, which honours `SSL_CERT_FILE`, excludes darwin).

Intercepting them was never buying anything. `inference-parser`, the MCP/A2A parsers and `tool-prune` act on agent↔LLM and agent↔tool messages; none has anything to say about a module download. The traffic was decrypted, understood by nobody, and broken for the caller.

`passthrough_hosts` now defaults to `tlsbridge.DefaultPassthroughHosts` when unset — GitHub, the Go toolchain, the package registries. Matching moves from exact string to the existing `skiphost` glob matcher, so a host family is one entry and a typo'd pattern is a boot error rather than a silent non-match.

Nil means unset and takes the defaults; an explicit list **replaces** them and `[]` intercepts everything, so anyone who wants to observe GitHub traffic still can.

**Verified** against a proxy built from this branch, no `SSL_CERT_FILE`, nothing in the keychain:

```
gh #1 OK   gh #2 OK   gh #3 OK
git OK     pip OK     npm OK     curl github: 200
handshake failures in the proxy log: 0
```

And the control holds — the endpoints that matter are still bridged:

```
api.anthropic.com                      BRIDGED  (parsers can see it)
generativelanguage.googleapis.com      BRIDGED  (parsers can see it)
api.github.com                         TUNNELED
proxy.golang.org                       TUNNELED
```

Four list entries came from testing rather than reasoning, which is the argument for having tested it: `storage.googleapis.com` (`proxy.golang.org` redirects module zips there), `go.dev` (toolchain version check), `dl.google.com` (`GOTOOLCHAIN` downloads), and `go.yaml.in`. Each surfaced only after everything before it was already skipped.

## 2. The CA bundle and the variables

`abctl claude-code enable` wrote `NODE_EXTRA_CA_CERTS` and stopped there. But `HTTPS_PROXY` is inherited by everything Claude Code spawns, so any non-Node client hitting a **bridged** host — which now means an LLM or tool endpoint, exactly the traffic we want — gets its TLS intercepted with no CA it recognises.

The in-tree examples are Python: `authbridge/sparc-service/sparc_service/providers.py` and `authbridge/demos/hr-cpex/agent/agent.py` both make LLM calls via `requests`. For those, passthrough would be *counterproductive* — it would blind the parsers on the calls that matter. `REQUESTS_CA_BUNDLE` is what makes them observable instead of broken.

The obvious approach — point `SSL_CERT_FILE` at `ca.crt` — is a trap. Node's variable **extends** the trust store; the others **replace** it:

```go
files := certFiles
if f := os.Getenv(certFileEnv); f != "" {
    files = []string{f}          // crypto/x509 root_unix.go — defaults discarded
}
```

So `ca.crt` alone means "trust one private CA and nothing else," and every unproxied TLS call from that process fails. Hence a **bundle**: `tlsbridge.EnsureTrustBundle` writes `<ca_dir>/bundle.crt` as the bridge CA followed by the platform's public roots, refreshed each boot. It mints nothing — no key, no certificate — it concatenates `ca.crt` with the platform root file OpenSSL, curl, git and Go already read.

| Variable | File | Why |
|---|---|---|
| `NODE_EXTRA_CA_CERTS` | `ca.crt` | extends Node's trust store |
| `GIT_SSL_CAINFO` | `bundle.crt` | git, incl. `go mod`'s VCS fetches |
| `REQUESTS_CA_BUNDLE` | `bundle.crt` | Python `requests` — the LLM callers above |
| `CURL_CA_BUNDLE` | `bundle.crt` | curl |
| `SSL_CERT_FILE` | `bundle.crt` | Go — **Linux and CI only**, see below |

### macOS: `SSL_CERT_FILE` is inert

Verified, not assumed. `root_unix.go` excludes darwin; darwin's `loadSystemRoots` returns a `systemPool: true` sentinel that reads no file, and `verify.go:563` routes to `systemVerify` — Security.framework only. It is written anyway because it is correct and necessary on Linux and in-cluster, and `enable` prints the `security add-trusted-cert` command on darwin for the residual case.

Worth recording that macOS does **not** restrict this to the keychain, as I first claimed: `verify.go:566-575` falls through to the pure-Go verifier when `Roots` came from `SystemCertPool()` and the platform verifier failed, so any Go program that opts in via `SystemCertPool` + `AppendCertsFromPEM` trusts a private CA fine. The real constraint is narrower — there is no way to inject roots into a binary you don't compile.

### Failure mode chosen deliberately

If no platform root store can be found, **no bundle is written** and the boot warns; a CA-only bundle would hand every tool a trust store containing one private CA. An existing bundle is **kept**, not deleted: four variables point at that file and each replaces its tool's trust store, so an absent bundle fails every TLS call rather than falling back.

## Testing

```bash
cd authbridge/authlib   && GOWORK=off go test -race ./tlsbridge/ ./listener/...
cd authbridge/cmd/abctl && GOWORK=off go test -race ./...
```

Bundle: both trust sets present, CA ordering, idempotency, rewrite-on-rotation, missing CA, missing roots, unparseable roots, stale-bundle retention, PEM splice safety. Decision: the default list covers the observed failures, **inference and tool endpoints are never skipped**, nil-vs-empty semantics, and unusable patterns are rejected. abctl: the key→file split, and refusing to clobber a user's own `SSL_CERT_FILE`.

`install.sh` needed no logic change (it delegates to `abctl claude-code enable`); its manual hint and `laptop-service.md` are updated, including keychain cleanup on uninstall, since the CA is now something a user may have added themselves.

Note `gofmt` also flags `authlib/auth/result.go`, `plugins/tokenexchange/provider.go` and three `_test.go` files on `main`; those are pre-existing and left alone.

## Related

- #912 — the auto-skip behaviour behind the intermittent failures. This PR removes the most common trigger (the tooling hosts are no longer bridged at all) but not the masking behaviour itself.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a combined trust bundle containing the bridge CA and valid platform root certificates.
  * Claude Code setup now configures common tools to use the combined bundle while preserving Node-based CA settings.
  * Added default passthrough rules for common developer tools and package registries.
* **Bug Fixes**
  * Invalid certificate sources are ignored, and read-only CA directories are handled gracefully.
  * Invalid passthrough patterns now produce a clear startup error.
  * Improved protection of user settings and restoration during disable.
* **Documentation**
  * Updated platform-specific certificate guidance, including macOS keychain instructions and installer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->