### PR TITLE
Feat: Column picker for the events table

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -94,12 +94,16 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
 - **Sessions** (default): table of active sessions in the store, most
   recently updated first. Columns: ID, updated (relative), event count,
   active marker.
-- **Events**: per-session event table, with `c` to choose columns. Twelve are
-  defined and all of them together need ~135 terminal columns, so the table
-  drops what does not fit and the footer says how many (`→ N more columns`).
-  HOST is defined but off by default for that reason — turn it on with `c`, and
-  a column you enable explicitly outranks the ones that are merely on by
-  default, so it is not the first thing dropped again.
+- **Events**: per-session event table. `c` opens a column picker — a popup with
+  a checkbox and a one-line description per column, since twelve abbreviated
+  headers are not self-describing.
+
+  All twelve together need ~156 terminal columns, so the table drops what does
+  not fit and the footer says how many (`→ N more columns`). Columns carry a
+  keep rank rather than being equally expendable: DIR, DURATION, TOKENS and COST
+  give way first, while `#` and HOST survive longest. That is what makes HOST
+  usable at 80 columns despite being last in display order — it is the column
+  most people open this pane for.
 
   Default columns: time, direction (in/out),
   phase (req/resp), protocol (a2a/mcp/inf), method or model, HTTP status,
@@ -182,7 +186,7 @@ Layered on top of all of them:
 | `Esc` | sessions, pipeline | (picker mode) tear down port-forward and back to pods |
 | `/` | sessions, events | filter (substring match; Enter commits, Esc cancels) |
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
-| `c` | events | choose which columns to show (`←→` move, `space` toggle, `r` reset, `c`/`Esc` done) |
+| `c` | events | open the column picker (`↑↓` move, `space` toggle, `r` reset, `Esc` close) |
 | `p` | any | pause/resume stream |
 | `y` | detail | yank event JSON to `/tmp` |
 | `g` / `G` | lists | jump to top / bottom |

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -98,7 +98,7 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   a checkbox and a one-line description per column, since twelve abbreviated
   headers are not self-describing.
 
-  All twelve together need ~156 terminal columns, so the table drops what does
+  All twelve together need ~168 terminal columns, so the table drops what does
   not fit and the footer says how many (`→ N more columns`). Columns carry a
   keep rank rather than being equally expendable: DIR, DURATION, TOKENS and COST
   give way first, while `#` and HOST survive longest. That is what makes HOST

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -105,10 +105,14 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   usable at 80 columns despite being last in display order — it is the column
   most people open this pane for.
 
-  Default columns: time, direction (in/out),
-  phase (req/resp), protocol (a2a/mcp/inf), method or model, HTTP status,
-  duration, host. Live-updates while in view — if the cursor is on the
-  last row, it auto-follows new events.
+  All twelve are on by default: `#` (exchange number, shared by a request
+  and its response), TIME, DIR, PHASE, ACTION, PLUGIN, METHOD, STATUS,
+  DURATION, TOKENS, COST, HOST. On a narrow terminal the low-ranked ones
+  are hidden rather than turned off, so widening the window brings them
+  back without touching the picker.
+
+  Live-updates while in view — if the cursor is on the last row, it
+  auto-follows new events.
 - **Detail**: pretty-printed JSON of a single event. Scroll with arrow
   keys; `y` yanks to `/tmp/abctl-event-<timestamp>.json` and flashes the
   path in the footer.

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -94,7 +94,14 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
 - **Sessions** (default): table of active sessions in the store, most
   recently updated first. Columns: ID, updated (relative), event count,
   active marker.
-- **Events**: per-session event table. Columns: time, direction (in/out),
+- **Events**: per-session event table, with `c` to choose columns. Twelve are
+  defined and all of them together need ~135 terminal columns, so the table
+  drops what does not fit and the footer says how many (`→ N more columns`).
+  HOST is defined but off by default for that reason — turn it on with `c`, and
+  a column you enable explicitly outranks the ones that are merely on by
+  default, so it is not the first thing dropped again.
+
+  Default columns: time, direction (in/out),
   phase (req/resp), protocol (a2a/mcp/inf), method or model, HTTP status,
   duration, host. Live-updates while in view — if the cursor is on the
   last row, it auto-follows new events.
@@ -175,6 +182,7 @@ Layered on top of all of them:
 | `Esc` | sessions, pipeline | (picker mode) tear down port-forward and back to pods |
 | `/` | sessions, events | filter (substring match; Enter commits, Esc cancels) |
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
+| `c` | events | choose which columns to show (`←→` move, `space` toggle, `r` reset, `c`/`Esc` done) |
 | `p` | any | pause/resume stream |
 | `y` | detail | yank event JSON to `/tmp` |
 | `g` / `G` | lists | jump to top / bottom |

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -190,7 +190,7 @@ Layered on top of all of them:
 | `Esc` | sessions, pipeline | (picker mode) tear down port-forward and back to pods |
 | `/` | sessions, events | filter (substring match; Enter commits, Esc cancels) |
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
-| `c` | events | open the column picker (`↑↓` move, `space` toggle, `r` reset, `Esc` close) |
+| `c` | events | open the column picker (`↑↓`/`jk` move, `space`/`x` toggle, `r` reset, `Esc`/`Enter`/`c` close) |
 | `p` | any | pause/resume stream |
 | `y` | detail | yank event JSON to `/tmp` |
 | `g` / `G` | lists | jump to top / bottom |

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -1103,6 +1103,11 @@ func (m *model) View() string {
 	if m.helpVisible {
 		return overlayCenter(base, renderHelpOverlay(m.helpVp, m.width, m.height), m.width, m.height)
 	}
+	if m.colPicker {
+		return overlayCenter(base,
+			renderColumnPicker(m.eventColumns, m.colCursor, m.width, m.height),
+			m.width, m.height)
+	}
 	return base
 }
 

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -228,7 +228,20 @@ type model struct {
 	// UI state.
 	pane paneID
 	// usage is the Usage pane's view state (metric, window, scope, snapshot).
-	usage        usageState
+	usage usageState
+
+	// eventColumns is which events-table columns are shown. Keyed by a stable id
+	// rather than an index, so a future column inserted in the middle does not
+	// silently change what an existing selection means.
+	eventColumns map[eventColumnID]bool
+	// eventColsDropped is how many selected columns did not fit the terminal on the
+	// last rebuild. Surfaced in the footer: with every column on the table needs
+	// ~151 columns, and the excess was clipped with nothing saying so (#866).
+	eventColsDropped int
+	// colPicker is open while `c` owns the keyboard; colCursor is the highlighted
+	// column within it.
+	colPicker    bool
+	colCursor    int
 	selectedSess string
 	filter       string
 	filtering    bool
@@ -361,6 +374,7 @@ func New(ctx context.Context, c *apiclient.Client) tea.Model {
 		cancel:       cancel,
 		events:       make(map[string][]pipeline.SessionEvent),
 		pane:         paneSessions,
+		eventColumns: defaultColumnSelection(),
 		sessionsTbl:  newSessionsTable(),
 		eventsTbl:    newEventsTable(),
 		pipelineTbl:  newPipelineTable(),

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -1137,6 +1137,10 @@ func (m *model) paneView() string {
 		if m.pickerErr != "" {
 			footer = "error: " + m.pickerErr + "    " + footer
 		}
+		// Fitted like the session-view footer: an error prefix can push even a
+		// short picker hint past the terminal width, and a wrapped footer costs a
+		// row of the table above it.
+		footer = fitHintLine(footer, m.width)
 		return lipgloss.JoinVertical(lipgloss.Left,
 			styleTitle.Render(title),
 			body,
@@ -1150,6 +1154,10 @@ func (m *model) paneView() string {
 		if m.pickerErr != "" {
 			footer = "error: " + m.pickerErr + "    " + footer
 		}
+		// Fitted like the session-view footer: an error prefix can push even a
+		// short picker hint past the terminal width, and a wrapped footer costs a
+		// row of the table above it.
+		footer = fitHintLine(footer, m.width)
 		return lipgloss.JoinVertical(lipgloss.Left,
 			styleTitle.Render(title),
 			body,

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -236,7 +236,7 @@ type model struct {
 	eventColumns map[eventColumnID]bool
 	// eventColsDropped is how many selected columns did not fit the terminal on the
 	// last rebuild. Surfaced in the footer: with every column on the table needs
-	// ~151 columns, and the excess was clipped with nothing saying so (#866).
+	// ~156 columns, and the excess was clipped with nothing saying so (#866).
 	eventColsDropped int
 	// colPicker is open while `c` owns the keyboard; colCursor is the highlighted
 	// column within it.

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -626,6 +626,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.selectedSess != "" && !serverIDs[m.selectedSess] && m.pane != paneSessions {
 			m.selectedSess = ""
 			m.pane = paneSessions
+			// Close the picker with the pane it belongs to.
+			//
+			// The paneEvents gates on the key block and in View() make it inert and
+			// invisible while the user is on the sessions table, but the flag itself
+			// outlived the pane: pressing enter on another session put m.pane back to
+			// paneEvents and the popup the user never reopened was there again, owning
+			// the keyboard until they found esc. Gating covers "drawn over the wrong
+			// pane"; this covers the return trip.
+			m.colPicker = false
 		}
 		m.sessions = []session.SessionSummary(msg)
 		m.connState.phase = connOpen

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -236,7 +236,7 @@ type model struct {
 	eventColumns map[eventColumnID]bool
 	// eventColsDropped is how many selected columns did not fit the terminal on the
 	// last rebuild. Surfaced in the footer: with every column on the table needs
-	// ~156 columns, and the excess was clipped with nothing saying so (#866).
+	// ~168 columns, and the excess was clipped with nothing saying so (#866).
 	eventColsDropped int
 	// colPicker is open while `c` owns the keyboard; colCursor is the highlighted
 	// column within it.
@@ -1103,7 +1103,9 @@ func (m *model) View() string {
 	if m.helpVisible {
 		return overlayCenter(base, renderHelpOverlay(m.helpVp, m.width, m.height), m.width, m.height)
 	}
-	if m.colPicker {
+	// Same paneEvents scoping as the key block: an async pane change must not leave
+	// the popup drawn over a pane it does not belong to.
+	if m.colPicker && m.pane == paneEvents {
 		return overlayCenter(base,
 			renderColumnPicker(m.eventColumns, m.colCursor, m.width, m.height),
 			m.width, m.height)

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -1,0 +1,237 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/table"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// eventColumnID names a column stably, so a saved selection survives reordering
+// and a future column being inserted in the middle.
+type eventColumnID string
+
+const (
+	colIndex    eventColumnID = "#"
+	colTime     eventColumnID = "TIME"
+	colDir      eventColumnID = "DIR"
+	colPhase    eventColumnID = "PHASE"
+	colAction   eventColumnID = "ACTION"
+	colPlugin   eventColumnID = "PLUGIN"
+	colMethod   eventColumnID = "METHOD"
+	colStatus   eventColumnID = "STATUS"
+	colDuration eventColumnID = "DURATION"
+	colTokens   eventColumnID = "TOKENS"
+	colCost     eventColumnID = "COST"
+	colHost     eventColumnID = "HOST"
+)
+
+// cellContext is what a cell function needs beyond the event itself.
+//
+// Two cells (TOKENS, COST) pair a request with its response to show a saving, so
+// they need the row slice and the partner index as well as the model. Passing one
+// struct keeps every cell function the same shape, rather than some taking an
+// event and others taking five arguments.
+type cellContext struct {
+	m       *model
+	rows    []eventRow
+	partner map[int]int
+	i       int
+	row     eventRow
+	// ids pairs a request event with its response, computed once per rebuild by
+	// computeEventPairs. Carried here rather than recomputed per cell.
+	ids map[*pipeline.SessionEvent]int
+}
+
+// eventColumn is one column: how to head it, how wide, and how to fill it.
+//
+// Header and cell live together on purpose. They were two parallel slices —
+// []table.Column and a positional table.Row literal — maintained by hand, so
+// inserting a column meant editing both in step and a mismatch silently shifted
+// every cell right of it into the wrong heading.
+type eventColumn struct {
+	id    eventColumnID
+	width int
+	// cell renders this column for one row.
+	cell func(cellContext) string
+	// defaultOn is whether the column shows without the user asking.
+	//
+	// HOST is off by default despite being the column issue #866 was filed about:
+	// with everything on, the table needs ~151 columns, so HOST was never visible
+	// anyway. Off-by-default plus a picker means it is reachable, rather than
+	// present-but-clipped.
+	defaultOn bool
+}
+
+// eventColumns is the single definition every events-table column comes from, in
+// display order.
+var eventColumns = []eventColumn{
+	{id: colIndex, width: 4, defaultOn: true,
+		cell: func(c cellContext) string {
+			if id, ok := c.ids[c.row.event]; ok {
+				return strconv.Itoa(id)
+			}
+			return ""
+		}},
+	{id: colTime, width: 12, defaultOn: true,
+		cell: func(c cellContext) string { return c.row.event.At.Format("15:04:05.00") }},
+	{id: colDir, width: 4, defaultOn: true,
+		cell: func(c cellContext) string { return shortDirection(c.row.event.Direction) }},
+	{id: colPhase, width: 7, defaultOn: true,
+		cell: func(c cellContext) string { return shortPhase(c.row.event.Phase) }},
+	{id: colAction, width: actionColWidth, defaultOn: true,
+		cell: func(c cellContext) string { a, _ := rowAction(c.row, c.row.invocations()); return a }},
+	{id: colPlugin, width: 18, defaultOn: true,
+		cell: func(c cellContext) string {
+			_, p := rowAction(c.row, c.row.invocations())
+			return truncStr(p, 18)
+		}},
+	{id: colMethod, width: methodColWidth, defaultOn: true,
+		cell: func(c cellContext) string { return eventMethod(*c.row.event) }},
+	{id: colStatus, width: 7, defaultOn: true,
+		cell: func(c cellContext) string { return statusCell(*c.row.event) }},
+	{id: colDuration, width: 10, defaultOn: true,
+		cell: func(c cellContext) string { return durationCell(*c.row.event) }},
+	{id: colTokens, width: 17, defaultOn: true,
+		cell: func(c cellContext) string { return c.m.tokensCell(c.rows, c.partner, c.i, c.row.event) }},
+	{id: colCost, width: 19, defaultOn: true,
+		cell: func(c cellContext) string { return c.m.costCell(c.rows, c.partner, c.i, c.row.event) }},
+	// The column the issue is about. Off by default — see eventColumn.defaultOn.
+	{id: colHost, width: 20, defaultOn: false,
+		cell: func(c cellContext) string { return truncStr(c.row.event.Host, 20) }},
+}
+
+// defaultColumnSelection is the set shown before the user chooses.
+func defaultColumnSelection() map[eventColumnID]bool {
+	out := make(map[eventColumnID]bool, len(eventColumns))
+	for _, c := range eventColumns {
+		out[c.id] = c.defaultOn
+	}
+	return out
+}
+
+// selectedColumns returns the visible columns in display order.
+//
+// Falls back to the defaults on an empty selection rather than rendering a table
+// with no columns: a user who turns everything off should get a chart back, not a
+// blank pane they cannot recover from without restarting.
+func selectedColumns(sel map[eventColumnID]bool) []eventColumn {
+	var out []eventColumn
+	for _, c := range eventColumns {
+		if sel[c.id] {
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 {
+		for _, c := range eventColumns {
+			if c.defaultOn {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+// tableColumns converts the selection into the bubbles column slice.
+func tableColumns(cols []eventColumn) []table.Column {
+	out := make([]table.Column, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, table.Column{Title: string(c.id), Width: c.width})
+	}
+	return out
+}
+
+// columnsWidth is how many terminal columns a selection needs, including the
+// one-space gutter bubbles renders between cells.
+func columnsWidth(cols []eventColumn) int {
+	w := 0
+	for _, c := range cols {
+		w += c.width + 1
+	}
+	return w
+}
+
+// fitColumns keeps as many selected columns as the terminal holds, and reports how
+// many it had to drop.
+//
+// Explicit rather than letting bubbles clip: with every column on the table needs
+// ~135 terminal columns, so HOST simply was not there and nothing said so. The
+// count feeds the footer, which is what issue #866 asks for.
+//
+// Drops by declaration order from the right, EXCEPT that a column the user turned
+// on explicitly outranks one that is merely on by default. Without that, the
+// issue's own scenario fails: turn off DIR/TIME/TOKENS to make room for HOST, and
+// HOST — last in display order — is still the first thing dropped, so the user
+// gets none of what they asked for. An explicit choice has to survive the columns
+// nobody chose.
+//
+// Never returns an empty slice: one clipped column beats a blank pane.
+func fitColumns(cols []eventColumn, width int) (fitted []eventColumn, dropped int) {
+	if width <= 0 || columnsWidth(cols) <= width {
+		return cols, 0
+	}
+
+	// Rank sacrifices: default-on columns first, from the right, then opted-in
+	// ones. Index 0 is never sacrificed — "#" pairs the exchange and is what makes
+	// the timeline readable at all.
+	// Two passes: default-on columns are given up first, then the opted-in ones. A
+	// column with defaultOn=false is only present because the user asked for it, so
+	// it is sacrificed LAST — the reverse of that is what made HOST vanish again in
+	// the issue's own scenario.
+	sacrificeOrder := make([]int, 0, len(cols))
+	for _, giveUpDefaults := range []bool{true, false} {
+		for i := len(cols) - 1; i > 0; i-- {
+			if cols[i].defaultOn != giveUpDefaults {
+				continue
+			}
+			sacrificeOrder = append(sacrificeOrder, i)
+		}
+	}
+
+	drop := make(map[int]bool, len(cols))
+	used := columnsWidth(cols)
+	for _, i := range sacrificeOrder {
+		if used <= width {
+			break
+		}
+		drop[i] = true
+		used -= cols[i].width + 1
+	}
+
+	for i, c := range cols {
+		if !drop[i] {
+			fitted = append(fitted, c)
+		}
+	}
+	return fitted, len(drop)
+}
+
+// columnPickerLine is the one-line column selector, rendered in the footer while
+// the picker is open.
+//
+// A line rather than a modal overlay: the choice is a set of toggles over twelve
+// short names, and seeing the table change underneath as you toggle is the whole
+// point — an overlay would cover the thing being configured.
+func columnPickerLine(sel map[eventColumnID]bool, cursor int) string {
+	var b strings.Builder
+	b.WriteString("columns: ")
+	for i, c := range eventColumns {
+		name := string(c.id)
+		switch {
+		case i == cursor && sel[c.id]:
+			b.WriteString(styleOK.Render("[" + name + "]"))
+		case i == cursor:
+			b.WriteString(styleWarn.Render("[" + name + "]"))
+		case sel[c.id]:
+			b.WriteString(styleOK.Render(name))
+		default:
+			b.WriteString(styleMuted.Render(name))
+		}
+		if i < len(eventColumns)-1 {
+			b.WriteString(" ")
+		}
+	}
+	return b.String()
+}

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -186,15 +186,12 @@ func columnsWidth(cols []eventColumn) int {
 // many it had to drop.
 //
 // Explicit rather than letting bubbles clip: with every column on the table needs
-// ~135 terminal columns, so HOST simply was not there and nothing said so. The
-// count feeds the footer, which is what issue #866 asks for.
+// ~156 terminal columns (144 of column width plus a gutter each, see
+// columnsWidth), so HOST simply was not there and nothing said so. The count feeds
+// the footer, which is what issue #866 asks for.
 //
-// Drops by declaration order from the right, EXCEPT that a column the user turned
-// on explicitly outranks one that is merely on by default. Without that, the
-// issue's own scenario fails: turn off DIR/TIME/TOKENS to make room for HOST, and
-// HOST — last in display order — is still the first thing dropped, so the user
-// gets none of what they asked for. An explicit choice has to survive the columns
-// nobody chose.
+// Drops from the right by the static keep rank, so the columns that identify a row
+// outlive the ones that merely annotate it.
 //
 // Never returns an empty slice: one clipped column beats a blank pane.
 func fitColumns(cols []eventColumn, width int) (fitted []eventColumn, dropped int) {
@@ -257,7 +254,50 @@ func renderColumnPicker(sel map[eventColumnID]bool, cursor, width, height int) s
 	b.WriteString(styleTitle.Render("COLUMNS"))
 	b.WriteString("\n\n")
 
+	// Bound the list to what the terminal can actually show.
+	//
+	// overlayCenter breaks out at `row >= len(out)`, so rows past the bottom edge
+	// are dropped silently — and the LAST row is the key hints, the one thing a
+	// stuck user needs. Verified: at 12 lines the "[esc] close" hint disappeared
+	// entirely. The `height` parameter was accepted and ignored; this is the guard
+	// it exists for.
+	//
+	// Reserve, counted against the rendered panel rather than guessed: 2 border
+	// rows + title + blank after it + blank before the hint + hint = 6, plus 1 for
+	// the "N of M shown" note that appears exactly when the list is clipped.
+	rows := len(eventColumns)
+	if height > 0 {
+		if avail := height - 7; avail < rows {
+			rows = avail
+		}
+		// Always show at least one column row, however short the terminal: a picker
+		// with a title and no columns is worse than one that is obviously clipped.
+		// Below ~8 lines the panel cannot fit its own border, title and hint, so it
+		// is clipped by overlayCenter — a physical limit of a bordered modal, not
+		// something this guard can recover. At 8 it degrades correctly: fitHintLine
+		// drops "[↑↓] move" and keeps close/quit.
+		if rows < 1 {
+			rows = 1
+		}
+	}
+	// Scroll the window so the cursor stays visible, rather than clipping the tail
+	// and leaving the selection off-screen where space toggles something unseen.
+	start := 0
+	if cursor >= rows {
+		start = cursor - rows + 1
+	}
+	end := start + rows
+	if end > len(eventColumns) {
+		end = len(eventColumns)
+		if start = end - rows; start < 0 {
+			start = 0
+		}
+	}
+
 	for i, c := range eventColumns {
+		if i < start || i >= end {
+			continue
+		}
 		box := "[ ]"
 		if sel[c.id] {
 			box = "[x]"
@@ -279,8 +319,38 @@ func renderColumnPicker(sel map[eventColumnID]bool, cursor, width, height int) s
 		b.WriteString("\n")
 	}
 
-	b.WriteString("\n")
-	b.WriteString(styleHint.Render("[↑↓] move  [space] toggle  [r] reset  [esc] close  [q] quit"))
+	if end-start < len(eventColumns) {
+		b.WriteString(styleMuted.Render(fmt.Sprintf("  … %d of %d shown (terminal too short)",
+			end-start, len(eventColumns))))
+		b.WriteString("\n")
+	}
 
-	return styleBorder.Render(b.String())
+	b.WriteString("\n")
+	// fitHintLine, so a narrow terminal drops hints from the front and keeps
+	// [q] quit rather than wrapping the line. Same treatment the footer gets.
+	b.WriteString(styleHint.Render(fitHintLine(
+		"[↑↓] move  [space]/[x] toggle  [r] reset  [esc]/[enter] close  [q] quit", width-4)))
+
+	// MaxWidth as a backstop. overlayCenter is explicit that bounding the panel is
+	// the caller's job — it renders an over-wide panel flush-left and lets the
+	// content spill — and renderHelpOverlay holds up its end the same way.
+	box := styleBorder
+	if width > 0 {
+		box = box.MaxWidth(width)
+	}
+	return box.Render(b.String())
+}
+
+// anyColumnSelected reports whether the user has at least one column on.
+//
+// Distinct from len(selectedColumns(sel)) > 0, which is never zero: that function
+// substitutes the defaults for an empty selection, so it cannot answer "did the
+// user turn everything off". The toggle handler needs exactly that question.
+func anyColumnSelected(sel map[eventColumnID]bool) bool {
+	for _, c := range eventColumns {
+		if sel[c.id] {
+			return true
+		}
+	}
+	return false
 }

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -10,8 +10,11 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
-// eventColumnID names a column stably, so a saved selection survives reordering
-// and a future column being inserted in the middle.
+// eventColumnID names a column stably, so a selection is keyed by identity rather
+// than position: a future column inserted in the middle cannot silently change what
+// an existing selection means. (Nothing persists a selection today — it lives in
+// m.eventColumns for the process lifetime — so this is the property the naming
+// buys, not behaviour already in place.)
 type eventColumnID string
 
 const (
@@ -44,6 +47,30 @@ type cellContext struct {
 	// ids pairs a request event with its response, computed once per rebuild by
 	// computeEventPairs. Carried here rather than recomputed per cell.
 	ids map[*pipeline.SessionEvent]int
+	// invs is this row's invocations, computed once in the row loop.
+	//
+	// rebuildEventsTable already needs them for the hideInactive check, and
+	// rowAction returns ACTION and PLUGIN together — so having each of those two
+	// cells call row.invocations() ran it three times per row and discarded half of
+	// rowAction's result twice. invocations() allocates (allInvocations, plus an
+	// append when a tunnel row is folded in) and eventAction walks the slice twice,
+	// on up to 500 rows for every SSE event and every resize.
+	//
+	// Carrying it also makes it structural rather than incidental that the ACTION
+	// and PLUGIN cells agree: they now read one rowAction result instead of two.
+	invs []pipeline.Invocation
+	// action and plugin are that one rowAction result.
+	action string
+	plugin string
+	// width is the declared width of the column being filled, set per column in
+	// the row loop.
+	//
+	// PLUGIN and HOST previously hardcoded 18 and 20 in their truncStr calls,
+	// duplicating the width two lines above them — the same drift actionColWidth and
+	// methodColWidth were named to prevent, in the one file whose premise is that a
+	// column is a single definition. Reading it from here means changing a width
+	// cannot leave a truncation behind.
+	width int
 }
 
 // eventColumn is one column: how to head it, how wide, and how to fill it.
@@ -102,12 +129,12 @@ var eventColumns = []eventColumn{
 		cell: func(c cellContext) string { return shortPhase(c.row.event.Phase) }},
 	{id: colAction, width: actionColWidth, defaultOn: true, keep: keepNormal,
 		desc: "what took effect: deny, modify, observe, allow, or tunnel",
-		cell: func(c cellContext) string { a, _ := rowAction(c.row, c.row.invocations()); return a }},
+		cell: func(c cellContext) string { return c.action }},
 	{id: colPlugin, width: 18, defaultOn: true, keep: keepNormal,
 		desc: "which plugin acted; blank when none did",
 		cell: func(c cellContext) string {
-			_, p := rowAction(c.row, c.row.invocations())
-			return truncStr(p, 18)
+			p := c.plugin
+			return truncStr(p, c.width)
 		}},
 	// methodColWidth rather than 22: the widest realistic value is a model name
 	// ("claude-opus-5"), and the columns freed pay for splitting TOKENS and COST
@@ -139,7 +166,7 @@ var eventColumns = []eventColumn{
 	// to be declared but never visible.
 	{id: colHost, width: 20, defaultOn: true, keep: keepHigh,
 		desc: "host the message was sent to",
-		cell: func(c cellContext) string { return truncStr(c.row.event.Host, 20) }},
+		cell: func(c cellContext) string { return truncStr(c.row.event.Host, c.width) }},
 }
 
 // defaultColumnSelection is the set shown before the user chooses.

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -202,13 +202,13 @@ func fitColumns(cols []eventColumn, width int) (fitted []eventColumn, dropped in
 		return cols, 0
 	}
 
-	// Rank sacrifices: default-on columns first, from the right, then opted-in
-	// ones. Index 0 is never sacrificed — "#" pairs the exchange and is what makes
-	// the timeline readable at all.
 	// Give up low-ranked columns first, then normal, then high — and within a rank,
 	// from the right. Ranking by "is it a default" instead made every default
 	// equally expendable, so HOST (last in display order) went first, which is the
 	// failure #866 describes.
+	//
+	// Index 0 is never sacrificed: "#" pairs a request with its response, and
+	// without it the timeline cannot be read at all.
 	sacrificeOrder := make([]int, 0, len(cols))
 	for _, rank := range []int{keepLow, keepNormal, keepHigh} {
 		for i := len(cols) - 1; i > 0; i-- {

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -57,49 +58,77 @@ type eventColumn struct {
 	// cell renders this column for one row.
 	cell func(cellContext) string
 	// defaultOn is whether the column shows without the user asking.
-	//
-	// HOST is off by default despite being the column issue #866 was filed about:
-	// with everything on, the table needs ~151 columns, so HOST was never visible
-	// anyway. Off-by-default plus a picker means it is reachable, rather than
-	// present-but-clipped.
 	defaultOn bool
+	// desc is the one-line explanation shown beside the name in the picker. Twelve
+	// abbreviated headers are not self-describing — DIR, PHASE and METHOD least of
+	// all — and a picker that only lists names asks the user to guess.
+	desc string
+	// keep ranks a column against being dropped when the terminal is too narrow.
+	// Higher survives longer.
+	//
+	// Separate from defaultOn because the two are different questions: HOST is now
+	// shown by default AND must outlive the columns it competes with, since it is
+	// the one the user came for (#866). Ranking by defaultOn alone made every
+	// default equally expendable and HOST — last in display order — the first to go.
+	keep int
 }
+
+// Keep ranks. Only the ordering matters, not the values.
+const (
+	keepLow    = 0 // give these up first
+	keepNormal = 1
+	keepHigh   = 2 // give these up last
+)
 
 // eventColumns is the single definition every events-table column comes from, in
 // display order.
 var eventColumns = []eventColumn{
-	{id: colIndex, width: 4, defaultOn: true,
+	{id: colIndex, width: 4, defaultOn: true, keep: keepHigh,
+		desc: "exchange number; a request and its response share one",
 		cell: func(c cellContext) string {
 			if id, ok := c.ids[c.row.event]; ok {
 				return strconv.Itoa(id)
 			}
 			return ""
 		}},
-	{id: colTime, width: 12, defaultOn: true,
+	{id: colTime, width: 12, defaultOn: true, keep: keepNormal,
+		desc: "wall-clock time the message was recorded",
 		cell: func(c cellContext) string { return c.row.event.At.Format("15:04:05.00") }},
-	{id: colDir, width: 4, defaultOn: true,
+	{id: colDir, width: 4, defaultOn: true, keep: keepLow,
+		desc: "in = toward your agent, out = toward an upstream",
 		cell: func(c cellContext) string { return shortDirection(c.row.event.Direction) }},
-	{id: colPhase, width: 7, defaultOn: true,
+	{id: colPhase, width: 7, defaultOn: true, keep: keepNormal,
+		desc: "req, resp, or denied",
 		cell: func(c cellContext) string { return shortPhase(c.row.event.Phase) }},
-	{id: colAction, width: actionColWidth, defaultOn: true,
+	{id: colAction, width: actionColWidth, defaultOn: true, keep: keepNormal,
+		desc: "what took effect: deny, modify, observe, allow, or tunnel",
 		cell: func(c cellContext) string { a, _ := rowAction(c.row, c.row.invocations()); return a }},
-	{id: colPlugin, width: 18, defaultOn: true,
+	{id: colPlugin, width: 18, defaultOn: true, keep: keepNormal,
+		desc: "which plugin acted; blank when none did",
 		cell: func(c cellContext) string {
 			_, p := rowAction(c.row, c.row.invocations())
 			return truncStr(p, 18)
 		}},
-	{id: colMethod, width: methodColWidth, defaultOn: true,
+	{id: colMethod, width: methodColWidth, defaultOn: true, keep: keepNormal,
+		desc: "protocol operation: model name, MCP or A2A method",
 		cell: func(c cellContext) string { return eventMethod(*c.row.event) }},
-	{id: colStatus, width: 7, defaultOn: true,
+	{id: colStatus, width: 7, defaultOn: true, keep: keepNormal,
+		desc: "HTTP status of the response",
 		cell: func(c cellContext) string { return statusCell(*c.row.event) }},
-	{id: colDuration, width: 10, defaultOn: true,
+	{id: colDuration, width: 10, defaultOn: true, keep: keepLow,
+		desc: "how long the exchange took",
 		cell: func(c cellContext) string { return durationCell(*c.row.event) }},
-	{id: colTokens, width: 17, defaultOn: true,
+	{id: colTokens, width: 17, defaultOn: true, keep: keepLow,
+		desc: "tokens used, and what tool-prune saved",
 		cell: func(c cellContext) string { return c.m.tokensCell(c.rows, c.partner, c.i, c.row.event) }},
-	{id: colCost, width: 19, defaultOn: true,
+	{id: colCost, width: 19, defaultOn: true, keep: keepLow,
+		desc: "estimated cost, and what tool-prune saved",
 		cell: func(c cellContext) string { return c.m.costCell(c.rows, c.partner, c.i, c.row.event) }},
-	// The column the issue is about. Off by default — see eventColumn.defaultOn.
-	{id: colHost, width: 20, defaultOn: false,
+	// keepHigh: the column #866 was filed about. Last in display order, so without
+	// a rank it is the first thing a narrow terminal drops — which is how it came
+	// to be declared but never visible.
+	{id: colHost, width: 20, defaultOn: true, keep: keepHigh,
+		desc: "host the message was sent to",
 		cell: func(c cellContext) string { return truncStr(c.row.event.Host, 20) }},
 }
 
@@ -176,17 +205,16 @@ func fitColumns(cols []eventColumn, width int) (fitted []eventColumn, dropped in
 	// Rank sacrifices: default-on columns first, from the right, then opted-in
 	// ones. Index 0 is never sacrificed — "#" pairs the exchange and is what makes
 	// the timeline readable at all.
-	// Two passes: default-on columns are given up first, then the opted-in ones. A
-	// column with defaultOn=false is only present because the user asked for it, so
-	// it is sacrificed LAST — the reverse of that is what made HOST vanish again in
-	// the issue's own scenario.
+	// Give up low-ranked columns first, then normal, then high — and within a rank,
+	// from the right. Ranking by "is it a default" instead made every default
+	// equally expendable, so HOST (last in display order) went first, which is the
+	// failure #866 describes.
 	sacrificeOrder := make([]int, 0, len(cols))
-	for _, giveUpDefaults := range []bool{true, false} {
+	for _, rank := range []int{keepLow, keepNormal, keepHigh} {
 		for i := len(cols) - 1; i > 0; i-- {
-			if cols[i].defaultOn != giveUpDefaults {
-				continue
+			if cols[i].keep == rank {
+				sacrificeOrder = append(sacrificeOrder, i)
 			}
-			sacrificeOrder = append(sacrificeOrder, i)
 		}
 	}
 
@@ -208,30 +236,51 @@ func fitColumns(cols []eventColumn, width int) (fitted []eventColumn, dropped in
 	return fitted, len(drop)
 }
 
-// columnPickerLine is the one-line column selector, rendered in the footer while
-// the picker is open.
+// renderColumnPicker draws the column selector as a centred popup.
 //
-// A line rather than a modal overlay: the choice is a set of toggles over twelve
-// short names, and seeing the table change underneath as you toggle is the whole
-// point — an overlay would cover the thing being configured.
-func columnPickerLine(sel map[eventColumnID]bool, cursor int) string {
-	var b strings.Builder
-	b.WriteString("columns: ")
-	for i, c := range eventColumns {
-		name := string(c.id)
-		switch {
-		case i == cursor && sel[c.id]:
-			b.WriteString(styleOK.Render("[" + name + "]"))
-		case i == cursor:
-			b.WriteString(styleWarn.Render("[" + name + "]"))
-		case sel[c.id]:
-			b.WriteString(styleOK.Render(name))
-		default:
-			b.WriteString(styleMuted.Render(name))
-		}
-		if i < len(eventColumns)-1 {
-			b.WriteString(" ")
-		}
+// A popup rather than the footer line this replaced: twelve abbreviated headers
+// are not self-describing, and a one-line list had no room to say what DIR or
+// METHOD mean. A box gives every column its own row, a checkbox, and a
+// description — which is the difference between choosing and guessing.
+//
+// A column that is selected but will not fit the current terminal is marked, so
+// enabling something and seeing no change is explained in place rather than only
+// by the footer's count.
+func renderColumnPicker(sel map[eventColumnID]bool, cursor, width, height int) string {
+	fitted, _ := fitColumns(selectedColumns(sel), width)
+	visible := make(map[eventColumnID]bool, len(fitted))
+	for _, c := range fitted {
+		visible[c.id] = true
 	}
-	return b.String()
+
+	var b strings.Builder
+	b.WriteString(styleTitle.Render("COLUMNS"))
+	b.WriteString("\n\n")
+
+	for i, c := range eventColumns {
+		box := "[ ]"
+		if sel[c.id] {
+			box = "[x]"
+		}
+		name := fmt.Sprintf("%-9s", string(c.id))
+		line := fmt.Sprintf("%s %s %s", box, name, c.desc)
+
+		// Mark a selection the terminal cannot honour. Without this, turning HOST
+		// on in an 80-column window looks like the checkbox did nothing.
+		if sel[c.id] && !visible[c.id] {
+			line += styleMuted.Render("  (no room)")
+		}
+
+		if i == cursor {
+			b.WriteString(styleTitle.Render("▸ " + line))
+		} else {
+			b.WriteString("  " + line)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(styleHint.Render("[↑↓] move  [space] toggle  [r] reset  [esc] close  [q] quit"))
+
+	return styleBorder.Render(b.String())
 }

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -109,6 +109,9 @@ var eventColumns = []eventColumn{
 			_, p := rowAction(c.row, c.row.invocations())
 			return truncStr(p, 18)
 		}},
+	// methodColWidth rather than 22: the widest realistic value is a model name
+	// ("claude-opus-5"), and the columns freed pay for splitting TOKENS and COST
+	// apart below.
 	{id: colMethod, width: methodColWidth, defaultOn: true, keep: keepNormal,
 		desc: "protocol operation: model name, MCP or A2A method",
 		cell: func(c cellContext) string { return eventMethod(*c.row.event) }},
@@ -118,9 +121,16 @@ var eventColumns = []eventColumn{
 	{id: colDuration, width: 10, defaultOn: true, keep: keepLow,
 		desc: "how long the exchange took",
 		cell: func(c cellContext) string { return durationCell(*c.row.event) }},
+	// 17, not 15: sized for a SEVEN-digit prompt, "1,048,576(−12.3k)". Million-token
+	// contexts are in service, and bubbles truncates a cell at the column width, so
+	// 15 rendered "1,048,576(−1…" — dropping the saving, which is the half of this
+	// cell that appears nowhere else.
 	{id: colTokens, width: 17, defaultOn: true, keep: keepLow,
 		desc: "tokens used, and what tool-prune saved",
 		cell: func(c cellContext) string { return c.m.tokensCell(c.rows, c.partner, c.i, c.row.event) }},
+	// 19 fits the widest cell the formatter can produce: "<$0.0001(−<$0.0001)",
+	// where both halves fell under the four-decimal floor. The ordinary shape is
+	// "$0.2546(−$0.0037)" at 17.
 	{id: colCost, width: 19, defaultOn: true, keep: keepLow,
 		desc: "estimated cost, and what tool-prune saved",
 		cell: func(c cellContext) string { return c.m.costCell(c.rows, c.partner, c.i, c.row.event) }},
@@ -174,10 +184,35 @@ func tableColumns(cols []eventColumn) []table.Column {
 
 // columnsWidth is how many terminal columns a selection needs, including the
 // one-space gutter bubbles renders between cells.
+// cellPadding is what bubbles adds to every cell's declared width.
+//
+// TWO, not one: bubbles pads each cell on BOTH sides rather than putting a single
+// space between them. table.DefaultStyles sets Cell and Header to
+// `Padding(0, 1)`, renderRow runs each value through styles.Cell.Render and
+// headersView through styles.Header.Render, and this repo's tableStyles() keeps
+// both paddings (it only adds Foreground/Bold). So a column occupies width+2 and
+// a row is sum(width) + 2n.
+//
+// Modelling it as +1 made fitColumns systematically under-count, so the fitting
+// the whole feature rests on never actually fit — measured against bubbles v1.0.0,
+// a row of all twelve columns renders at 168 while columnsWidth reported 156. At
+// 80 the table overflowed by one column and wrapped, costing two terminal rows per
+// event and throwing off the SetHeight accounting; between 156 and 167 it was
+// worse, because dropped==0 meant the footer said nothing and the picker showed no
+// "(no room)" while 8-12 columns sat off the edge — issue #866's exact failure
+// mode at a different width.
+const cellPadding = 2
+
+// borderWidth is what styleBorder costs: one column each side. It has no padding —
+// Border(RoundedBorder()).BorderForeground(colorMuted) — so the panel is its
+// content plus two, and reserving four trimmed the hint line two columns earlier
+// than necessary.
+const borderWidth = 2
+
 func columnsWidth(cols []eventColumn) int {
 	w := 0
 	for _, c := range cols {
-		w += c.width + 1
+		w += c.width + cellPadding
 	}
 	return w
 }
@@ -186,9 +221,9 @@ func columnsWidth(cols []eventColumn) int {
 // many it had to drop.
 //
 // Explicit rather than letting bubbles clip: with every column on the table needs
-// ~156 terminal columns (144 of column width plus a gutter each, see
-// columnsWidth), so HOST simply was not there and nothing said so. The count feeds
-// the footer, which is what issue #866 asks for.
+// ~168 terminal columns (144 of declared width plus two of bubbles padding per
+// column, see columnsWidth), so HOST simply was not there and nothing said so. The
+// count feeds the footer, which is what issue #866 asks for.
 //
 // Drops from the right by the static keep rank, so the columns that identify a row
 // outlive the ones that merely annotate it.
@@ -303,13 +338,20 @@ func renderColumnPicker(sel map[eventColumnID]bool, cursor, width, height int) s
 			box = "[x]"
 		}
 		name := fmt.Sprintf("%-9s", string(c.id))
-		line := fmt.Sprintf("%s %s %s", box, name, c.desc)
 
 		// Mark a selection the terminal cannot honour. Without this, turning HOST
 		// on in an 80-column window looks like the checkbox did nothing.
+		//
+		// BEFORE the description, not after: the MaxWidth backstop truncates from the
+		// right, so a marker appended to a long row was the first thing cut — ACTION's
+		// row at 60 columns rendered as "… observe, allow, or" with the marker gone
+		// entirely, losing the signal and keeping the prose that merely qualifies it.
+		// This way a narrow terminal loses the explanation instead.
+		marker := ""
 		if sel[c.id] && !visible[c.id] {
-			line += styleMuted.Render("  (no room)")
+			marker = styleMuted.Render("(no room) ")
 		}
+		line := fmt.Sprintf("%s %s %s%s", box, name, marker, c.desc)
 
 		if i == cursor {
 			b.WriteString(styleTitle.Render("▸ " + line))
@@ -329,7 +371,8 @@ func renderColumnPicker(sel map[eventColumnID]bool, cursor, width, height int) s
 	// fitHintLine, so a narrow terminal drops hints from the front and keeps
 	// [q] quit rather than wrapping the line. Same treatment the footer gets.
 	b.WriteString(styleHint.Render(fitHintLine(
-		"[↑↓] move  [space]/[x] toggle  [r] reset  [esc]/[enter] close  [q] quit", width-4)))
+		"[↑↓] move  [space]/[x] toggle  [r] reset  [esc]/[enter] close  [q] quit",
+		width-borderWidth)))
 
 	// MaxWidth as a backstop. overlayCenter is explicit that bounding the panel is
 	// the caller's job — it renders an over-wide panel flush-left and lets the

--- a/authbridge/cmd/abctl/tui/events_columns.go
+++ b/authbridge/cmd/abctl/tui/events_columns.go
@@ -182,8 +182,6 @@ func tableColumns(cols []eventColumn) []table.Column {
 	return out
 }
 
-// columnsWidth is how many terminal columns a selection needs, including the
-// one-space gutter bubbles renders between cells.
 // cellPadding is what bubbles adds to every cell's declared width.
 //
 // TWO, not one: bubbles pads each cell on BOTH sides rather than putting a single
@@ -209,6 +207,8 @@ const cellPadding = 2
 // than necessary.
 const borderWidth = 2
 
+// columnsWidth is how many terminal columns a selection needs: each column's
+// declared width plus the cellPadding bubbles adds around it.
 func columnsWidth(cols []eventColumn) int {
 	w := 0
 	for _, c := range cols {
@@ -257,7 +257,34 @@ func fitColumns(cols []eventColumn, width int) (fitted []eventColumn, dropped in
 			break
 		}
 		drop[i] = true
-		used -= cols[i].width + 1
+		// cellPadding, matching what columnsWidth charged. Crediting back +1 against
+		// a +2 charge refunded one column too little per drop.
+		used -= cols[i].width + cellPadding
+	}
+
+	// Second pass: take back what still fits.
+	//
+	// The loop above is greedy and never reconsiders, so it overshoots whenever the
+	// column that finally gets it under the limit is a wide one. At 80 it stood at 81
+	// — one column over — and had to give up an 18-wide PLUGIN to comply, landing at
+	// 61 and leaving 19 columns unused while DIR (6), STATUS (9), DURATION (12) and
+	// TOKENS (19) each would have fit in that slack.
+	//
+	// Restoring in REVERSE sacrifice order returns the most valuable candidates
+	// first: the last thing given up was the least expendable, so it has the best
+	// claim on the room that turned out to be there. A column that does not fit is
+	// skipped rather than ending the pass, since a narrower one further back may
+	// still fit — which is exactly the COST-then-TOKENS case at 80.
+	for i := len(sacrificeOrder) - 1; i >= 0; i-- {
+		idx := sacrificeOrder[i]
+		if !drop[idx] {
+			continue
+		}
+		cost := cols[idx].width + cellPadding
+		if used+cost <= width {
+			delete(drop, idx)
+			used += cost
+		}
 	}
 
 	for i, c := range cols {

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -56,20 +56,33 @@ func TestFitColumns_IssueScenarioRevealsHost(t *testing.T) {
 	}
 }
 
-// A column the user turned on explicitly must outrank one that is merely on by
-// default. Without this the feature does not work: the user's choice is the first
-// thing sacrificed.
-func TestFitColumns_OptedInColumnsSurviveDefaults(t *testing.T) {
-	sel := defaultColumnSelection()
-	sel[colHost] = true // opted in; defaultOn is false
-
-	fitted, dropped := fitColumns(selectedColumns(sel), 90)
+// A high-ranked column must outlive a low-ranked one. Ranking by "is it a default"
+// instead made every default equally expendable, so HOST — last in display order —
+// was the first thing dropped, which is the failure #866 describes.
+func TestFitColumns_KeepRankDecidesWhatSurvives(t *testing.T) {
+	fitted, dropped := fitColumns(selectedColumns(defaultColumnSelection()), 90)
 	if dropped == 0 {
-		t.Skip("terminal wide enough that nothing was dropped")
+		t.Fatal("nothing dropped at 90 columns; the ranking is untested")
 	}
-	if !has(fitted, colHost) {
-		t.Errorf("the opted-in HOST column was dropped before default-on ones; got %v",
-			colNames(fitted))
+
+	for _, c := range fitted {
+		if c.keep != keepLow {
+			continue
+		}
+		// A keepLow column survived, so no keepHigh one may have been dropped in
+		// its place.
+		for _, want := range eventColumns {
+			if want.keep == keepHigh && !has(fitted, want.id) {
+				t.Errorf("dropped %s (keepHigh) while keeping %s (keepLow); got %v",
+					want.id, c.id, colNames(fitted))
+			}
+		}
+	}
+	// Concretely: the columns the ranks exist to protect.
+	for _, id := range []eventColumnID{colIndex, colHost} {
+		if !has(fitted, id) {
+			t.Errorf("%s is keepHigh but was dropped; got %v", id, colNames(fitted))
+		}
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
+
 	"strings"
 	"testing"
 	"time"
@@ -164,24 +166,57 @@ func TestEventColumns_AllHaveCellFuncs(t *testing.T) {
 	}
 }
 
-// The picker names every column, marks which are on, and shows the cursor —
-// otherwise a user cannot tell what pressing space would do.
-func TestColumnPickerLine(t *testing.T) {
+// The popup must name every column, describe it, show a checkbox, and mark the
+// cursor — a one-line list of twelve abbreviated headers asked the user to guess
+// what DIR or METHOD meant.
+func TestRenderColumnPicker(t *testing.T) {
 	sel := defaultColumnSelection()
-	line := stripANSI(columnPickerLine(sel, 0))
+	out := stripANSI(renderColumnPicker(sel, 0, 160, 40))
 
 	for _, c := range eventColumns {
-		if !strings.Contains(line, string(c.id)) {
-			t.Errorf("picker omits %s: %q", c.id, line)
+		if !strings.Contains(out, string(c.id)) {
+			t.Errorf("popup omits the %s column: %q", c.id, out)
+		}
+		if c.desc == "" {
+			t.Errorf("column %s has no description", c.id)
+		} else if !strings.Contains(out, c.desc) {
+			t.Errorf("popup omits %s's description %q", c.id, c.desc)
 		}
 	}
-	// The cursor is bracketed, so the highlighted column is identifiable without
-	// colour — a terminal without it, or a screenshot, still reads.
-	if !strings.Contains(line, "["+string(eventColumns[0].id)+"]") {
-		t.Errorf("picker does not bracket the cursor column: %q", line)
+	if !strings.Contains(out, "[x]") {
+		t.Errorf("no checked box for a default-on column: %q", out)
 	}
-	if strings.Contains(stripANSI(columnPickerLine(sel, 3)), "["+string(eventColumns[0].id)+"]") {
-		t.Error("bracket did not move with the cursor")
+	// Cursor marked with a glyph, not only a colour, so it reads without colour.
+	if !strings.Contains(out, "\u25b8") {
+		t.Errorf("popup does not mark the cursor row: %q", out)
+	}
+	// Quit is advertised: the popup is modal, so the key a user reaches for has to
+	// be listed.
+	if !strings.Contains(out, "[q] quit") {
+		t.Errorf("popup does not advertise quit: %q", out)
+	}
+}
+
+// An unchecked column shows an empty box, so on and off are distinguishable.
+func TestRenderColumnPicker_ShowsUncheckedBoxes(t *testing.T) {
+	sel := defaultColumnSelection()
+	sel[colHost] = false
+	out := stripANSI(renderColumnPicker(sel, 0, 160, 40))
+	if !strings.Contains(out, "[ ]") {
+		t.Errorf("no empty box for a disabled column: %q", out)
+	}
+}
+
+// A selected column that cannot fit is marked in place. Without it, ticking HOST in
+// an 80-column window looks like the checkbox did nothing.
+func TestRenderColumnPicker_MarksColumnsThatDoNotFit(t *testing.T) {
+	narrow := stripANSI(renderColumnPicker(defaultColumnSelection(), 0, 80, 40))
+	if !strings.Contains(narrow, "no room") {
+		t.Errorf("narrow terminal does not flag unfittable columns: %q", narrow)
+	}
+	wide := stripANSI(renderColumnPicker(defaultColumnSelection(), 0, 200, 40))
+	if strings.Contains(wide, "no room") {
+		t.Errorf("wide terminal wrongly flags a column as unfittable: %q", wide)
 	}
 }
 
@@ -315,5 +350,75 @@ func TestColumnPicker_OwnsTheKeyboard(t *testing.T) {
 
 	if got := m.eventsTbl.Cursor(); got != 2 {
 		t.Errorf("table cursor moved to %d while the picker was open", got)
+	}
+}
+
+// `q` must quit while the picker is open. A modal that traps the user until they
+// find its exit is worse than one that honours the key they already reach for, and
+// `q` means quit everywhere else in abctl.
+func TestColumnPicker_QuitStaysLive(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.handleKey(keyRune('c'))
+	if !m.colPicker {
+		t.Fatal("picker did not open")
+	}
+	// The general handler calls m.cancel, which a bare test model does not have.
+	// Supplying it also proves the key reached that handler rather than being
+	// swallowed by the picker's switch.
+	cancelled := false
+	m.cancel = func() { cancelled = true }
+
+	cmd := m.handleKey(keyRune('q'))
+	if !cancelled {
+		t.Error("`q` was swallowed by the picker; it must reach the quit handler")
+	}
+	if cmd == nil {
+		t.Error("`q` returned no command; expected tea.Quit")
+	}
+}
+
+// esc closes the picker without quitting, so the two exits are distinguishable.
+func TestColumnPicker_EscClosesWithoutQuitting(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.handleKey(keyRune('c'))
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.colPicker {
+		t.Error("esc did not close the picker")
+	}
+}
+
+// Up and down move the cursor and stop at the ends rather than wrapping or
+// indexing out of range.
+func TestColumnPicker_CursorStaysInRange(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.handleKey(keyRune('c'))
+
+	for i := 0; i < len(eventColumns)*2; i++ {
+		m.handleKey(keyRune('j'))
+	}
+	if m.colCursor != len(eventColumns)-1 {
+		t.Errorf("cursor = %d after over-scrolling down, want %d", m.colCursor, len(eventColumns)-1)
+	}
+	for i := 0; i < len(eventColumns)*2; i++ {
+		m.handleKey(keyRune('k'))
+	}
+	if m.colCursor != 0 {
+		t.Errorf("cursor = %d after over-scrolling up, want 0", m.colCursor)
+	}
+}
+
+// HOST is on by default and survives a narrow terminal. It is the column #866 was
+// filed about: declared but never visible, because it is last in display order and
+// nothing ranked it above the columns it competed with.
+func TestDefaultColumns_HostIsOnAndSurvivesNarrowTerminals(t *testing.T) {
+	sel := defaultColumnSelection()
+	if !sel[colHost] {
+		t.Error("HOST is not a default column")
+	}
+	for _, width := range []int{80, 100, 120, 140, 160} {
+		fitted, _ := fitColumns(selectedColumns(sel), width)
+		if !has(fitted, colHost) {
+			t.Errorf("width %d: HOST dropped; got %v", width, colNames(fitted))
+		}
 	}
 }

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -3,6 +3,9 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
 func colNames(cols []eventColumn) []string {
@@ -179,5 +182,138 @@ func TestColumnPickerLine(t *testing.T) {
 	}
 	if strings.Contains(stripANSI(columnPickerLine(sel, 3)), "["+string(eventColumns[0].id)+"]") {
 		t.Error("bracket did not move with the cursor")
+	}
+}
+
+// newTestEventsModel builds a model with a populated events table, at a width
+// wide enough for every default column.
+func newTestEventsModel(t *testing.T) *model {
+	t.Helper()
+	events := make([]pipeline.SessionEvent, 6)
+	for i := range events {
+		events[i] = pipeline.SessionEvent{
+			At:        time.Now(),
+			Direction: pipeline.Outbound,
+			Phase:     pipeline.SessionRequest,
+			Host:      "api.example.com",
+			Inference: &pipeline.InferenceExtension{Model: "claude-sonnet-5", TotalTokens: 100},
+		}
+	}
+	m := &model{
+		pane: paneEvents, selectedSess: "s", bodyHeight: 12, width: 200,
+		events:       map[string][]pipeline.SessionEvent{"s": events},
+		eventColumns: defaultColumnSelection(),
+	}
+	m.eventsTbl = newEventsTable()
+	m.rebuildEventsTable()
+	return m
+}
+
+// Toggling a column OFF must not panic.
+//
+// bubbles' SetColumns calls UpdateViewport, which re-renders the rows already
+// loaded; its renderRow iterates the ROW's cells while indexing m.cols[i], so a
+// row wider than the new column set reads past the end of m.cols. Setting the
+// columns before the rows was exactly that — 11 stale cells against 10 new
+// columns — and it panicked inside the bubbletea render loop the first time a
+// user pressed space.
+func TestRebuildEventsTable_ToggleOffDoesNotPanic(t *testing.T) {
+	m := newTestEventsModel(t)
+
+	// Start wide so every default column is present, then narrow the selection one
+	// column at a time. Each rebuild renders the previous, wider rows.
+	for _, id := range []eventColumnID{colCost, colTokens, colDuration, colStatus, colMethod} {
+		m.eventColumns[id] = false
+		m.rebuildEventsTable() // must not panic
+	}
+	// And back on again, which widens rows against a narrower column set.
+	for _, id := range []eventColumnID{colMethod, colStatus, colDuration, colTokens, colCost} {
+		m.eventColumns[id] = true
+		m.rebuildEventsTable()
+	}
+}
+
+// Every row must carry exactly one cell per rendered column. A mismatch is what
+// panics inside bubbles, so assert the invariant directly rather than only that we
+// survived.
+func TestRebuildEventsTable_RowWidthMatchesColumns(t *testing.T) {
+	m := newTestEventsModel(t)
+
+	for _, sel := range []map[eventColumnID]bool{
+		defaultColumnSelection(),
+		{colIndex: true, colHost: true},
+		{colIndex: true},
+		{}, // falls back to the defaults
+	} {
+		m.eventColumns = sel
+		m.rebuildEventsTable()
+
+		want := len(m.eventsTbl.Columns())
+		for i, row := range m.eventsTbl.Rows() {
+			if len(row) != want {
+				t.Errorf("row %d has %d cells for %d columns", i, len(row), want)
+			}
+		}
+	}
+}
+
+// A narrow terminal re-fits on every rebuild, so the same invariant has to hold
+// as the width changes underneath.
+func TestRebuildEventsTable_WidthChangesKeepRowsAligned(t *testing.T) {
+	m := newTestEventsModel(t)
+	for _, w := range []int{200, 120, 80, 40, 200} {
+		m.width = w
+		m.rebuildEventsTable()
+		want := len(m.eventsTbl.Columns())
+		for i, row := range m.eventsTbl.Rows() {
+			if len(row) != want {
+				t.Errorf("width %d: row %d has %d cells for %d columns", w, i, len(row), want)
+			}
+		}
+	}
+}
+
+// Drive the picker the way a user does — `c`, then space and arrow keys. The crash
+// this guards against fired through the key path, not through a direct
+// rebuildEventsTable call, so exercise that path end to end.
+func TestColumnPicker_KeyPathSurvivesEveryToggle(t *testing.T) {
+	m := newTestEventsModel(t)
+
+	m.handleKey(keyRune('c'))
+	if !m.colPicker {
+		t.Fatal("`c` did not open the picker")
+	}
+	// Toggle every column off, moving right each time.
+	for i := 0; i < len(eventColumns); i++ {
+		m.handleKey(keyRune(' '))
+		m.handleKey(keyRune('l'))
+	}
+	// Never a blank table, however much was turned off.
+	if len(m.eventsTbl.Columns()) == 0 {
+		t.Error("every column off left a blank table")
+	}
+	// Reset restores the defaults.
+	m.handleKey(keyRune('r'))
+	if got, want := len(m.eventsTbl.Columns()), len(selectedColumns(defaultColumnSelection())); got != want {
+		t.Errorf("after reset: %d columns, want %d", got, want)
+	}
+	m.handleKey(keyRune('c'))
+	if m.colPicker {
+		t.Error("`c` did not close the picker")
+	}
+}
+
+// The picker owns the keyboard while open: space and the arrows must not also move
+// the table cursor underneath it.
+func TestColumnPicker_OwnsTheKeyboard(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.eventsTbl.SetCursor(2)
+
+	m.handleKey(keyRune('c'))
+	m.handleKey(keyRune('l'))
+	m.handleKey(keyRune(' '))
+
+	if got := m.eventsTbl.Cursor(); got != 2 {
+		t.Errorf("table cursor moved to %d while the picker was open", got)
 	}
 }

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"github.com/charmbracelet/bubbles/table"
+
 	"github.com/charmbracelet/lipgloss"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -528,5 +530,119 @@ func TestColumnPicker_CursorStaysVisibleWhenClipped(t *testing.T) {
 	}
 	if !strings.Contains(out, "terminal too short") {
 		t.Errorf("a clipped list should say so:\n%s", out)
+	}
+}
+
+// The invariant the whole feature rests on: what fitColumns returns must actually
+// render inside the terminal width. Asserted against a real bubbles table, because
+// the bug this replaces was a mismodelled padding constant — every unit test that
+// checked only fitColumns' return value passed while the rendered row overflowed.
+//
+// bubbles pads each cell on both sides (Padding(0, 1) on Cell and Header), so a
+// column occupies width+2. Modelling it as +1 under-counted by one per column: a
+// row of all twelve rendered at 168 against a computed 156, so the table wrapped
+// at 80 and — worse, between 156 and 167 — reported dropped==0 while up to twelve
+// columns sat off the edge, with no footer count and no "(no room)" marker.
+func TestFitColumns_RenderedWidthNeverExceedsTerminal(t *testing.T) {
+	sel := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		sel[c.id] = true
+	}
+	all := selectedColumns(sel)
+
+	// Every width from very narrow to past the full table, so no band is skipped —
+	// 156..167 is precisely where the old model reported a clean fit.
+	for w := 20; w <= 180; w++ {
+		fitted, dropped := fitColumns(all, w)
+		if len(fitted) == 0 {
+			t.Fatalf("width %d: no columns returned", w)
+		}
+
+		tbl := newEventsTable()
+		tbl.SetColumns(tableColumns(fitted))
+		row := make([]string, len(fitted))
+		for i := range row {
+			row[i] = "x"
+		}
+		tbl.SetRows([]table.Row{row})
+
+		rendered := 0
+		for _, ln := range strings.Split(tbl.View(), "\n") {
+			if n := lipgloss.Width(ln); n > rendered {
+				rendered = n
+			}
+		}
+
+		// The one legitimate exception: a terminal too narrow for even one column.
+		// fitColumns never returns empty, so a single column may exceed a tiny width.
+		if len(fitted) == 1 && rendered > w {
+			continue
+		}
+		if rendered > w {
+			t.Errorf("width %d: %d columns render at %d (%d dropped) — overflows by %d",
+				w, len(fitted), rendered, dropped, rendered-w)
+		}
+		// And the model must agree with reality, or the footer count and the picker's
+		// "(no room)" markers describe a different table than the one on screen.
+		if got := columnsWidth(fitted); got != rendered {
+			t.Errorf("width %d: columnsWidth says %d, bubbles renders %d", w, got, rendered)
+		}
+	}
+}
+
+// Nothing bounds the table downstream — SetWidth is never called and paneView
+// applies no MaxWidth — so dropped==0 has to mean the whole selection really fits.
+func TestFitColumns_ZeroDroppedMeansItFits(t *testing.T) {
+	sel := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		sel[c.id] = true
+	}
+	all := selectedColumns(sel)
+	full := columnsWidth(all)
+
+	for w := full - 20; w <= full+4; w++ {
+		fitted, dropped := fitColumns(all, w)
+		if dropped != 0 {
+			continue
+		}
+		if len(fitted) != len(all) {
+			t.Errorf("width %d: dropped==0 but only %d of %d columns returned",
+				w, len(fitted), len(all))
+		}
+		if columnsWidth(fitted) > w {
+			t.Errorf("width %d: dropped==0 while the table needs %d — silently off the edge",
+				w, columnsWidth(fitted))
+		}
+	}
+}
+
+// The picker must not own the keyboard, or draw itself, over a pane it does not
+// belong to. No KEY can switch panes underneath it, but a MESSAGE can: the
+// sessionsMsg handler drops to paneSessions when the selected session disappears
+// server-side, which left the popup drawn over the sessions table with its key
+// block swallowing enter/j/k — an inert pane until the user guessed esc.
+func TestColumnPicker_DoesNotStrandOnAnAsyncPaneChange(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.handleKey(keyRune('c'))
+	if !m.colPicker {
+		t.Fatal("picker did not open")
+	}
+
+	// The server no longer reports the session being read: same shape as
+	// app.go's sessionsMsg handler.
+	m.selectedSess = ""
+	m.pane = paneSessions
+
+	// The picker's block must not claim these any more.
+	if cmd := m.handleKey(keyRune('j')); cmd != nil {
+		t.Log("j returned a command, which is fine — what matters is the pane below")
+	}
+	if m.colCursor != 0 {
+		t.Errorf("picker moved its cursor while the sessions pane was active (colCursor=%d)", m.colCursor)
+	}
+
+	// And it must not paint over the sessions pane.
+	if strings.Contains(m.paneView(), "COLUMNS") {
+		t.Error("the column picker popup was drawn over the sessions pane")
 	}
 }

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"github.com/charmbracelet/lipgloss"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"strings"
@@ -331,10 +333,24 @@ func TestColumnPicker_KeyPathSurvivesEveryToggle(t *testing.T) {
 	if !m.colPicker {
 		t.Fatal("`c` did not open the picker")
 	}
-	// Toggle every column off, moving right each time.
+	// Toggle every column off, moving DOWN each time.
+	//
+	// `j`, not `l`: the picker binds up/k and down/j, and `l` falls to the switch's
+	// default. With `l` the cursor never moved, so all twelve space presses toggled
+	// the same column — an even count that ended back at all-on, and both assertions
+	// below passed without the picker ever having emptied the selection.
 	for i := 0; i < len(eventColumns); i++ {
 		m.handleKey(keyRune(' '))
-		m.handleKey(keyRune('l'))
+		m.handleKey(keyRune('j'))
+	}
+	// The final toggle empties the selection, and the handler snaps it back to the
+	// defaults so the checkboxes keep matching the table. Before that snap-back the
+	// popup drew twelve empty boxes over a table showing twelve default columns.
+	if !anyColumnSelected(m.eventColumns) {
+		t.Fatal("emptying the selection left every checkbox off; the table shows defaults, so the picker misreports it")
+	}
+	if got, want := len(selectedColumns(m.eventColumns)), len(selectedColumns(defaultColumnSelection())); got != want {
+		t.Errorf("after emptying: %d columns selected, want the %d defaults", got, want)
 	}
 	// Never a blank table, however much was turned off.
 	if len(m.eventsTbl.Columns()) == 0 {
@@ -433,5 +449,84 @@ func TestDefaultColumns_HostIsOnAndSurvivesNarrowTerminals(t *testing.T) {
 		if !has(fitted, colHost) {
 			t.Errorf("width %d: HOST dropped; got %v", width, colNames(fitted))
 		}
+	}
+}
+
+// TestColumnPicker_UDoesNotEscapeModality is the first blocker from the #915
+// review. The `u`-opens-Usage handler sits ABOVE the picker block, so `u` reached
+// openUsage while m.colPicker stayed true: View() then drew the picker popup over
+// the Usage pane, paneUsage's own m/w/b/s bindings went live underneath it, and
+// `esc` closed the picker onto Usage rather than the events timeline the user
+// opened it from.
+func TestColumnPicker_UDoesNotEscapeModality(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.handleKey(keyRune('c'))
+	if !m.colPicker {
+		t.Fatal("picker did not open")
+	}
+
+	m.handleKey(keyRune('u'))
+
+	if m.pane != paneEvents {
+		t.Errorf("pane switched to %v underneath the open picker; the picker owns the keyboard", m.pane)
+	}
+	if !m.colPicker {
+		t.Error("picker closed on `u`; it should have been ignored")
+	}
+}
+
+// The picker popup must bound itself to the terminal. overlayCenter is explicit
+// that this is the caller's job: it renders an over-wide panel flush-left and
+// drops rows past the bottom edge, so an unbounded panel loses content silently.
+func TestColumnPicker_FitsTheTerminal(t *testing.T) {
+	// Every column on, so the "(no room)" markers are live too — the widest state.
+	sel := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		sel[c.id] = true
+	}
+	for _, w := range []int{60, 80, 100, 200} {
+		for _, c := range []int{0, len(eventColumns) - 1} {
+			out := renderColumnPicker(sel, c, w, 40)
+			for _, ln := range strings.Split(out, "\n") {
+				if n := lipgloss.Width(ln); n > w {
+					t.Errorf("width %d, cursor %d: a row is %d columns wide:\n%s", w, c, n, ln)
+					break
+				}
+			}
+		}
+	}
+}
+
+// The bottom row is the key hints, and overlayCenter drops rows past the bottom
+// edge. Before the height guard, a 12-line terminal lost "[esc] close" entirely —
+// the keys a stuck user reaches for, which is the same thing fitHintLine exists to
+// protect in the footer.
+func TestColumnPicker_HintsSurviveAShortTerminal(t *testing.T) {
+	sel := defaultColumnSelection()
+	base := strings.Repeat("row\n", 11)
+	for _, h := range []int{40, 24, 18, 14, 12, 10, 8} {
+		panel := renderColumnPicker(sel, 0, 100, h)
+		if got := len(strings.Split(panel, "\n")); got > h {
+			t.Errorf("height %d: panel is %d lines, so overlayCenter will clip it", h, got)
+		}
+		out := overlayCenter(base, panel, 100, h)
+		if !strings.Contains(out, "close") {
+			t.Errorf("height %d: the close hint was dropped:\n%s", h, out)
+		}
+	}
+}
+
+// Clipping the list must not hide the cursor: space would then toggle a column the
+// user cannot see.
+func TestColumnPicker_CursorStaysVisibleWhenClipped(t *testing.T) {
+	sel := defaultColumnSelection()
+	// 12 lines leaves room for only a few column rows.
+	last := len(eventColumns) - 1
+	out := renderColumnPicker(sel, last, 100, 12)
+	if !strings.Contains(out, string(eventColumns[last].id)) {
+		t.Errorf("cursor row %q is not rendered in a clipped popup:\n%s", eventColumns[last].id, out)
+	}
+	if !strings.Contains(out, "terminal too short") {
+		t.Errorf("a clipped list should say so:\n%s", out)
 	}
 }

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func colNames(cols []eventColumn) []string {
+	out := make([]string, 0, len(cols))
+	for _, c := range cols {
+		out = append(out, string(c.id))
+	}
+	return out
+}
+
+func has(cols []eventColumn, id eventColumnID) bool {
+	for _, c := range cols {
+		if c.id == id {
+			return true
+		}
+	}
+	return false
+}
+
+// The scenario from issue #866: "if I suppressed the DIR, TOKEN and TIME columns
+// the HOST column could appear on the screen using a reasonable font size."
+//
+// This is the acceptance test for the whole feature, and it failed on the first
+// implementation: HOST is last in display order, so dropping from the right took
+// the one column the user had turned others off to see.
+func TestFitColumns_IssueScenarioRevealsHost(t *testing.T) {
+	sel := defaultColumnSelection()
+	sel[colDir] = false
+	sel[colTokens] = false
+	sel[colTime] = false
+	sel[colHost] = true
+
+	fitted, _ := fitColumns(selectedColumns(sel), 80)
+
+	if !has(fitted, colHost) {
+		t.Errorf("HOST not visible at 80 columns after suppressing DIR/TIME/TOKENS; got %v",
+			colNames(fitted))
+	}
+	if w := columnsWidth(fitted); w > 80 {
+		t.Errorf("fitted width %d exceeds the terminal", w)
+	}
+	for _, off := range []eventColumnID{colDir, colTokens, colTime} {
+		if has(fitted, off) {
+			t.Errorf("%s was suppressed but still rendered", off)
+		}
+	}
+}
+
+// A column the user turned on explicitly must outrank one that is merely on by
+// default. Without this the feature does not work: the user's choice is the first
+// thing sacrificed.
+func TestFitColumns_OptedInColumnsSurviveDefaults(t *testing.T) {
+	sel := defaultColumnSelection()
+	sel[colHost] = true // opted in; defaultOn is false
+
+	fitted, dropped := fitColumns(selectedColumns(sel), 90)
+	if dropped == 0 {
+		t.Skip("terminal wide enough that nothing was dropped")
+	}
+	if !has(fitted, colHost) {
+		t.Errorf("the opted-in HOST column was dropped before default-on ones; got %v",
+			colNames(fitted))
+	}
+}
+
+// Whatever the width, the result must fit and must never be empty — a blank pane
+// is unrecoverable without restarting.
+func TestFitColumns_AlwaysFitsAndNeverEmpty(t *testing.T) {
+	all := selectedColumns(defaultColumnSelection())
+	for _, width := range []int{1, 5, 20, 40, 80, 100, 120, 140, 200, 400} {
+		fitted, dropped := fitColumns(all, width)
+		if len(fitted) == 0 {
+			t.Fatalf("width %d: no columns at all", width)
+		}
+		// One column may exceed a very narrow terminal — better a clipped cell
+		// than nothing — but with room to spare the fit must be honest.
+		if len(fitted) > 1 && columnsWidth(fitted) > width {
+			t.Errorf("width %d: fitted %d columns needing %d", width, len(fitted), columnsWidth(fitted))
+		}
+		if dropped != len(all)-len(fitted) {
+			t.Errorf("width %d: reported %d dropped, actually dropped %d",
+				width, dropped, len(all)-len(fitted))
+		}
+	}
+}
+
+// The first column is never sacrificed: "#" pairs a request with its response, and
+// without it the timeline cannot be read at all.
+func TestFitColumns_KeepsTheIndexColumn(t *testing.T) {
+	all := selectedColumns(defaultColumnSelection())
+	for _, width := range []int{1, 10, 30, 60} {
+		fitted, _ := fitColumns(all, width)
+		if len(fitted) == 0 || fitted[0].id != colIndex {
+			t.Errorf("width %d: lost the # column; got %v", width, colNames(fitted))
+		}
+	}
+}
+
+// A wide terminal drops nothing, so the indicator stays silent when there is
+// nothing to indicate.
+func TestFitColumns_WideTerminalDropsNothing(t *testing.T) {
+	all := selectedColumns(defaultColumnSelection())
+	fitted, dropped := fitColumns(all, columnsWidth(all))
+	if dropped != 0 || len(fitted) != len(all) {
+		t.Errorf("exact-width terminal dropped %d of %d", dropped, len(all))
+	}
+}
+
+// Turning every column off must not leave a blank pane: the selection falls back
+// to the defaults, since a user cannot recover from an empty table in-place.
+func TestSelectedColumns_EmptySelectionFallsBack(t *testing.T) {
+	sel := map[eventColumnID]bool{}
+	got := selectedColumns(sel)
+	if len(got) == 0 {
+		t.Fatal("empty selection produced no columns")
+	}
+	if !has(got, colIndex) {
+		t.Errorf("fallback does not include #; got %v", colNames(got))
+	}
+}
+
+// Header and cells come from one definition, so they cannot disagree. They were
+// two hand-maintained parallel lists, where inserting a column shifted every later
+// cell under the wrong heading.
+func TestTableColumns_MatchesTheDefinition(t *testing.T) {
+	cols := selectedColumns(defaultColumnSelection())
+	tc := tableColumns(cols)
+	if len(tc) != len(cols) {
+		t.Fatalf("tableColumns produced %d for %d columns", len(tc), len(cols))
+	}
+	for i := range cols {
+		if tc[i].Title != string(cols[i].id) {
+			t.Errorf("column %d: header %q, definition %q", i, tc[i].Title, cols[i].id)
+		}
+		if tc[i].Width != cols[i].width {
+			t.Errorf("column %d (%s): header width %d, definition %d",
+				i, cols[i].id, tc[i].Width, cols[i].width)
+		}
+	}
+}
+
+// Every column must render a cell, or a selection would panic on a nil func.
+func TestEventColumns_AllHaveCellFuncs(t *testing.T) {
+	seen := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		if c.cell == nil {
+			t.Errorf("column %s has no cell function", c.id)
+		}
+		if c.width <= 0 {
+			t.Errorf("column %s has width %d", c.id, c.width)
+		}
+		if seen[c.id] {
+			t.Errorf("duplicate column id %s", c.id)
+		}
+		seen[c.id] = true
+	}
+}
+
+// The picker names every column, marks which are on, and shows the cursor —
+// otherwise a user cannot tell what pressing space would do.
+func TestColumnPickerLine(t *testing.T) {
+	sel := defaultColumnSelection()
+	line := stripANSI(columnPickerLine(sel, 0))
+
+	for _, c := range eventColumns {
+		if !strings.Contains(line, string(c.id)) {
+			t.Errorf("picker omits %s: %q", c.id, line)
+		}
+	}
+	// The cursor is bracketed, so the highlighted column is identifiable without
+	// colour — a terminal without it, or a screenshot, still reads.
+	if !strings.Contains(line, "["+string(eventColumns[0].id)+"]") {
+		t.Errorf("picker does not bracket the cursor column: %q", line)
+	}
+	if strings.Contains(stripANSI(columnPickerLine(sel, 3)), "["+string(eventColumns[0].id)+"]") {
+		t.Error("bracket did not move with the cursor")
+	}
+}

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -544,49 +544,132 @@ func TestColumnPicker_CursorStaysVisibleWhenClipped(t *testing.T) {
 // at 80 and — worse, between 156 and 167 — reported dropped==0 while up to twelve
 // columns sat off the edge, with no footer count and no "(no room)" marker.
 func TestFitColumns_RenderedWidthNeverExceedsTerminal(t *testing.T) {
-	sel := map[eventColumnID]bool{}
-	for _, c := range eventColumns {
-		sel[c.id] = true
-	}
-	all := selectedColumns(sel)
+	// Several selections, not just all-on. The all-on case alone let a real bug
+	// through: fitColumns credited back width+1 while columnsWidth charged
+	// width+cellPadding, and the greedy loop never reconsidered an overshoot — at 80
+	// it dropped seven columns and left 19 unused. Neither shows up if the only
+	// input is "everything on", because the invariant checked (rendered <= width)
+	// stays true when too MUCH is dropped.
+	for _, tc := range columnSelectionCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			cols := selectedColumns(tc.sel)
+			for w := 20; w <= 180; w++ {
+				fitted, dropped := fitColumns(cols, w)
+				if len(fitted) == 0 {
+					t.Fatalf("width %d: no columns returned", w)
+				}
 
-	// Every width from very narrow to past the full table, so no band is skipped —
-	// 156..167 is precisely where the old model reported a clean fit.
-	for w := 20; w <= 180; w++ {
-		fitted, dropped := fitColumns(all, w)
-		if len(fitted) == 0 {
-			t.Fatalf("width %d: no columns returned", w)
-		}
+				tbl := newEventsTable()
+				tbl.SetColumns(tableColumns(fitted))
+				row := make([]string, len(fitted))
+				for i := range row {
+					row[i] = "x"
+				}
+				tbl.SetRows([]table.Row{row})
 
-		tbl := newEventsTable()
-		tbl.SetColumns(tableColumns(fitted))
-		row := make([]string, len(fitted))
-		for i := range row {
-			row[i] = "x"
-		}
-		tbl.SetRows([]table.Row{row})
+				rendered := 0
+				for _, ln := range strings.Split(tbl.View(), "\n") {
+					if n := lipgloss.Width(ln); n > rendered {
+						rendered = n
+					}
+				}
 
-		rendered := 0
-		for _, ln := range strings.Split(tbl.View(), "\n") {
-			if n := lipgloss.Width(ln); n > rendered {
-				rendered = n
+				// The one legitimate exception: a terminal too narrow for even one
+				// column. fitColumns never returns empty, so a single column may exceed.
+				if len(fitted) == 1 && rendered > w {
+					continue
+				}
+				if rendered > w {
+					t.Errorf("width %d: %d columns render at %d (%d dropped) — overflows by %d",
+						w, len(fitted), rendered, dropped, rendered-w)
+				}
+				if got := columnsWidth(fitted); got != rendered {
+					t.Errorf("width %d: columnsWidth says %d, bubbles renders %d", w, got, rendered)
+				}
 			}
-		}
+		})
+	}
+}
 
-		// The one legitimate exception: a terminal too narrow for even one column.
-		// fitColumns never returns empty, so a single column may exceed a tiny width.
-		if len(fitted) == 1 && rendered > w {
-			continue
+// The other half of "fits": it must not drop MORE than it has to. The
+// rendered-width check above is satisfied by dropping everything, so without this
+// an over-eager fitColumns looks correct.
+func TestFitColumns_DropsNoMoreThanNecessary(t *testing.T) {
+	for _, tc := range columnSelectionCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			cols := selectedColumns(tc.sel)
+			for w := 20; w <= 180; w++ {
+				fitted, _ := fitColumns(cols, w)
+				used := columnsWidth(fitted)
+				if used > w {
+					continue // covered by the invariant test above
+				}
+				in := make(map[eventColumnID]bool, len(fitted))
+				for _, c := range fitted {
+					in[c.id] = true
+				}
+				// Any dropped column that would still fit in the leftover room means the
+				// drop was unnecessary — the user lost a column for nothing.
+				for _, c := range cols {
+					if in[c.id] {
+						continue
+					}
+					if used+c.width+cellPadding <= w {
+						t.Errorf("width %d: dropped %s (needs %d) with %d columns unused",
+							w, c.id, c.width+cellPadding, w-used)
+					}
+				}
+			}
+		})
+	}
+}
+
+// columnSelectionCases spans the selection shapes the picker can produce: all on,
+// the defaults, and several partial sets chosen to vary which keep-ranks and which
+// widths are present.
+func columnSelectionCases() []struct {
+	name string
+	sel  map[eventColumnID]bool
+} {
+	all := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		all[c.id] = true
+	}
+	// Only the widest columns, so a single drop swings the total a long way — the
+	// shape that made the greedy loop overshoot.
+	wide := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		if c.width >= 17 {
+			wide[c.id] = true
 		}
-		if rendered > w {
-			t.Errorf("width %d: %d columns render at %d (%d dropped) — overflows by %d",
-				w, len(fitted), rendered, dropped, rendered-w)
+	}
+	// Only narrow ones, where many drops are needed to move the total at all.
+	narrow := map[eventColumnID]bool{}
+	for _, c := range eventColumns {
+		if c.width <= 10 {
+			narrow[c.id] = true
 		}
-		// And the model must agree with reality, or the footer count and the picker's
-		// "(no room)" markers describe a different table than the one on screen.
-		if got := columnsWidth(fitted); got != rendered {
-			t.Errorf("width %d: columnsWidth says %d, bubbles renders %d", w, got, rendered)
+	}
+	// Alternating, to mix ranks and widths.
+	alt := map[eventColumnID]bool{}
+	for i, c := range eventColumns {
+		if i%2 == 0 {
+			alt[c.id] = true
 		}
+	}
+	// A single column: the degenerate case fitColumns must not return empty for.
+	one := map[eventColumnID]bool{eventColumns[len(eventColumns)-1].id: true}
+
+	return []struct {
+		name string
+		sel  map[eventColumnID]bool
+	}{
+		{"all-on", all},
+		{"defaults", defaultColumnSelection()},
+		{"wide-only", wide},
+		{"narrow-only", narrow},
+		{"alternating", alt},
+		{"single", one},
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -1,15 +1,13 @@
 package tui
 
 import (
-	"github.com/charmbracelet/bubbles/table"
-
-	"github.com/charmbracelet/lipgloss"
-
-	tea "github.com/charmbracelet/bubbletea"
-
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
@@ -727,5 +725,83 @@ func TestColumnPicker_DoesNotStrandOnAnAsyncPaneChange(t *testing.T) {
 	// And it must not paint over the sessions pane.
 	if strings.Contains(m.paneView(), "COLUMNS") {
 		t.Error("the column picker popup was drawn over the sessions pane")
+	}
+}
+
+// The picker must close with the pane it belongs to, not merely go quiet.
+//
+// The paneEvents gates make it inert and invisible while the user is bounced to
+// the sessions table, but the flag outlived the pane: pressing enter on another
+// session restored paneEvents and the popup was back without the user reopening
+// it, owning the keyboard until they found esc. Gating covers "drawn over the
+// wrong pane"; this covers the return trip.
+func TestColumnPicker_DoesNotReturnAfterAnAsyncPaneChange(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.width, m.height = 100, 40
+	m.handleKey(keyRune('c'))
+	if !m.colPicker || !strings.Contains(m.View(), "COLUMNS") {
+		t.Fatal("picker did not open")
+	}
+
+	// Drive the REAL handler, not a hand-set flag: the focused session disappears
+	// from the server's list, and sessionsLoadedMsg backs out to paneSessions. A
+	// test that assigned m.colPicker itself would pass without the fix.
+	m.Update(sessionsLoadedMsg{})
+	if m.pane != paneSessions {
+		t.Fatalf("handler did not back out to paneSessions (pane=%v)", m.pane)
+	}
+	if strings.Contains(m.View(), "COLUMNS") {
+		t.Error("popup still drawn over the sessions pane")
+	}
+
+	// The user picks another session. The picker must NOT reappear.
+	m.selectedSess = "s"
+	m.pane = paneEvents
+	if m.colPicker {
+		t.Error("colPicker survived the pane change; the popup returns unbidden")
+	}
+	if strings.Contains(m.View(), "COLUMNS") {
+		t.Error("a popup the user never reopened is back on the events pane")
+	}
+	// And it does not own the keyboard.
+	before := m.colCursor
+	m.handleKey(keyRune('j'))
+	if m.colCursor != before {
+		t.Errorf("the closed picker still captured `j` (colCursor %d -> %d)", before, m.colCursor)
+	}
+}
+
+// Cells must truncate to their own column's declared width, read from
+// cellContext rather than hardcoded.
+//
+// PLUGIN and HOST previously repeated 18 and 20 in their truncStr calls,
+// duplicating the width two lines above — the same drift actionColWidth and
+// methodColWidth were named to prevent, in the file whose premise is that a column
+// is one definition. This fails if the plumbing regresses to a hardcoded number or
+// silently passes 0.
+func TestEventColumns_CellsTruncateToTheirOwnWidth(t *testing.T) {
+	m := newTestEventsModel(t)
+	long := strings.Repeat("x", 80)
+	for i := range m.events["s"] {
+		m.events["s"][i].Host = long + ".example.com"
+	}
+	m.rebuildEventsTable()
+
+	cols := m.eventsTbl.Columns()
+	rows := m.eventsTbl.Rows()
+	if len(rows) == 0 {
+		t.Fatal("no rows")
+	}
+	for i, c := range cols {
+		cell := rows[0][i]
+		n := len([]rune(cell))
+		if n > c.Width {
+			t.Errorf("%s cell is %d wide, exceeding its column width %d: %q", c.Title, n, c.Width, cell)
+		}
+		// A cell that came back empty for a column that has content to show would be
+		// the signature of a zero width reaching truncStr.
+		if c.Title == "HOST" && n == 0 {
+			t.Error("HOST truncated to nothing; the column width was not plumbed through")
+		}
 	}
 }

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -16,30 +16,13 @@ import (
 // now safe because per-cell ANSI coloring was removed from this table.
 func newEventsTable() table.Model {
 	t := table.New(
-		table.WithColumns([]table.Column{
-			{Title: "#", Width: 4},
-			{Title: "TIME", Width: 12},
-			{Title: "DIR", Width: 4},
-			{Title: "PHASE", Width: 7},
-			{Title: "ACTION", Width: actionColWidth},
-			{Title: "PLUGIN", Width: 18},
-			// methodColWidth rather than 22: the widest realistic value is a model
-			// name ("claude-opus-5"), and the columns freed pay for splitting
-			// TOKENS and COST apart below.
-			{Title: "METHOD", Width: methodColWidth},
-			{Title: "STATUS", Width: 7},
-			{Title: "DURATION", Width: 10},
-			// 17, not 15: sized for a SEVEN-digit prompt, "1,048,576(−12.3k)".
-			// Million-token contexts are in service, and bubbles truncates a cell
-			// at the column width, so 15 rendered "1,048,576(−1…" — dropping the
-			// saving, which is the half of this cell that appears nowhere else.
-			{Title: "TOKENS", Width: 17},
-			// 19 fits the widest cell the formatter can produce:
-			// "<$0.0001(−<$0.0001)", where both halves fell under the
-			// four-decimal floor. The ordinary shape is "$0.2546(−$0.0037)" at 17.
-			{Title: "COST", Width: 19},
-			{Title: "HOST", Width: 20},
-		}),
+		// One definition, not two. This used to hold a hand-written twelve-entry
+		// copy of eventColumns' widths — harmless, because the first
+		// rebuildEventsTable overwrites it via SetColumns, which is exactly what
+		// made it a hazard: a width changed in one place and not the other produced
+		// no symptom at all. The rationale for the non-obvious widths now lives
+		// beside the widths that actually decide, in eventColumns.
+		table.WithColumns(tableColumns(selectedColumns(defaultColumnSelection()))),
 		table.WithFocused(true),
 	)
 	t.SetStyles(tableStyles())

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -108,8 +108,9 @@ func (m *model) rebuildEventsTable() {
 	// row cell come from `cols`, so they cannot disagree.
 	cols, dropped := fitColumns(selectedColumns(m.eventColumns), m.width)
 	m.eventColsDropped = dropped
-	m.eventsTbl.SetColumns(tableColumns(cols))
 
+	// Rows are built first and handed to the table together with their columns at
+	// the end of this function — see the note there on why the order matters.
 	rows := make([]table.Row, 0, len(eventRows))
 	m.visibleRows = m.visibleRows[:0]
 	m.hiddenInactive = 0
@@ -149,6 +150,15 @@ func (m *model) rebuildEventsTable() {
 		rows = append(rows, row)
 		m.visibleRows = append(m.visibleRows, er)
 	}
+	// Clear, set columns, then set the matching rows.
+	//
+	// SetColumns calls UpdateViewport, which re-renders whatever rows are loaded,
+	// and bubbles' renderRow walks the ROW's cells while indexing m.cols[i] — so a
+	// row with more cells than there are columns reads past the end and panics
+	// ("index out of range [10] with length 10"). Toggling a column off is exactly
+	// that. Clearing first leaves SetColumns nothing to mis-render.
+	m.eventsTbl.SetRows(nil)
+	m.eventsTbl.SetColumns(tableColumns(cols))
 	m.eventsTbl.SetRows(rows)
 
 	// Auto-follow: if user was at the bottom, stay at the bottom. Otherwise

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -125,9 +125,17 @@ func (m *model) rebuildEventsTable() {
 		// notation, so both rows claimed to contain each other and the output was
 		// actively misleading. The # column pairs exchanges exactly (by the
 		// proxy-stamped RequestID), which is what the glyphs approximated.
-		cc := cellContext{m: m, rows: eventRows, partner: partner, i: i, row: er, ids: ids}
+		// One rowAction per row, reusing the invs computed for hideInactive above:
+		// the ACTION and PLUGIN cells read this result rather than each recomputing
+		// the pair and discarding half of it.
+		action, plugin := rowAction(er, invs)
+		cc := cellContext{
+			m: m, rows: eventRows, partner: partner, i: i, row: er, ids: ids,
+			invs: invs, action: action, plugin: plugin,
+		}
 		row := make(table.Row, 0, len(cols))
 		for _, c := range cols {
+			cc.width = c.width
 			row = append(row, c.cell(cc))
 		}
 		rows = append(rows, row)

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/table"
@@ -105,11 +104,16 @@ func (m *model) rebuildEventsTable() {
 	// exchange is read off the timeline.
 	ids, partner := computeEventPairs(eventRows)
 
+	// One selection per rebuild, fitted to the terminal. Both the header and every
+	// row cell come from `cols`, so they cannot disagree.
+	cols, dropped := fitColumns(selectedColumns(m.eventColumns), m.width)
+	m.eventColsDropped = dropped
+	m.eventsTbl.SetColumns(tableColumns(cols))
+
 	rows := make([]table.Row, 0, len(eventRows))
 	m.visibleRows = m.visibleRows[:0]
 	m.hiddenInactive = 0
 	for i, er := range eventRows {
-		ev := er.event
 		if m.filter != "" && !matchEventRow(er, m.filter) {
 			continue
 		}
@@ -124,34 +128,25 @@ func (m *model) rebuildEventsTable() {
 			continue
 		}
 
-		action, plugin := rowAction(er, invs)
-		var idCell string
-		if id, ok := ids[ev]; ok {
-			idCell = strconv.Itoa(id)
+		// Cells come from the selected columns, in their order — see
+		// events_columns.go. Previously this was a positional table.Row literal
+		// parallel to a []table.Column slice, so inserting a column meant editing
+		// both in step and a mismatch shifted every later cell under the wrong
+		// heading.
+		//
+		// PHASE carries no bracket glyphs. They were box-drawing corners (┌/│/└)
+		// meant to visually connect a request to its response, and they could only
+		// ever be correct for exchanges that NEST. Concurrent requests cross
+		// instead: A starts, B starts, A ends, B ends — for which a tree has no
+		// notation, so both rows claimed to contain each other and the output was
+		// actively misleading. The # column pairs exchanges exactly (by the
+		// proxy-stamped RequestID), which is what the glyphs approximated.
+		cc := cellContext{m: m, rows: eventRows, partner: partner, i: i, row: er, ids: ids}
+		row := make(table.Row, 0, len(cols))
+		for _, c := range cols {
+			row = append(row, c.cell(cc))
 		}
-		// PHASE carries no bracket glyphs. They were box-drawing corners
-		// (┌/│/└) meant to visually connect a request to its response, and they
-		// could only ever be correct for exchanges that NEST. Concurrent
-		// requests cross instead: A starts, B starts, A ends, B ends — for
-		// which a tree has no notation, so both rows claimed to contain each
-		// other and the output was actively misleading. The # column pairs
-		// exchanges exactly (by the proxy-stamped RequestID), which is what the
-		// glyphs were a lossy approximation of.
-		phaseCell := shortPhase(ev.Phase)
-		rows = append(rows, table.Row{
-			idCell,
-			ev.At.Format("15:04:05.00"),
-			shortDirection(ev.Direction),
-			phaseCell,
-			action,
-			truncStr(plugin, 18),
-			eventMethod(*ev),
-			statusCell(*ev),
-			durationCell(*ev),
-			m.tokensCell(eventRows, partner, i, ev),
-			m.costCell(eventRows, partner, i, ev),
-			truncStr(ev.Host, 20),
-		})
+		rows = append(rows, row)
 		m.visibleRows = append(m.visibleRows, er)
 	}
 	m.eventsTbl.SetRows(rows)

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // footerView renders the bottom two lines: status (connection + rate + drops
@@ -50,7 +52,43 @@ func (m *model) footerView() string {
 		status.WriteString(styleTitle.Render("   " + m.flash))
 	}
 
-	hint := m.helpView()
+	hint := fitHintLine(m.helpView(), m.width)
 
 	return status.String() + "\n" + styleHint.Render(hint)
+}
+
+// fitHintLine trims a footer hint line to the terminal width, dropping whole
+// hints from the FRONT.
+//
+// The events footer runs ~135 columns, so an 80-column terminal simply lost the
+// tail — and the tail is where "[?] keys" and "[q] quit" live, the pair a stuck
+// user reaches for. helpView orders its hints so the essential ones come last;
+// this is the half that makes that ordering mean something, by cutting the other
+// end.
+//
+// A leading "…" marks the cut, so a missing hint reads as "there are more" rather
+// than as a key that does not exist. The [?] overlay is the complete reference.
+func fitHintLine(hint string, width int) string {
+	if width <= 0 || lipgloss.Width(hint) <= width {
+		return hint
+	}
+	const sep = "  "
+	const ellipsis = "… "
+
+	parts := strings.Split(hint, sep)
+	// Drop from the front until it fits, always keeping the last hint: one clipped
+	// hint beats a bare ellipsis.
+	for i := 0; i < len(parts)-1; i++ {
+		candidate := ellipsis + strings.Join(parts[i+1:], sep)
+		if lipgloss.Width(candidate) <= width {
+			return candidate
+		}
+	}
+	// Even the last hint alone is too wide. Truncate it rather than return a line
+	// that overflows and wraps, which would push a row of the table off-screen.
+	last := parts[len(parts)-1]
+	if lipgloss.Width(last) <= width {
+		return last
+	}
+	return truncToWidth(last, width)
 }

--- a/authbridge/cmd/abctl/tui/footer_fit_test.go
+++ b/authbridge/cmd/abctl/tui/footer_fit_test.go
@@ -87,3 +87,75 @@ func TestFitHintLine_UnknownWidthIsUnchanged(t *testing.T) {
 		t.Error("zero width altered the hint line")
 	}
 }
+
+// The optional notices — hidden-message and dropped-column counts — must not
+// outlive the keys that let a user act on them.
+//
+// They were appended AFTER "[q] quit", and fitHintLine drops from the front, so at
+// width 40 the footer read "… · → 1 more column ([c] to choose)" with no way to
+// quit or open help. A notice is worth less than the keys it refers to.
+func TestFitHintLine_NoticesNeverOutliveQuit(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*model)
+	}{
+		{"dropped columns", func(m *model) { m.eventColsDropped = 1 }},
+		{"many dropped columns", func(m *model) { m.eventColsDropped = 7 }},
+		{"hidden messages", func(m *model) { m.hideInactive = true; m.hiddenInactive = 42 }},
+		{"both notices", func(m *model) {
+			m.eventColsDropped = 3
+			m.hideInactive = true
+			m.hiddenInactive = 9
+		}},
+	} {
+		m := &model{pane: paneEvents, eventColumns: defaultColumnSelection()}
+		tc.setup(m)
+		full := m.helpView()
+
+		for _, width := range []int{120, 80, 60, 40, 30, 20} {
+			got := fitHintLine(full, width)
+			if len([]rune(got)) > width {
+				t.Errorf("%s at %d: %d columns:\n%q", tc.name, width, len([]rune(got)), got)
+			}
+			if !strings.Contains(got, "[q] quit") {
+				t.Errorf("%s at %d: lost [q] quit:\n%q", tc.name, width, got)
+			}
+			if width >= 24 && !strings.Contains(got, "[?] keys") {
+				t.Errorf("%s at %d: lost [?] keys:\n%q", tc.name, width, got)
+			}
+		}
+	}
+}
+
+// A wide terminal still shows the notice — moving it earlier must not lose it.
+func TestFooter_NoticesStillAppearWhenThereIsRoom(t *testing.T) {
+	m := &model{pane: paneEvents, eventColumns: defaultColumnSelection()}
+	m.eventColsDropped = 2
+	m.hideInactive = true
+	m.hiddenInactive = 5
+
+	got := fitHintLine(m.helpView(), 220)
+	for _, want := range []string{"2 more columns", "5 hidden", "[?] keys", "[q] quit"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wide footer omits %q:\n%q", want, got)
+		}
+	}
+}
+
+// The pipeline pane appended its unmet-deps notice the same way, so it had the
+// same defect. Pre-existing rather than introduced here, but identical in kind.
+func TestFitHintLine_PipelineNoticeNeverOutlivesQuit(t *testing.T) {
+	m := &model{pane: panePipeline}
+	// unmetDepsCount reads the pipeline; a nil one yields 0, so drive the notice
+	// through a stub-free path by checking both with and without it present.
+	full := m.helpView()
+	for _, width := range []int{80, 60, 40, 24} {
+		got := fitHintLine(full, width)
+		if !strings.Contains(got, "[q] quit") {
+			t.Errorf("width %d: lost [q] quit:\n%q", width, got)
+		}
+		if len([]rune(got)) > width {
+			t.Errorf("width %d: %d columns:\n%q", width, len([]rune(got)), got)
+		}
+	}
+}

--- a/authbridge/cmd/abctl/tui/footer_fit_test.go
+++ b/authbridge/cmd/abctl/tui/footer_fit_test.go
@@ -1,0 +1,89 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// Quit and help must survive at every terminal width. The events footer runs ~135
+// columns, so an 80-column terminal cut the tail — and the tail is exactly where
+// [?] and [q] were, the pair a stuck user reaches for.
+func TestFitHintLine_KeepsQuitAndHelpAtEveryWidth(t *testing.T) {
+	m := &model{pane: paneEvents, eventColumns: defaultColumnSelection()}
+	full := m.helpView()
+
+	for _, width := range []int{200, 140, 120, 100, 80, 60, 40, 24, 20} {
+		got := fitHintLine(full, width)
+		if len([]rune(got)) > width {
+			t.Errorf("width %d: hint is %d columns:\n%q", width, len([]rune(got)), got)
+		}
+		if !strings.Contains(got, "[q] quit") {
+			t.Errorf("width %d: lost [q] quit:\n%q", width, got)
+		}
+		// Help is the complete reference, so it outlives every specialised hint.
+		if width >= 24 && !strings.Contains(got, "[?] keys") {
+			t.Errorf("width %d: lost [?] keys:\n%q", width, got)
+		}
+	}
+}
+
+// A truncated line says so. Without the marker, a missing hint reads as a key that
+// does not exist rather than one that did not fit.
+func TestFitHintLine_MarksTruncation(t *testing.T) {
+	m := &model{pane: paneEvents, eventColumns: defaultColumnSelection()}
+	full := m.helpView()
+
+	if got := fitHintLine(full, 60); !strings.HasPrefix(got, "…") {
+		t.Errorf("truncated line does not start with an ellipsis: %q", got)
+	}
+	// And an untruncated line does not claim to be.
+	wide := fitHintLine(full, 400)
+	if strings.HasPrefix(wide, "…") {
+		t.Errorf("untruncated line marked as truncated: %q", wide)
+	}
+	if wide != full {
+		t.Error("a line that fits was altered")
+	}
+}
+
+// Dropping is from the front, so the hints that survive are the ones helpView put
+// last. Ordering and trimming are two halves of one mechanism.
+func TestFitHintLine_DropsFromTheFront(t *testing.T) {
+	m := &model{pane: paneEvents, eventColumns: defaultColumnSelection()}
+	got := fitHintLine(m.helpView(), 60)
+
+	// The specialised, pane-specific keys go first.
+	for _, gone := range []string{"[↑↓] nav", "[c] columns", "[u] usage"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("width 60 kept %q, which should have been dropped: %q", gone, got)
+		}
+	}
+}
+
+// Every pane's footer must fit, not only the events one — the others are shorter
+// but the guard should hold for all of them.
+func TestFitHintLine_EveryPaneFitsAt80(t *testing.T) {
+	for _, pane := range []paneID{
+		paneNamespaces, panePods, paneSessions, paneEvents,
+		paneDetail, paneUsage, panePipeline, panePluginDetail, paneCatalog,
+	} {
+		m := &model{pane: pane, eventColumns: defaultColumnSelection()}
+		got := fitHintLine(m.helpView(), 80)
+		if len([]rune(got)) > 80 {
+			t.Errorf("pane %v: hint is %d columns at 80:\n%q", pane, len([]rune(got)), got)
+		}
+		if !strings.Contains(got, "[q] quit") {
+			t.Errorf("pane %v: lost [q] quit at 80 columns:\n%q", pane, got)
+		}
+	}
+}
+
+// A zero width means the size is not known yet (before the first WindowSizeMsg);
+// pass the line through rather than trimming it to nothing.
+func TestFitHintLine_UnknownWidthIsUnchanged(t *testing.T) {
+	m := &model{pane: paneEvents, eventColumns: defaultColumnSelection()}
+	full := m.helpView()
+	if got := fitHintLine(full, 0); got != full {
+		t.Error("zero width altered the hint line")
+	}
+}

--- a/authbridge/cmd/abctl/tui/footer_fit_test.go
+++ b/authbridge/cmd/abctl/tui/footer_fit_test.go
@@ -1,9 +1,12 @@
 package tui
 
 import (
-	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 )
 
 // Quit and help must survive at every terminal width. The events footer runs ~135
@@ -15,8 +18,8 @@ func TestFitHintLine_KeepsQuitAndHelpAtEveryWidth(t *testing.T) {
 
 	for _, width := range []int{200, 140, 120, 100, 80, 60, 40, 24, 20} {
 		got := fitHintLine(full, width)
-		if len([]rune(got)) > width {
-			t.Errorf("width %d: hint is %d columns:\n%q", width, len([]rune(got)), got)
+		if lipgloss.Width(got) > width {
+			t.Errorf("width %d: hint is %d columns:\n%q", width, lipgloss.Width(got), got)
 		}
 		if !strings.Contains(got, "[q] quit") {
 			t.Errorf("width %d: lost [q] quit:\n%q", width, got)
@@ -70,8 +73,8 @@ func TestFitHintLine_EveryPaneFitsAt80(t *testing.T) {
 	} {
 		m := &model{pane: pane, eventColumns: defaultColumnSelection()}
 		got := fitHintLine(m.helpView(), 80)
-		if len([]rune(got)) > 80 {
-			t.Errorf("pane %v: hint is %d columns at 80:\n%q", pane, len([]rune(got)), got)
+		if lipgloss.Width(got) > 80 {
+			t.Errorf("pane %v: hint is %d columns at 80:\n%q", pane, lipgloss.Width(got), got)
 		}
 		if !strings.Contains(got, "[q] quit") {
 			t.Errorf("pane %v: lost [q] quit at 80 columns:\n%q", pane, got)
@@ -115,8 +118,8 @@ func TestFitHintLine_NoticesNeverOutliveQuit(t *testing.T) {
 
 		for _, width := range []int{120, 80, 60, 40, 30, 20} {
 			got := fitHintLine(full, width)
-			if len([]rune(got)) > width {
-				t.Errorf("%s at %d: %d columns:\n%q", tc.name, width, len([]rune(got)), got)
+			if lipgloss.Width(got) > width {
+				t.Errorf("%s at %d: %d columns:\n%q", tc.name, width, lipgloss.Width(got), got)
 			}
 			if !strings.Contains(got, "[q] quit") {
 				t.Errorf("%s at %d: lost [q] quit:\n%q", tc.name, width, got)
@@ -164,13 +167,18 @@ func TestFitHintLine_PipelineNoticeNeverOutlivesQuit(t *testing.T) {
 	if !strings.Contains(full, "unmet deps") {
 		t.Fatalf("footer lacks the unmet-deps notice this test is named for:\n%q", full)
 	}
+	// lipgloss.Width, not len([]rune(...)): fitHintLine measures display columns, so
+	// the test has to measure the same thing. They agree for today's hints (↑ and ↓
+	// are width 1), but a hint with a genuinely wide glyph would overflow the footer
+	// while a rune count still read it as fitting — which is the exact failure this
+	// test exists to catch.
 	for _, width := range []int{80, 60, 40, 24} {
 		got := fitHintLine(full, width)
 		if !strings.Contains(got, "[q] quit") {
 			t.Errorf("width %d: lost [q] quit:\n%q", width, got)
 		}
-		if len([]rune(got)) > width {
-			t.Errorf("width %d: %d columns:\n%q", width, len([]rune(got)), got)
+		if lipgloss.Width(got) > width {
+			t.Errorf("width %d: %d columns:\n%q", width, lipgloss.Width(got), got)
 		}
 	}
 }

--- a/authbridge/cmd/abctl/tui/footer_fit_test.go
+++ b/authbridge/cmd/abctl/tui/footer_fit_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
 	"strings"
 	"testing"
 )
@@ -145,10 +146,24 @@ func TestFooter_NoticesStillAppearWhenThereIsRoom(t *testing.T) {
 // The pipeline pane appended its unmet-deps notice the same way, so it had the
 // same defect. Pre-existing rather than introduced here, but identical in kind.
 func TestFitHintLine_PipelineNoticeNeverOutlivesQuit(t *testing.T) {
-	m := &model{pane: panePipeline}
-	// unmetDepsCount reads the pipeline; a nil one yields 0, so drive the notice
-	// through a stub-free path by checking both with and without it present.
+	// A populated pipeline with one genuinely unmet dependency, so the
+	// "%d plugin%s with unmet deps" branch is actually taken. With a nil pipeline
+	// unmetDepsCount() returns 0 and this test asserted only the plain panePipeline
+	// footer — which TestEveryPaneFitsAt80 already covers, so the notice this test
+	// is named for went unexercised.
+	m := &model{pane: panePipeline, pipeline: &apiclient.PipelineView{
+		Outbound: []apiclient.PipelinePlugin{
+			{Name: "token-exchange", Direction: "outbound", Position: 0,
+				Requires: []string{"jwt-validation"}},
+		},
+	}}
+	if n := m.unmetDepsCount(); n == 0 {
+		t.Fatal("fixture produced no unmet deps, so the notice branch is not exercised")
+	}
 	full := m.helpView()
+	if !strings.Contains(full, "unmet deps") {
+		t.Fatalf("footer lacks the unmet-deps notice this test is named for:\n%q", full)
+	}
 	for _, width := range []int{80, 60, 40, 24} {
 		got := fitHintLine(full, width)
 		if !strings.Contains(got, "[q] quit") {

--- a/authbridge/cmd/abctl/tui/help_overlay.go
+++ b/authbridge/cmd/abctl/tui/help_overlay.go
@@ -80,7 +80,7 @@ var paneKeys = map[paneID]keyGroup{
 			{"↵ / → / l", "event detail"},
 			{"/", "filter"},
 			{"s", "toggle passthru/skip rows"},
-			{"c", "choose which columns to show"},
+			{"c", "column picker (checkboxes + descriptions)"},
 			{"u", "usage charts (this session)"},
 			{"esc / ← / h", "back to sessions"},
 		},

--- a/authbridge/cmd/abctl/tui/help_overlay.go
+++ b/authbridge/cmd/abctl/tui/help_overlay.go
@@ -80,6 +80,7 @@ var paneKeys = map[paneID]keyGroup{
 			{"↵ / → / l", "event detail"},
 			{"/", "filter"},
 			{"s", "toggle passthru/skip rows"},
+			{"c", "choose which columns to show"},
 			{"u", "usage charts (this session)"},
 			{"esc / ← / h", "back to sessions"},
 		},

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -647,7 +647,14 @@ func (m *model) helpView() string {
 		if m.hideInactive {
 			skipHint = "[s] show all"
 		}
-		base := "[↑↓] nav  [b/f] page  [↵] detail  [u] usage  [c] columns  [esc] back  [/] filter  " + skipHint + "  [p] pause  [?] keys  [q] quit"
+		// Ordered by what must survive truncation, not by how the keys group. The
+		// footer runs 135 columns and an 80-column terminal cuts the tail, so
+		// anything after the cut is invisible — [?] keys and [q] quit were both
+		// past it, which is the pair a stuck user reaches for. They now sit at the
+		// end, and the escapable/discoverable keys ahead of them, with the
+		// specialised ones first to be lost.
+		base := "[↑↓] nav  [b/f] page  [↵] detail  [c] columns  [u] usage  " +
+			skipHint + "  [p] pause  [/] filter  [esc] back  [?] keys  [q] quit"
 		// Surface the hidden-message count so a filtered timeline doesn't
 		// look like data loss. Only annotate when hiding is on AND at
 		// least one message was hidden.

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -115,7 +115,15 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 	// events timeline it charts the session being read, from the session picker
 	// it charts everything. Suppressed while filtering, where `u` is a character
 	// the user is typing — the same reasoning as the `?` overlay above.
-	if msg.String() == "u" && !m.filtering && m.editState.phase == editPhaseDone {
+	//
+	// Gated on !m.colPicker as well: this handler sits above the picker block, so
+	// without it `u` reached openUsage while m.colPicker stayed true — View() drew
+	// the picker popup over the Usage pane, paneUsage's own m/w/b/s bindings went
+	// live underneath it, and `esc` then closed the picker onto Usage instead of the
+	// events timeline the picker was opened from. (`?` above is deliberately NOT
+	// gated: it layers help over the picker without changing panes, and closing it
+	// restores the picker.)
+	if msg.String() == "u" && !m.filtering && !m.colPicker && m.editState.phase == editPhaseDone {
 		switch m.pane {
 		case paneEvents, paneDetail:
 			if m.selectedSess != "" {
@@ -155,6 +163,15 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			// pane.
 			id := eventColumns[m.colCursor].id
 			m.eventColumns[id] = !m.eventColumns[id]
+			// Make that fallback visible in the checkboxes rather than only in the
+			// table. Without this, emptying the selection drew twelve `[ ]` boxes over
+			// a table showing twelve default columns — the one state the fallback
+			// exists to rescue was also the state where the picker misreported what is
+			// on screen, and the `(no room)` markers vanished too since they are gated
+			// on the selection.
+			if len(selectedColumns(m.eventColumns)) > 0 && !anyColumnSelected(m.eventColumns) {
+				m.eventColumns = defaultColumnSelection()
+			}
 			m.rebuildEventsTable()
 			return nil
 		case "r":

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -654,38 +654,45 @@ func (m *model) helpView() string {
 		// end, and the escapable/discoverable keys ahead of them, with the
 		// specialised ones first to be lost.
 		base := "[↑↓] nav  [b/f] page  [↵] detail  [c] columns  [u] usage  " +
-			skipHint + "  [p] pause  [/] filter  [esc] back  [?] keys  [q] quit"
-		// Surface the hidden-message count so a filtered timeline doesn't
-		// look like data loss. Only annotate when hiding is on AND at
-		// least one message was hidden.
+			skipHint + "  [p] pause  [/] filter  [esc] back"
+
+		// Notices go BEFORE the essential hints, not after.
+		//
+		// fitHintLine drops from the front, so anything appended past "[q] quit"
+		// outlives it — at width 40 the footer read "… · → 1 more column ([c] to
+		// choose)" with no way to quit or reach help. A notice is worth less than
+		// the keys that let a user act on it.
+		//
+		// Surface the hidden-message count so a filtered timeline doesn't look like
+		// data loss. Only when hiding is on AND at least one message was hidden.
 		if m.hideInactive && m.hiddenInactive > 0 {
-			base = fmt.Sprintf("%s  ·  %d hidden",
-				base, m.hiddenInactive)
+			base = fmt.Sprintf("%s  ·  %d hidden", base, m.hiddenInactive)
 		}
-		// Columns that did not fit. The whole reason issue #866 was filed: HOST
-		// was declared but never visible, and nothing said the table had been
-		// clipped. Says how many and how to reach them.
+		// Columns that did not fit — the whole reason issue #866 was filed: HOST was
+		// declared but never visible, and nothing said the table had been clipped.
 		if m.eventColsDropped > 0 {
 			base = fmt.Sprintf("%s  ·  → %d more column%s ([c] to choose)",
 				base, m.eventColsDropped, plural(m.eventColsDropped))
 		}
-		return base
+		return base + "  [?] keys  [q] quit"
 	case paneDetail:
 		return "[↑↓] scroll  [y] yank  [u] usage  [esc] back  [?] keys  [q] quit"
 	case panePipeline:
 		var base string
 		if m.parentCtx != nil {
-			base = "[↑↓] nav  [↵] plugin detail  [e] edit  [tab] sessions  [esc] pods  [?] keys  [q] quit"
+			base = "[↑↓] nav  [↵] plugin detail  [e] edit  [tab] sessions  [esc] pods"
 		} else {
-			base = "[↑↓] nav  [↵] plugin detail  [e] edit  [tab] sessions  [?] keys  [q] quit"
+			base = "[↑↓] nav  [↵] plugin detail  [e] edit  [tab] sessions"
 		}
-		// Surface a count of plugins with unmet dependencies so a single
-		// "✗" in the DEPS column doesn't get lost in a long list.
+		// Surface a count of plugins with unmet dependencies so a single "✗" in the
+		// DEPS column doesn't get lost in a long list. Before the essential hints,
+		// for the reason given in the paneEvents case: fitHintLine drops from the
+		// front, so a notice appended past "[q] quit" outlives it.
 		if n := m.unmetDepsCount(); n > 0 {
 			base = fmt.Sprintf("%s  ·  %d plugin%s with unmet deps",
 				base, n, plural(n))
 		}
-		return base
+		return base + "  [?] keys  [q] quit"
 	case panePluginDetail:
 		return "[↑↓] scroll  [esc] back  [?] keys  [q] quit"
 	case paneUsage:

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -131,15 +131,20 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 	// same reason the help overlay is.
 	if m.colPicker && !m.filtering {
 		switch msg.String() {
+		case "q", "ctrl+c":
+			// Quit stays live. A modal that traps the user until they find its exit
+			// is worse than one that closes on the key they already reach for, and
+			// `q` means quit everywhere else in abctl. Falls through to the global
+			// handler rather than being reimplemented here.
 		case "c", "esc", "enter":
 			m.colPicker = false
 			return nil
-		case "left", "h":
+		case "up", "k":
 			if m.colCursor > 0 {
 				m.colCursor--
 			}
 			return nil
-		case "right", "l":
+		case "down", "j":
 			if m.colCursor < len(eventColumns)-1 {
 				m.colCursor++
 			}
@@ -156,8 +161,11 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			m.eventColumns = defaultColumnSelection()
 			m.rebuildEventsTable()
 			return nil
+		default:
+			// Everything else is swallowed: the popup is modal, so a stray key must
+			// not move the table cursor underneath it.
+			return nil
 		}
-		return nil
 	}
 
 	// `c` opens the column picker from the events timeline. Suppressed while
@@ -638,12 +646,6 @@ func (m *model) helpView() string {
 		skipHint := "[s] hide passthru/skip"
 		if m.hideInactive {
 			skipHint = "[s] show all"
-		}
-		// While the picker is up it replaces the footer: it owns the keyboard, so
-		// advertising the timeline's keys would list bindings that do nothing.
-		if m.colPicker {
-			return columnPickerLine(m.eventColumns, m.colCursor) +
-				"   [←→] move  [space] toggle  [r] reset  [c/esc] done"
 		}
 		base := "[↑↓] nav  [b/f] page  [↵] detail  [u] usage  [c] columns  [esc] back  [/] filter  " + skipHint + "  [p] pause  [?] keys  [q] quit"
 		// Surface the hidden-message count so a filtered timeline doesn't

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -126,6 +126,49 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		}
 	}
 
+	// The column picker owns the keyboard while it is up, so ↑↓/space cannot also
+	// move the table cursor underneath it. Checked before pane dispatch for the
+	// same reason the help overlay is.
+	if m.colPicker && !m.filtering {
+		switch msg.String() {
+		case "c", "esc", "enter":
+			m.colPicker = false
+			return nil
+		case "left", "h":
+			if m.colCursor > 0 {
+				m.colCursor--
+			}
+			return nil
+		case "right", "l":
+			if m.colCursor < len(eventColumns)-1 {
+				m.colCursor++
+			}
+			return nil
+		case " ", "x":
+			// Toggle. selectedColumns falls back to the defaults when the set is
+			// empty, so turning everything off cannot leave an unrecoverable blank
+			// pane.
+			id := eventColumns[m.colCursor].id
+			m.eventColumns[id] = !m.eventColumns[id]
+			m.rebuildEventsTable()
+			return nil
+		case "r":
+			m.eventColumns = defaultColumnSelection()
+			m.rebuildEventsTable()
+			return nil
+		}
+		return nil
+	}
+
+	// `c` opens the column picker from the events timeline. Suppressed while
+	// filtering, where `c` is a character being typed — the same reasoning as `?`
+	// and `u`.
+	if msg.String() == "c" && m.pane == paneEvents && !m.filtering &&
+		m.editState.phase == editPhaseDone {
+		m.colPicker = true
+		return nil
+	}
+
 	// Picker panes handle their own keys before session-view logic.
 	if m.pane == paneNamespaces {
 		switch msg.String() {
@@ -596,13 +639,26 @@ func (m *model) helpView() string {
 		if m.hideInactive {
 			skipHint = "[s] show all"
 		}
-		base := "[↑↓] nav  [b/f] page  [↵] detail  [u] usage  [esc] back  [/] filter  " + skipHint + "  [p] pause  [?] keys  [q] quit"
+		// While the picker is up it replaces the footer: it owns the keyboard, so
+		// advertising the timeline's keys would list bindings that do nothing.
+		if m.colPicker {
+			return columnPickerLine(m.eventColumns, m.colCursor) +
+				"   [←→] move  [space] toggle  [r] reset  [c/esc] done"
+		}
+		base := "[↑↓] nav  [b/f] page  [↵] detail  [u] usage  [c] columns  [esc] back  [/] filter  " + skipHint + "  [p] pause  [?] keys  [q] quit"
 		// Surface the hidden-message count so a filtered timeline doesn't
 		// look like data loss. Only annotate when hiding is on AND at
 		// least one message was hidden.
 		if m.hideInactive && m.hiddenInactive > 0 {
 			base = fmt.Sprintf("%s  ·  %d hidden",
 				base, m.hiddenInactive)
+		}
+		// Columns that did not fit. The whole reason issue #866 was filed: HOST
+		// was declared but never visible, and nothing said the table had been
+		// clipped. Says how many and how to reach them.
+		if m.eventColsDropped > 0 {
+			base = fmt.Sprintf("%s  ·  → %d more column%s ([c] to choose)",
+				base, m.eventColsDropped, plural(m.eventColsDropped))
 		}
 		return base
 	case paneDetail:

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -137,7 +137,14 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 	// The column picker owns the keyboard while it is up, so ↑↓/space cannot also
 	// move the table cursor underneath it. Checked before pane dispatch for the
 	// same reason the help overlay is.
-	if m.colPicker && !m.filtering {
+	//
+	// Scoped to paneEvents, mirroring the condition that opens it: no KEY can change
+	// panes underneath the picker, but a MESSAGE still can — the sessionsMsg handler
+	// drops to paneSessions when the selected session disappears server-side, which
+	// left this block swallowing enter/j/k over an inert sessions table. Gating on
+	// the pane covers that and any future transition, where clearing the flag in one
+	// handler would only fix today's path.
+	if m.colPicker && m.pane == paneEvents && !m.filtering {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			// Quit stays live. A modal that traps the user until they find its exit
@@ -169,7 +176,7 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			// exists to rescue was also the state where the picker misreported what is
 			// on screen, and the `(no room)` markers vanished too since they are gated
 			// on the selection.
-			if len(selectedColumns(m.eventColumns)) > 0 && !anyColumnSelected(m.eventColumns) {
+			if !anyColumnSelected(m.eventColumns) {
 				m.eventColumns = defaultColumnSelection()
 			}
 			m.rebuildEventsTable()


### PR DESCRIPTION
Closes #866.

`c` on the events pane opens a popup with a checkbox and one-line description per column.

```
╭──────────────────────────────────────────────────────────────────────────╮
│COLUMNS                                                                   │
│  [x] #         exchange number; a request and its response share one     │
│▸ [x] DIR       in = toward your agent, out = toward an upstream (no room) │
│  [x] METHOD    protocol operation: model name, MCP or A2A method          │
│  [x] HOST      host the message was sent to                              │
│[↑↓] move  [space] toggle  [r] reset  [esc] close  [q] quit                │
╰──────────────────────────────────────────────────────────────────────────╯
```

All twelve columns together need ~168 terminal columns (144 of declared width plus two of bubbles cell padding each), so HOST was declared but never visible. Three things fix that:

- **Columns carry a keep rank**, so a narrow terminal drops DIR/DURATION/TOKENS/COST first and keeps `#` and HOST — the column most people open this pane for. HOST is now on by default and survives down to 80 columns.
- **The footer reports what did not fit** (`→ N more columns ([c] to choose)`), and a selected column that cannot fit is marked `(no room)` in the popup, so ticking it explains itself.
- **The footer itself now fits.** It ran 135 columns with nothing trimming it, so at 80 the tail was cut — losing `[?] keys` and `[q] quit`. Hints are ordered by what must survive and trimmed from the front, marked with a leading `…`. At 20 columns the line is still `… [?] keys  [q] quit`.

Header and cells now come from one definition, replacing a `[]table.Column` slice and a positional `table.Row` literal maintained in parallel.

**Note the second commit is a crash fix for the first.** `SetColumns` re-renders loaded rows and bubbles indexes `m.cols[i]` per row cell, so setting columns before rows panicked with `index out of range [10] with length 10` on the first toggle. None of the nine tests written with the feature caught it — they exercised the fitting functions as pure code and never drove a rebuild across a change in column count. The added tests assert the invariant that panics when violated, through the real key path.

24 tests. Worth driving on a real terminal before merge given the above.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Events pane column picker, opened with `c`, to show or hide columns, restore defaults, and navigate selections with the keyboard.
  * Added descriptions, default visibility, and fit priorities for available columns, with an indicator when selected columns do not fit the terminal.
  * Updated Events pane help and keybinding hints to document column customization.

* **Bug Fixes**
  * Improved table rendering and footer hints on narrow terminals while preserving essential information.
  * Ensured the picker closes appropriately when changing panes or when its session is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
