### PR TITLE
Feat: Add `abctl exec` to run one command through Cortex

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -113,13 +113,23 @@ these eight variables:
 | Variable | Value |
 |---|---|
 | `HTTP_PROXY` `HTTPS_PROXY` `http_proxy` `https_proxy` | the forward proxy URL |
-| `NODE_EXTRA_CA_CERTS` `CURL_CA_BUNDLE` `REQUESTS_CA_BUNDLE` `SSL_CERT_FILE` | the TLS-bridge CA file |
+| `NODE_EXTRA_CA_CERTS` | the bridge CA, *added* to the runtime's own roots |
+| `CURL_CA_BUNDLE` `REQUESTS_CA_BUNDLE` `SSL_CERT_FILE` | a temporary bundle: system roots + bridge CA |
 
-Four spellings of each because there is no agreed one: Go and most Unix
-tools read the lowercase pair, Node the uppercase, libcurl either; the CA
-name differs per runtime (Node, libcurl, Python `requests`, OpenSSL). A
-tool that reads only the spelling we left out would silently bypass the
-proxy — invisible, because it keeps working.
+Four proxy spellings because there is no agreed one: Go and most Unix
+tools read the lowercase pair, Node the uppercase, libcurl either. A tool
+that reads only the spelling we left out would silently bypass the proxy —
+invisible, because it keeps working.
+
+The CA names split two ways, and the difference matters. `NODE_EXTRA_CA_CERTS`
+*extends* Node's trust store, so it takes the bridge CA directly. The other
+three *replace* the trust store: whatever file they name becomes the complete
+set of roots. `ca.crt` is a single certificate, so naming it there would leave
+the child trusting one CA and nothing else — breaking every host the bridge
+does **not** terminate (`tls_bridge.passthrough_hosts`, `listener.skip_hosts`,
+ports outside `tls_bridge.ports`, non-TLS traffic). So those three get a
+concatenation of your system roots and the bridge CA, written to a temp file
+for the child's lifetime and removed afterwards.
 
 Both proxy variables get the **`http://`** URL, deliberately. The scheme
 in a `*_PROXY` variable says how to reach the *proxy*, not what the
@@ -141,11 +151,16 @@ abctl exec --print --              # eight shell-quoted export lines
 eval "$(abctl exec --print --)"    # or apply them to the current shell
 ```
 
-Requires the TLS bridge (`tls_bridge.ca_dir`). Without a CA to trust,
-every https request would either fail verification or — worse, in a
-lenient client — tunnel through unparsed, which looks exactly like
-success while Cortex sees nothing; `abctl exec` refuses rather than
-inject a proxy with no CA.
+Requires an enabled TLS bridge — both `tls_bridge.mode: enabled` and
+`tls_bridge.ca_dir`. `mode: disabled` with a `ca_dir` set is a valid config,
+but the bridge then terminates nothing, so a CA would buy the child nothing
+while breaking its https; `abctl exec` refuses rather than inject either half
+of a setup that cannot work.
+
+Before Cortex's first start, `ca.crt` does not exist yet. `exec` still runs the
+command and says so, but leaves the three replacing variables unset — the child
+keeps its own public roots and only bridged hosts fail, rather than losing all
+trust to a bundle with no bridge CA in it.
 
 ## Panes
 

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -107,8 +107,8 @@ abctl exec -- bob
 
 Everything after `--` is passed through exactly as typed. abctl never
 parses it, so the command's own flags need no escaping — even ones abctl
-also has, like `--config`. The child inherits your whole environment plus
-these eight variables:
+also has, like `--print`. The child inherits your whole environment plus
+these nine variables:
 
 | Variable | Value |
 |---|---|

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -176,6 +176,12 @@ meant to be kept, and are the same ones `abctl claude-code enable` writes into
 for its lifetime. Asking for both in one invocation is a contradiction about
 which you want, so abctl says so rather than picking one.
 
+`abctl claude-code enable` shares this requirement as of the same change: it too
+refuses `tls_bridge.mode: disabled` with a `ca_dir` set, a combination it used to
+accept and write into `settings.json`, where the CA bought nothing because the
+bridge terminated no TLS. `enable` also now points its four replacing variables at
+`bundle.crt` rather than the bare `ca.crt`.
+
 Requires an enabled TLS bridge — both `tls_bridge.mode: enabled` and
 `tls_bridge.ca_dir`. `mode: disabled` with a `ca_dir` set is a valid config,
 but the bridge then terminates nothing, so a CA would buy the child nothing
@@ -183,7 +189,7 @@ while breaking its https; `abctl exec` refuses rather than inject either half
 of a setup that cannot work.
 
 Before Cortex's first start, `ca.crt` does not exist yet. `exec` still runs the
-command and says so, but leaves the three replacing variables unset — the child
+command and says so, but leaves the four replacing variables unset — the child
 keeps its own public roots and only bridged hosts fail, rather than losing all
 trust to a bundle with no bridge CA in it.
 

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -113,8 +113,8 @@ these eight variables:
 | Variable | Value |
 |---|---|
 | `HTTP_PROXY` `HTTPS_PROXY` `http_proxy` `https_proxy` | the forward proxy URL |
-| `NODE_EXTRA_CA_CERTS` | the bridge CA, *added* to the runtime's own roots |
-| `CURL_CA_BUNDLE` `REQUESTS_CA_BUNDLE` `SSL_CERT_FILE` | a temporary bundle: system roots + bridge CA |
+| `NODE_EXTRA_CA_CERTS` | `ca.crt`, *added* to the runtime's own roots |
+| `CURL_CA_BUNDLE` `REQUESTS_CA_BUNDLE` `SSL_CERT_FILE` `GIT_SSL_CAINFO` | `bundle.crt` — the bridge CA plus the platform roots |
 
 Four proxy spellings because there is no agreed one: Go and most Unix
 tools read the lowercase pair, Node the uppercase, libcurl either. A tool
@@ -122,16 +122,14 @@ that reads only the spelling we left out would silently bypass the proxy —
 invisible, because it keeps working.
 
 The CA names split two ways, and the difference matters. `NODE_EXTRA_CA_CERTS`
-*extends* Node's trust store, so it takes the bridge CA directly. The other
-three *replace* the trust store: whatever file they name becomes the complete
-set of roots. `ca.crt` is a single certificate, so naming it there would leave
-the child trusting one CA and nothing else — breaking every host the bridge
-does **not** terminate (`tls_bridge.passthrough_hosts`, `listener.skip_hosts`,
-ports outside `tls_bridge.ports`, non-TLS traffic). So those three get a
-concatenation of your system roots and the bridge CA. For a child process that
-bundle is a temp file removed when the child exits; for `--print` it is written
-beside the CA as `trust-bundle.pem`, because the path it exports has to outlive
-the abctl process that printed it.
+*extends* Node's trust store, so it takes `ca.crt` directly. The other four
+*replace* it: whatever file they name becomes the complete set of roots, so
+pointing them at `ca.crt` would leave the child trusting the bridge and nothing
+else — breaking every host the bridge does not terminate. They get `bundle.crt`
+instead, which Cortex writes beside `ca.crt` on startup (bridge CA + platform
+roots). These are the same values `abctl claude-code enable` writes into
+`settings.json`; `exec` reuses that derivation rather than repeating it, so the
+two commands cannot disagree.
 
 Both proxy variables get the **`http://`** URL, deliberately. The scheme
 in a `*_PROXY` variable says how to reach the *proxy*, not what the
@@ -157,10 +155,9 @@ abctl exec --print --              # eight shell-quoted export lines
 eval "$(abctl exec --print --)"    # or apply them to the current shell
 ```
 
-`--print` writes `trust-bundle.pem` next to your `ca.crt` and points the three
-replacing variables at it, rewriting it each time so a rotated CA is picked up.
-That is what makes the `eval` form usable: the exported paths still resolve after
-abctl has exited.
+`--print` emits paths only — it writes nothing. `bundle.crt` and `ca.crt` are
+created by Cortex itself on first start, so the exported paths keep resolving
+long after abctl exits, which is what makes the `eval` form usable.
 
 `--print` and a command are mutually exclusive — `abctl exec --print -- curl …`
 is a usage error, not a command that runs. The paths `--print` hands out are

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -137,8 +137,16 @@ proxied request is; Cortex's forward proxy speaks plain HTTP and
 CONNECT-tunnels TLS, so `https://` there would make clients attempt TLS
 to the proxy itself and fail the handshake.
 
-The values come from `~/.cortex/config.yaml` — the same derivation
-`claude-code enable` uses, so the two cannot drift apart. Nothing is
+The values come from the **running proxy**, fetched from its stats endpoint
+(`http://localhost:47602/config` by default, `--cortex-stats-url` to point
+elsewhere). There is no `--config` flag: `exec` works against a proxy that has to
+be up for the child to reach anything, and that process already has a config —
+reading a file instead would let the two disagree, since listener addresses are
+not hot-reloaded and a file says nothing about whether anything is listening. A
+Cortex that is down is reported as down rather than yielding an environment that
+points at nothing. The derivation from config to variables is still the one
+`claude-code enable` uses, so the two produce identical values for the same
+Cortex. Nothing is
 exported to your shell and no file is modified.
 
 abctl exits with the child's status (127 if the command was not found,
@@ -151,16 +159,18 @@ orphaned with the injected environment.
 To see the variables without running anything:
 
 ```sh
-abctl exec --print --              # eight shell-quoted export lines
-eval "$(abctl exec --print --)"    # or apply them to the current shell
+abctl exec --print                 # nine shell-quoted export lines
+eval "$(abctl exec --print)"       # or apply them to the current shell
 ```
 
 `--print` emits paths only — it writes nothing. `bundle.crt` and `ca.crt` are
 created by Cortex itself on first start, so the exported paths keep resolving
 long after abctl exits, which is what makes the `eval` form usable.
 
-`--print` and a command are mutually exclusive — `abctl exec --print -- curl …`
-is a usage error, not a command that runs. The paths `--print` hands out are
+`--print` takes no command, and no `--`: it is a complete request on its own.
+Both `abctl exec --print -- curl …` and a bare `abctl exec --print --` are usage
+errors — the first asks for two different things at once, the second promises a
+command and supplies none. The paths `--print` hands out are
 meant to be kept, and are the same ones `abctl claude-code enable` writes into
 `settings.json`; running a command is the opposite, applying them to one process
 for its lifetime. Asking for both in one invocation is a contradiction about

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -128,8 +128,10 @@ set of roots. `ca.crt` is a single certificate, so naming it there would leave
 the child trusting one CA and nothing else — breaking every host the bridge
 does **not** terminate (`tls_bridge.passthrough_hosts`, `listener.skip_hosts`,
 ports outside `tls_bridge.ports`, non-TLS traffic). So those three get a
-concatenation of your system roots and the bridge CA, written to a temp file
-for the child's lifetime and removed afterwards.
+concatenation of your system roots and the bridge CA. For a child process that
+bundle is a temp file removed when the child exits; for `--print` it is written
+beside the CA as `trust-bundle.pem`, because the path it exports has to outlive
+the abctl process that printed it.
 
 Both proxy variables get the **`http://`** URL, deliberately. The scheme
 in a `*_PROXY` variable says how to reach the *proxy*, not what the
@@ -154,6 +156,11 @@ To see the variables without running anything:
 abctl exec --print --              # eight shell-quoted export lines
 eval "$(abctl exec --print --)"    # or apply them to the current shell
 ```
+
+`--print` writes `trust-bundle.pem` next to your `ca.crt` and points the three
+replacing variables at it, rewriting it each time so a rotated CA is picked up.
+That is what makes the `eval` form usable: the exported paths still resolve after
+abctl has exited.
 
 Requires an enabled TLS bridge — both `tls_bridge.mode: enabled` and
 `tls_bridge.ca_dir`. `mode: disabled` with a `ca_dir` set is a valid config,

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -87,6 +87,66 @@ kubectl port-forward -n team1 pod/weather-agent-xxxx 9094:9094 &
 This preserves the pre-picker behavior for scripts, CI, or remote
 session APIs that aren't in your kube context.
 
+## Running one command through Cortex (`abctl exec`)
+
+`abctl claude-code enable` works because Claude Code has a settings file:
+the variables can be written once and reach every session on the machine,
+background agents included. Nothing else has that. `curl`, `python`,
+`node`, `gh` and your test suite read the process environment and nothing
+else, and the usual workaround — exporting `HTTPS_PROXY` in your shell —
+leaks into every unrelated command in that terminal until you remember to
+unset it.
+
+`abctl exec` scopes the routing to a single child process:
+
+```sh
+abctl exec -- curl -sv https://api.anthropic.com/v1/messages
+abctl exec -- claude --dangerously-skip-permissions
+abctl exec -- bob
+```
+
+Everything after `--` is passed through exactly as typed. abctl never
+parses it, so the command's own flags need no escaping — even ones abctl
+also has, like `--config`. The child inherits your whole environment plus
+these eight variables:
+
+| Variable | Value |
+|---|---|
+| `HTTP_PROXY` `HTTPS_PROXY` `http_proxy` `https_proxy` | the forward proxy URL |
+| `NODE_EXTRA_CA_CERTS` `CURL_CA_BUNDLE` `REQUESTS_CA_BUNDLE` `SSL_CERT_FILE` | the TLS-bridge CA file |
+
+Four spellings of each because there is no agreed one: Go and most Unix
+tools read the lowercase pair, Node the uppercase, libcurl either; the CA
+name differs per runtime (Node, libcurl, Python `requests`, OpenSSL). A
+tool that reads only the spelling we left out would silently bypass the
+proxy — invisible, because it keeps working.
+
+Both proxy variables get the **`http://`** URL, deliberately. The scheme
+in a `*_PROXY` variable says how to reach the *proxy*, not what the
+proxied request is; Cortex's forward proxy speaks plain HTTP and
+CONNECT-tunnels TLS, so `https://` there would make clients attempt TLS
+to the proxy itself and fail the handshake.
+
+The values come from `~/.cortex/config.yaml` — the same derivation
+`claude-code enable` uses, so the two cannot drift apart. Nothing is
+exported to your shell and no file is modified. Signals reach the child
+through the shared process group, and abctl exits with the child's
+status (127 if the command was not found, 128+signum if it was killed),
+so it is safe in a pipeline or a Makefile.
+
+To see the variables without running anything:
+
+```sh
+abctl exec --print --              # eight shell-quoted export lines
+eval "$(abctl exec --print --)"    # or apply them to the current shell
+```
+
+Requires the TLS bridge (`tls_bridge.ca_dir`). Without a CA to trust,
+every https request would either fail verification or — worse, in a
+lenient client — tunnel through unparsed, which looks exactly like
+success while Cortex sees nothing; `abctl exec` refuses rather than
+inject a proxy with no CA.
+
 ## Panes
 
 The UI has these top-level panes. `Enter` drills in; `Esc` backs out.

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -162,6 +162,13 @@ replacing variables at it, rewriting it each time so a rotated CA is picked up.
 That is what makes the `eval` form usable: the exported paths still resolve after
 abctl has exited.
 
+`--print` and a command are mutually exclusive — `abctl exec --print -- curl …`
+is a usage error, not a command that runs. The paths `--print` hands out are
+meant to be kept, and are the same ones `abctl claude-code enable` writes into
+`settings.json`; running a command is the opposite, applying them to one process
+for its lifetime. Asking for both in one invocation is a contradiction about
+which you want, so abctl says so rather than picking one.
+
 Requires an enabled TLS bridge — both `tls_bridge.mode: enabled` and
 `tls_bridge.ca_dir`. `mode: disabled` with a `ca_dir` set is a valid config,
 but the bridge then terminates nothing, so a CA would buy the child nothing

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -139,10 +139,14 @@ to the proxy itself and fail the handshake.
 
 The values come from `~/.cortex/config.yaml` — the same derivation
 `claude-code enable` uses, so the two cannot drift apart. Nothing is
-exported to your shell and no file is modified. Signals reach the child
-through the shared process group, and abctl exits with the child's
-status (127 if the command was not found, 128+signum if it was killed),
-so it is safe in a pipeline or a Makefile.
+exported to your shell and no file is modified.
+
+abctl exits with the child's status (127 if the command was not found,
+128+signum if it was killed), so it is safe in a pipeline or a Makefile.
+Keyboard signals (Ctrl-C) reach the child directly through the shared
+process group; a signal aimed at abctl itself — `timeout 30 abctl exec
+-- …`, a CI runner, systemd — is relayed to the child, so it is not left
+orphaned with the injected environment.
 
 To see the variables without running anything:
 

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -326,7 +326,7 @@ func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, 
 		// Everything else gets the bundle, never ca.crt — see bundleKeys.
 		bundle, berr := filepath.Abs(filepath.Join(cfg.TLSBridge.CADir, tlsbridge.TrustBundleName))
 		if berr != nil {
-			return nil, berr
+			return nil, nil, berr
 		}
 		for _, k := range bundleKeys {
 			out[k] = bundle

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -289,7 +289,7 @@ func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading %s: %w", cortexCfgPath, err)
 	}
-	out, err := wantedFromLoaded(cfg)
+	out, err := wantedFromLoaded(cfg, cortexCfgPath)
 	return out, cfg, err
 }
 
@@ -299,10 +299,15 @@ func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, 
 // proxy while `claude-code enable` feeds it one read from disk. One derivation, two
 // sources: the values the two commands produce for the same Cortex cannot drift,
 // which is the property both rely on.
-func wantedFromLoaded(cfg *config.Config) (map[string]string, error) {
+// source names where cfg came from — a file path from wantedFromConfig, a stats
+// URL from execEnv — so a refusal points at the thing the reader can go and change.
+// errBridgeDisabled already took this parameter for exactly that reason; this
+// applies the same reasoning to the forward_proxy_addr refusal, which had lost the
+// path when the derivation became shared.
+func wantedFromLoaded(cfg *config.Config, source string) (map[string]string, error) {
 	addr := cfg.Listener.ForwardProxyAddr
 	if addr == "" {
-		return nil, fmt.Errorf("the Cortex config has no listener.forward_proxy_addr; there is no forward proxy to point at")
+		return nil, fmt.Errorf("%s has no listener.forward_proxy_addr; there is no forward proxy to point at", source)
 	}
 	// A bind address is not a URL: ":8081" and "127.0.0.1:47600" both need a host
 	// a client can actually dial.

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -251,13 +251,44 @@ func runClaudeCode(args []string, stdout, stderr io.Writer) int {
 // from the proxy that is actually running. Hardcoding 47600 here would silently
 // point Claude Code at nothing the moment someone edited their config.
 func wanted(cortexCfgPath string) (map[string]string, error) {
+	out, _, err := wantedFromConfig(cortexCfgPath)
+	return out, err
+}
+
+// bridgeEnabled reports whether cfg has an enabled TLS bridge.
+//
+// Empty Mode means disabled, per TLSBridgeConfig.Mode's own documentation, and a
+// nil TLSBridge means the block is absent entirely.
+func bridgeEnabled(cfg *config.Config) bool {
+	return cfg != nil && cfg.TLSBridge != nil && cfg.TLSBridge.Mode == "enabled"
+}
+
+// errBridgeDisabled is the shared refusal for a config whose bridge is off.
+//
+// Shared, because `abctl exec` and `abctl claude-code enable` must agree about the
+// bridge posture as well as the addresses. ca_dir is only *required* when
+// mode is "enabled" (config.Validate), so `mode: disabled` with a ca_dir set is
+// valid config that both commands used to accept — writing a CA for a bridge that
+// terminates nothing, so every https request fails verification against the real
+// upstream certificate. exec grew the check first; hoisting it here is what makes
+// "the two cannot drift" true of the posture too, not only the proxy and CA paths.
+func errBridgeDisabled(cortexCfgPath string) error {
+	return fmt.Errorf("%s has no enabled TLS bridge (tls_bridge.mode must be \"enabled\");\n"+
+		"  without it Cortex terminates no TLS, so there is nothing for a client to\n"+
+		"  trust and every https request would fail verification. Enable the TLS bridge first",
+		cortexCfgPath)
+}
+
+// wantedFromConfig is wanted plus the loaded config, so a caller needing more than
+// the three values does not parse the file twice.
+func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, error) {
 	cfg, err := config.Load(cortexCfgPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %w", cortexCfgPath, err)
+		return nil, nil, fmt.Errorf("reading %s: %w", cortexCfgPath, err)
 	}
 	addr := cfg.Listener.ForwardProxyAddr
 	if addr == "" {
-		return nil, fmt.Errorf("%s has no listener.forward_proxy_addr; Claude Code needs a forward proxy to point at", cortexCfgPath)
+		return nil, nil, fmt.Errorf("%s has no listener.forward_proxy_addr; Claude Code needs a forward proxy to point at", cortexCfgPath)
 	}
 	// A bind address is not a URL: ":8081" and "127.0.0.1:47600" both need a host
 	// a client can actually dial.
@@ -270,7 +301,7 @@ func wanted(cortexCfgPath string) (map[string]string, error) {
 	// errors on genuinely bad input.
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return nil, fmt.Errorf("listener.forward_proxy_addr %q is not host:port: %w", addr, err)
+		return nil, nil, fmt.Errorf("listener.forward_proxy_addr %q is not host:port: %w", addr, err)
 	}
 	if host == "" || host == "0.0.0.0" || host == "::" {
 		host = "localhost"
@@ -289,7 +320,7 @@ func wanted(cortexCfgPath string) (map[string]string, error) {
 	if cfg.TLSBridge != nil && cfg.TLSBridge.CADir != "" {
 		ca, aerr := filepath.Abs(filepath.Join(cfg.TLSBridge.CADir, "ca.crt"))
 		if aerr != nil {
-			return nil, aerr
+			return nil, nil, aerr
 		}
 		out[envCACerts] = ca
 		// Everything else gets the bundle, never ca.crt — see bundleKeys.
@@ -301,13 +332,20 @@ func wanted(cortexCfgPath string) (map[string]string, error) {
 			out[k] = bundle
 		}
 	}
-	return out, nil
+	return out, cfg, nil
 }
 
 func claudeCodeEnable2(settingsPath, cortexCfgPath, statePath string, yes bool, stdout, stderr io.Writer) int {
-	want, err := wanted(cortexCfgPath)
+	want, cfg, err := wantedFromConfig(cortexCfgPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		return 1
+	}
+	// Same bridge-posture gate `abctl exec` applies. Without it, `mode: disabled`
+	// with a ca_dir set was written into settings.json and produced exactly the
+	// silent break the ca_dir check below exists to prevent.
+	if !bridgeEnabled(cfg) {
+		fmt.Fprintf(stderr, "abctl: %v\n", errBridgeDisabled(cortexCfgPath))
 		return 1
 	}
 	if _, ok := want[envCACerts]; !ok {

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -272,11 +272,14 @@ func bridgeEnabled(cfg *config.Config) bool {
 // terminates nothing, so every https request fails verification against the real
 // upstream certificate. exec grew the check first; hoisting it here is what makes
 // "the two cannot drift" true of the posture too, not only the proxy and CA paths.
-func errBridgeDisabled(cortexCfgPath string) error {
+// source names where the config came from — a file path for `claude-code enable`,
+// a stats URL for `abctl exec` — so the message points at the thing the reader can
+// actually go and change.
+func errBridgeDisabled(source string) error {
 	return fmt.Errorf("%s has no enabled TLS bridge (tls_bridge.mode must be \"enabled\");\n"+
 		"  without it Cortex terminates no TLS, so there is nothing for a client to\n"+
 		"  trust and every https request would fail verification. Enable the TLS bridge first",
-		cortexCfgPath)
+		source)
 }
 
 // wantedFromConfig is wanted plus the loaded config, so a caller needing more than
@@ -286,9 +289,20 @@ func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading %s: %w", cortexCfgPath, err)
 	}
+	out, err := wantedFromLoaded(cfg)
+	return out, cfg, err
+}
+
+// wantedFromLoaded is the derivation itself, over a config that is already in hand.
+//
+// Split out so `abctl exec` can feed it the config it fetched from the RUNNING
+// proxy while `claude-code enable` feeds it one read from disk. One derivation, two
+// sources: the values the two commands produce for the same Cortex cannot drift,
+// which is the property both rely on.
+func wantedFromLoaded(cfg *config.Config) (map[string]string, error) {
 	addr := cfg.Listener.ForwardProxyAddr
 	if addr == "" {
-		return nil, nil, fmt.Errorf("%s has no listener.forward_proxy_addr; Claude Code needs a forward proxy to point at", cortexCfgPath)
+		return nil, fmt.Errorf("the Cortex config has no listener.forward_proxy_addr; there is no forward proxy to point at")
 	}
 	// A bind address is not a URL: ":8081" and "127.0.0.1:47600" both need a host
 	// a client can actually dial.
@@ -301,7 +315,7 @@ func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, 
 	// errors on genuinely bad input.
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("listener.forward_proxy_addr %q is not host:port: %w", addr, err)
+		return nil, fmt.Errorf("listener.forward_proxy_addr %q is not host:port: %w", addr, err)
 	}
 	if host == "" || host == "0.0.0.0" || host == "::" {
 		host = "localhost"
@@ -320,19 +334,19 @@ func wantedFromConfig(cortexCfgPath string) (map[string]string, *config.Config, 
 	if cfg.TLSBridge != nil && cfg.TLSBridge.CADir != "" {
 		ca, aerr := filepath.Abs(filepath.Join(cfg.TLSBridge.CADir, "ca.crt"))
 		if aerr != nil {
-			return nil, nil, aerr
+			return nil, aerr
 		}
 		out[envCACerts] = ca
 		// Everything else gets the bundle, never ca.crt — see bundleKeys.
 		bundle, berr := filepath.Abs(filepath.Join(cfg.TLSBridge.CADir, tlsbridge.TrustBundleName))
 		if berr != nil {
-			return nil, nil, berr
+			return nil, berr
 		}
 		for _, k := range bundleKeys {
 			out[k] = bundle
 		}
 	}
-	return out, cfg, nil
+	return out, nil
 }
 
 func claudeCodeEnable2(settingsPath, cortexCfgPath, statePath string, yes bool, stdout, stderr io.Writer) int {

--- a/authbridge/cmd/abctl/cmd_claudecode.go
+++ b/authbridge/cmd/abctl/cmd_claudecode.go
@@ -281,7 +281,12 @@ func wanted(cortexCfgPath string) (map[string]string, error) {
 		envProxy:   "http://" + net.JoinHostPort(host, port),
 		envNoTelem: "1",
 	}
-	if cfg.TLSBridge.CADir != "" {
+	// Nil-checked: tls_bridge is an omitempty pointer, so a config without the
+	// block at all leaves it nil and dereferencing it segfaulted — `abctl
+	// claude-code enable` crashed with a stack trace on a perfectly valid config
+	// whose only fault was having no TLS bridge, which is exactly the case the
+	// caller below is written to report cleanly.
+	if cfg.TLSBridge != nil && cfg.TLSBridge.CADir != "" {
 		ca, aerr := filepath.Abs(filepath.Join(cfg.TLSBridge.CADir, "ca.crt"))
 		if aerr != nil {
 			return nil, aerr

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -42,34 +41,11 @@ import (
 // the proxy itself and fail the handshake.
 var execProxyVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"}
 
-// execCAExtraVars are the ADDITIVE trust variables: the runtime keeps its own
-// root store and adds this file to it. Node is the only one of the four that
-// works this way.
-var execCAExtraVars = []string{"NODE_EXTRA_CA_CERTS"}
-
-// execCAReplaceVars REPLACE the trust store: whatever file they name becomes the
-// complete set of roots. CURL_CA_BUNDLE is libcurl, REQUESTS_CA_BUNDLE is Python
-// requests, SSL_CERT_FILE is OpenSSL and most things built on it.
-//
-// This distinction is the whole reason execEnv writes a bundle instead of
-// pointing everything at ca.crt. ca.crt is a single certificate — the bridge CA
-// alone (tlsbridge/ca.go writes certPEM to it, not a chain) — so naming it here
-// would leave the child trusting exactly one CA and nothing else. Every request
-// the bridge does NOT terminate then fails verification against the real
-// upstream certificate: tls_bridge.passthrough_hosts, listener.skip_hosts, any
-// port outside tls_bridge.ports (default 443 + 8443), and the runtime
-// passthrough decisions in tlsbridge/decision.go (non-TLS bytes, skip list).
-// Verified rather than assumed: on a Linux/OpenSSL curl, CURL_CA_BUNDLE pointed
-// at a lone CA fails `curl https://example.com` with exit 77.
-//
-// So these get a concatenation of the system roots and the bridge CA, written to
-// a temp file for the child's lifetime. Bridged hosts verify against the bridge
-// CA; everything excluded from bridging still verifies against the public roots
-// it would have used anyway.
-var execCAReplaceVars = []string{"CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"}
-
-// execCAVars is every CA name, in the order --print emits them.
-var execCAVars = append(append([]string{}, execCAExtraVars...), execCAReplaceVars...)
+// The CA variable names are NOT redeclared here. authlib owns that split:
+// envCACerts is the one additive name (Node) and bundleKeys are the four that
+// replace the trust store, both defined next to the trust bundle they describe.
+// A local copy went stale the moment GIT_SSL_CAINFO joined the managed set —
+// --print silently stopped emitting it — so exec reads the managed set instead.
 
 // systemRootFiles are the usual system CA bundle locations, in the order
 // crypto/x509 itself consults them (root_linux.go's certFiles, plus the common
@@ -202,51 +178,32 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 		*cortexCfg = filepath.Join(home, cortexCfgRel)
 	}
 
-	inject, cleanup, err := execEnv(*cortexCfg, *printOnly)
-	// Registered before the error branches below, so "cleanup always runs" is
-	// enforced in one place. Nothing leaks today — writeTrustBundle removes its own
-	// file on every error path — but that invariant was being held in two places,
-	// and the next error return added there would have broken it silently.
-	if cleanup != nil {
-		defer cleanup()
-	}
-	// errNoSystemRoots comes back WITH a usable bundle: the bridge CA is in it, so
-	// bridged hosts verify fine; only public trust is absent, and on an image with
-	// no root store there was none to begin with. Reported, not fatal.
-	if errors.Is(err, errNoSystemRoots) {
-		fmt.Fprintf(stderr, "abctl: note: no system CA bundle found on this machine, so the child\n"+
-			"  trusts only Cortex's bridge CA. Hosts the bridge does not terminate\n"+
-			"  (tls_bridge.passthrough_hosts, listener.skip_hosts, ports outside\n"+
-			"  tls_bridge.ports) will fail certificate verification.\n")
-		err = nil
-	}
+	inject, err := execEnv(*cortexCfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
 	}
-	// A CA path that does not exist yet is a warning, not an error: enabling
-	// before the first start is legitimate and the proxy writes it on boot. But
-	// unlike the settings path, here the failure is loud rather than silent —
-	// Node and curl both refuse to start with a CA file they cannot read — so it
-	// is worth naming the cause before the child dies of it.
-	//
-	// Checked on the additive name, which is the bridge CA itself; the replacing
-	// vars name the generated bundle, which by construction exists. Named
-	// explicitly rather than by list position, so this warning does not depend on
-	// the declaration order of a slice it does not own.
-	if ca := inject[envCACerts]; ca != "" {
-		if _, serr := os.Stat(ca); serr != nil {
+
+	// Neither ca.crt nor bundle.crt is written by exec any more: the proxy writes
+	// both on boot (authbridge-proxy calls tlsbridge.EnsureTrustBundle). Running
+	// before that first start is legitimate, so this is a warning rather than an
+	// error — but it is worth naming, because the failure it causes is loud and
+	// otherwise unexplained: git, curl and Python all refuse outright when the CA
+	// file they were pointed at cannot be read.
+	for _, k := range []string{envCACerts, envSSLCert} {
+		p := inject[k]
+		if p == "" {
+			continue
+		}
+		if _, serr := os.Stat(p); serr != nil {
 			fmt.Fprintf(stderr, "abctl: note: %s does not exist yet — Cortex writes it on first start.\n"+
-				"  TLS verification against the bridge will fail until then (abctl service start).\n", ca)
+				"  TLS through the bridge will fail until then (abctl service start).\n", p)
+			break
 		}
 	}
 
 	if *printOnly {
 		printExecEnv(inject, stdout)
-		if b := inject[execCAReplaceVars[0]]; b != "" {
-			fmt.Fprintf(stderr, "abctl: wrote the trust bundle to %s (system roots + Cortex's bridge CA).\n"+
-				"  It is rewritten on each --print, so a rotated CA is picked up.\n", b)
-		}
 		return 0
 	}
 	if len(cmdArgs) == 0 {
@@ -357,172 +314,59 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 	return 0
 }
 
-// execEnv builds the variables to inject, fanning the two values wanted()
-// derives out over the eight names tools actually read.
-//
-// Reusing wanted() rather than re-reading the config is the point: exec and
-// `claude-code enable` must agree about the proxy address and the CA, and the
-// only way to guarantee that is one derivation. The telemetry key wanted() also
-// returns is dropped here — it is a Claude Code setting, and exec's child is
-// usually not Claude Code.
-// persist selects where the trust bundle goes: a stable path beside the CA (for
-// --print, whose output must outlive this process) or a temp file removed by
-// cleanup (for a child, which reads it while running).
-func execEnv(cortexCfgPath string, persist bool) (env map[string]string, cleanup func(), err error) {
+// execEnv builds the variables to inject for one child.
+func execEnv(cortexCfgPath string) (env map[string]string, err error) {
+	// wanted() is the whole derivation, bundle paths included: since the trust
+	// bundle moved into authlib/tlsbridge, `claude-code enable` already points
+	// SSL_CERT_FILE / GIT_SSL_CAINFO / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE at
+	// bundle.crt and NODE_EXTRA_CA_CERTS at ca.crt. exec reuses that verbatim
+	// rather than deriving it again — the two commands cannot drift if only one of
+	// them decides.
+	//
+	// What exec adds is the lowercase proxy spellings, which Claude Code does not
+	// need (it reads HTTPS_PROXY from its settings file) but Go's
+	// http.ProxyFromEnvironment and most Unix tools do.
 	want, cfg, err := wantedFromConfig(cortexCfgPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	proxy := want[envProxy]
 	if proxy == "" {
-		return nil, nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
+		return nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
 	}
 
 	// The bridge posture, not just the CA path. Shared with `claude-code enable`
 	// via bridgeEnabled/errBridgeDisabled so the two commands cannot disagree about
 	// it — see errBridgeDisabled for why a disabled bridge has to be refused.
 	if !bridgeEnabled(cfg) {
-		return nil, nil, errBridgeDisabled(cortexCfgPath)
+		return nil, errBridgeDisabled(cortexCfgPath)
 	}
-
-	ca, ok := want[envCACerts]
-	if !ok || ca == "" {
+	if want[envCACerts] == "" {
 		// Refused rather than injecting the proxy alone. Without a trusted CA the
 		// bridge cannot terminate TLS, so every https request either fails
 		// verification or — worse, if the tool is lenient — tunnels through
 		// unparsed, which looks exactly like success while Cortex sees nothing.
-		return nil, nil, fmt.Errorf("%s has no tls_bridge.ca_dir, so the child would have no CA to trust;\n"+
+		return nil, fmt.Errorf("%s has no tls_bridge.ca_dir, so the child would have no CA to trust;\n"+
 			"  https requests through the bridge would fail verification. Enable the TLS bridge first", cortexCfgPath)
 	}
 
-	out := make(map[string]string, len(execProxyVars)+len(execCAVars))
+	out := make(map[string]string, len(want)+len(execProxyVars))
+	// Every managed key except the Claude-Code-only telemetry switch: that is a
+	// setting for one application, and exec's child is usually not that application.
+	for _, k := range managedKeys {
+		if k == envNoTelem {
+			continue
+		}
+		if v := want[k]; v != "" {
+			out[k] = v
+		}
+	}
+	// The lowercase proxy spellings, plus HTTP_PROXY alongside wanted()'s HTTPS_PROXY.
 	for _, k := range execProxyVars {
 		out[k] = proxy
 	}
-	// Additive names take the bridge CA directly — the runtime keeps its own roots.
-	for _, k := range execCAExtraVars {
-		out[k] = ca
-	}
-	// Replacing names take a bundle, so excluded hosts keep public trust.
-	bundle, cleanup, berr := writeTrustBundle(ca, persist)
-	switch {
-	case errors.Is(berr, errNoBridgeCA):
-		// The CA is not on disk yet — Cortex writes it on first start, and enabling
-		// before then is legitimate (the caller warns about it). Leave the replacing
-		// vars UNSET rather than name a bundle without the bridge CA in it: unset
-		// means the child keeps its own public roots and only bridged hosts fail,
-		// which is the same state `claude-code enable` has always produced. Naming a
-		// bridge-CA-less bundle would instead break every host, bridged or not.
-		return out, cleanup, nil
-	case berr != nil && !errors.Is(berr, errNoSystemRoots):
-		return nil, cleanup, berr
-	}
-	for _, k := range execCAReplaceVars {
-		out[k] = bundle
-	}
-	// errNoSystemRoots is returned with a usable bundle; propagate it so the caller
-	// can report the missing public trust without treating it as a failure.
-	return out, cleanup, berr
+	return out, nil
 }
-
-// writeTrustBundle concatenates the system roots with the bridge CA and returns
-// the path to the result, plus a cleanup to remove it.
-//
-// Ordering is system-roots-then-bridge-CA, but only for readability: PEM trust
-// files are an unordered set, and every consumer parses all of them.
-//
-// A missing system store is not fatal. A distroless or scratch-based image may
-// genuinely have no root bundle, in which case the bridge CA alone is the whole
-// trust set — which is exactly right there, since such an image had no public
-// trust to lose. It is reported so the difference is not silent.
-// When persist is true the bundle is written to a STABLE path beside the CA
-// (ca_dir/trust-bundle.pem) and no cleanup is returned, because the caller is
-// --print: the exported path has to outlive this process for
-// `eval "$(abctl exec --print --)"` to mean anything. A temp file per eval would
-// also leak with no owner, so a single rewritten file beside the CA it is derived
-// from is both durable and self-limiting.
-func writeTrustBundle(caPath string, persist bool) (path string, cleanup func(), err error) {
-	caPEM, err := os.ReadFile(caPath) //nolint:gosec // path derived from the operator's own config
-	if err != nil {
-		// Signalled, not fatal: the CA is written by Cortex on first start and exec
-		// deliberately works before that. The caller decides what to do — it leaves
-		// the replacing vars unset, because a bundle without the bridge CA is worse
-		// than no bundle at all.
-		return "", func() {}, fmt.Errorf("%w: %s: %v", errNoBridgeCA, caPath, err)
-	}
-
-	var buf []byte
-	for _, f := range systemRootFiles {
-		// Stat first: some of these paths are a DIRECTORY on some distros
-		// (/etc/ssl/certs is a hashed cert dir on Alpine), and ReadFile on a
-		// directory fails on Linux but succeeds with garbage on some systems.
-		if fi, serr := os.Stat(f); serr != nil || fi.IsDir() {
-			continue
-		}
-		b, rerr := os.ReadFile(f) //nolint:gosec // fixed list of well-known system paths
-		if rerr == nil && len(b) > 0 {
-			buf = append(buf, b...)
-			if !bytes.HasSuffix(buf, []byte("\n")) {
-				buf = append(buf, '\n')
-			}
-			break
-		}
-	}
-	systemFound := len(buf) > 0
-	buf = append(buf, caPEM...)
-
-	if persist {
-		// Beside the CA, not in the temp dir: --print's output must still resolve
-		// after this process exits. Rewritten in place each run so a rotated CA is
-		// picked up, and atomically so a concurrent reader never sees a half-written
-		// trust store.
-		name := filepath.Join(filepath.Dir(caPath), "trust-bundle.pem")
-		tmp := name + ".tmp"
-		// 0644, matching ca.crt: a trust store is public material, and a file only
-		// the writing user can read would break a child running as anyone else.
-		if werr := os.WriteFile(tmp, buf, 0o644); werr != nil { //nolint:gosec // trust anchors are not secret
-			return "", func() {}, werr
-		}
-		if rerr := os.Rename(tmp, name); rerr != nil {
-			_ = os.Remove(tmp)
-			return "", func() {}, rerr
-		}
-		if !systemFound {
-			return name, func() {}, errNoSystemRoots
-		}
-		return name, func() {}, nil
-	}
-
-	// 0600 in the process's temp dir: this is a trust store, and a world-writable
-	// one would let any local user add a root the child then trusts.
-	f, err := os.CreateTemp("", "abctl-trust-*.pem")
-	if err != nil {
-		return "", func() {}, err
-	}
-	name := f.Name()
-	rm := func() { _ = os.Remove(name) }
-	if _, werr := f.Write(buf); werr != nil {
-		f.Close()
-		rm()
-		return "", func() {}, werr
-	}
-	if cerr := f.Close(); cerr != nil {
-		rm()
-		return "", func() {}, cerr
-	}
-	if !systemFound {
-		return name, rm, errNoSystemRoots
-	}
-	return name, rm, nil
-}
-
-// errNoSystemRoots is returned alongside a usable bundle when no system CA store
-// was found, so the caller can say so without treating it as a failure.
-var errNoSystemRoots = errors.New("no system CA bundle found")
-
-// errNoBridgeCA means ca.crt is not on disk yet, which is an expected state
-// before Cortex's first start rather than a misconfiguration.
-var errNoBridgeCA = errors.New("bridge CA not written yet")
 
 // mergeEnv layers inject over env, replacing rather than appending.
 //
@@ -578,14 +422,32 @@ func mergeEnv(env []string, inject map[string]string) []string {
 	return out
 }
 
-// printExecEnv writes the variables as shell export lines, in a fixed order:
-// proxy names then CA names, each group in the order declared, so the output is
-// diffable and reads as the two decisions it is rather than eight unrelated ones.
+// printExecEnv writes the variables as shell export lines.
+//
+// Driven from the map itself, not a hand-kept name list: the previous version
+// iterated a local slice and so silently omitted GIT_SSL_CAINFO the moment authlib
+// added it to the managed set. Proxy names first in declaration order, then the CA
+// names sorted, so the output is stable run to run and diffable.
 func printExecEnv(inject map[string]string, stdout io.Writer) {
-	for _, k := range append(append([]string{}, execProxyVars...), execCAVars...) {
-		if v, ok := inject[k]; ok {
+	seen := make(map[string]bool, len(inject))
+	emit := func(k string) {
+		if v, ok := inject[k]; ok && !seen[k] {
+			seen[k] = true
 			fmt.Fprintf(stdout, "export %s=%s\n", k, shellQuote(v))
 		}
+	}
+	for _, k := range execProxyVars {
+		emit(k)
+	}
+	rest := make([]string, 0, len(inject))
+	for k := range inject {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	sort.Strings(rest)
+	for _, k := range rest {
+		emit(k)
 	}
 }
 

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -47,23 +47,6 @@ var execProxyVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_p
 // A local copy went stale the moment GIT_SSL_CAINFO joined the managed set —
 // --print silently stopped emitting it — so exec reads the managed set instead.
 
-// systemRootFiles are the usual system CA bundle locations, in the order
-// crypto/x509 itself consults them (root_linux.go's certFiles, plus the common
-// BSD/macOS paths). The first one that exists is treated as the system store.
-//
-// Read from disk rather than via x509.SystemCertPool because the output has to
-// be a PEM *file* another process can open: SystemCertPool returns an opaque
-// pool whose certificates cannot be re-serialised (the DER is not retained on
-// every platform), so there is nothing to write back out.
-var systemRootFiles = []string{
-	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Alpine(ish)
-	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
-	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
-	"/etc/pki/tls/cacert.pem",                           // OpenELEC
-	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
-	"/etc/ssl/cert.pem",                                 // Alpine, macOS (Homebrew OpenSSL)
-}
-
 const execUsage = `abctl exec — run a command with Cortex's proxy and CA in its environment
 
 Usage:

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -50,8 +49,8 @@ var execProxyVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_p
 const execUsage = `abctl exec — run a command with Cortex's proxy and CA in its environment
 
 Usage:
-  abctl exec [--config PATH] -- COMMAND [ARG...]
-  abctl exec [--config PATH] --print --
+  abctl exec [--cortex-stats-url URL] -- COMMAND [ARG...]
+  abctl exec [--cortex-stats-url URL] --print
 
 Everything after -- is passed to COMMAND exactly as given; abctl does not
 interpret it, so the command's own flags need no escaping:
@@ -80,9 +79,14 @@ abctl exits with the child's exit status, so it is safe in a pipeline or a
 Makefile.
 
 Flags:
-  --config PATH  Cortex config to read addresses from (default ~/.cortex/config.yaml)
+  --cortex-stats-url URL
+                 stats URL of the running Cortex (default http://localhost:47602/).
+                 The values come from the RUNNING proxy's /config, not from a file,
+                 so they describe the process that will actually serve the request —
+                 and a proxy that is down is reported rather than yielding an
+                 environment that points at nothing.
   --print        print the variables that would be set and exit, without running
-                 anything. Shell-quoted, so: eval "$(abctl exec --print --)"
+                 anything. Shell-quoted, so: eval "$(abctl exec --print)"
                  Mutually exclusive with a command: --print emits settings for a
                  shell to keep (paths under the CA directory, which outlive this
                  process), whereas a command gets them for its own lifetime only.
@@ -109,17 +113,32 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	// after it is ever parsed, so no child flag can collide with an abctl flag,
 	// now or when a future flag is added.
 	before, cmdArgs, found := cutArgs(args, "--")
-	if !found {
-		fmt.Fprint(stderr, execUsage)
-		return 2
-	}
 
 	fs := flag.NewFlagSet("exec", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.Usage = func() { fmt.Fprint(stderr, execUsage) }
-	cortexCfg := fs.String("config", "", "Cortex config file")
 	printOnly := fs.Bool("print", false, "print the variables instead of running a command")
+	statsURL := fs.String("cortex-stats-url", defaultCortexStatsURL, "stats URL of the running Cortex")
 	if err := fs.Parse(before); err != nil {
+		return 2
+	}
+
+	// The delimiter is required to RUN something, not to print.
+	//
+	// `abctl exec --print` is a complete request on its own: it asks for the
+	// environment, and there is no command for a delimiter to separate. Demanding
+	// `--print --` answered a well-formed request with usage text.
+	if !found && !*printOnly {
+		fmt.Fprint(stderr, execUsage)
+		return 2
+	}
+	// `abctl exec --print --` is the opposite mistake: the delimiter promises a
+	// command and none follows. Refused rather than quietly read as plain --print —
+	// it is the empty case of the mutual exclusion below, and the same reasoning
+	// applies, so it gets the same answer.
+	if found && *printOnly && len(cmdArgs) == 0 {
+		fmt.Fprintln(stderr, "abctl: --print takes no command, so `--` has nothing to separate.")
+		fmt.Fprintln(stderr, "  Use `abctl exec --print` on its own.")
 		return 2
 	}
 	// Stray positional arguments before the delimiter are a mistake, not something
@@ -146,22 +165,13 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 			"  --print emits environment settings to keep (paths under the CA directory,\n"+
 			"  which outlive this process); running a command applies them to that one\n"+
 			"  child. Pick one:\n"+
-			"    abctl exec --print --          # print the settings\n"+
+			"    abctl exec --print               # print the settings\n"+
 			"    abctl exec -- %s\n",
 			strings.Join(cmdArgs, " "))
 		return 2
 	}
 
-	if *cortexCfg == "" {
-		home, err := os.UserHomeDir()
-		if err != nil || home == "" {
-			fmt.Fprintf(stderr, "abctl: cannot determine your home directory: %v\n", err)
-			return 1
-		}
-		*cortexCfg = filepath.Join(home, cortexCfgRel)
-	}
-
-	inject, err := execEnv(*cortexCfg)
+	inject, err := execEnv(*statsURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
@@ -298,39 +308,43 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 }
 
 // execEnv builds the variables to inject for one child.
-func execEnv(cortexCfgPath string) (env map[string]string, err error) {
-	// wanted() is the whole derivation, bundle paths included: since the trust
-	// bundle moved into authlib/tlsbridge, `claude-code enable` already points
-	// SSL_CERT_FILE / GIT_SSL_CAINFO / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE at
-	// bundle.crt and NODE_EXTRA_CA_CERTS at ca.crt. exec reuses that verbatim
-	// rather than deriving it again — the two commands cannot drift if only one of
-	// them decides.
-	//
-	// What exec adds is the lowercase proxy spellings, which Claude Code does not
-	// need (it reads HTTPS_PROXY from its settings file) but Go's
-	// http.ProxyFromEnvironment and most Unix tools do.
-	want, cfg, err := wantedFromConfig(cortexCfgPath)
+func execEnv(statsURL string) (env map[string]string, err error) {
+	// The RUNNING proxy's config, not ~/.cortex/config.yaml. exec's whole job is to
+	// point a child at a proxy that has to be up for it to work, so the values must
+	// come from the process that will serve it — a file can have been edited since
+	// boot (listener addresses are not hot-reloaded) and says nothing about whether
+	// anything is listening.
+	cfg, err := runningConfig(statsURL)
+	if err != nil {
+		return nil, err
+	}
+	// wanted() still owns the derivation from a config to the env vars, so exec and
+	// `claude-code enable` produce identical values for the same Cortex; only the
+	// SOURCE of the config differs (live process here, file there — enable writes
+	// settings for sessions that outlive any one proxy run).
+	want, err := wantedFromLoaded(cfg)
 	if err != nil {
 		return nil, err
 	}
 	proxy := want[envProxy]
 	if proxy == "" {
-		return nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
+		return nil, fmt.Errorf("the Cortex at %s yields no proxy address", statsURL)
 	}
 
 	// The bridge posture, not just the CA path. Shared with `claude-code enable`
 	// via bridgeEnabled/errBridgeDisabled so the two commands cannot disagree about
 	// it — see errBridgeDisabled for why a disabled bridge has to be refused.
 	if !bridgeEnabled(cfg) {
-		return nil, errBridgeDisabled(cortexCfgPath)
+		return nil, errBridgeDisabled("the Cortex at " + statsURL)
 	}
 	if want[envCACerts] == "" {
 		// Refused rather than injecting the proxy alone. Without a trusted CA the
 		// bridge cannot terminate TLS, so every https request either fails
 		// verification or — worse, if the tool is lenient — tunnels through
 		// unparsed, which looks exactly like success while Cortex sees nothing.
-		return nil, fmt.Errorf("%s has no tls_bridge.ca_dir, so the child would have no CA to trust;\n"+
-			"  https requests through the bridge would fail verification. Enable the TLS bridge first", cortexCfgPath)
+		return nil, fmt.Errorf("the Cortex at %s has no tls_bridge.ca_dir, so the child would\n"+
+			"  have no CA to trust and https through the bridge would fail verification.\n"+
+			"  Enable the TLS bridge first", statsURL)
 	}
 
 	out := make(map[string]string, len(want)+len(execProxyVars))

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -91,7 +91,8 @@ var systemRootFiles = []string{
 const execUsage = `abctl exec — run a command with Cortex's proxy and CA in its environment
 
 Usage:
-  abctl exec [--config PATH] [--print] -- COMMAND [ARG...]
+  abctl exec [--config PATH] -- COMMAND [ARG...]
+  abctl exec [--config PATH] --print --
 
 Everything after -- is passed to COMMAND exactly as given; abctl does not
 interpret it, so the command's own flags need no escaping:
@@ -123,6 +124,9 @@ Flags:
   --config PATH  Cortex config to read addresses from (default ~/.cortex/config.yaml)
   --print        print the variables that would be set and exit, without running
                  anything. Shell-quoted, so: eval "$(abctl exec --print --)"
+                 Mutually exclusive with a command: --print emits settings for a
+                 shell to keep (paths under the CA directory, which outlive this
+                 process), whereas a command gets them for its own lifetime only.
 
 Exit status: the child's, or 1 if the command could not be started (127 if it
 was not found on PATH), or 2 for a usage error.
@@ -165,6 +169,27 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	// saying so.
 	if fs.NArg() > 0 {
 		fmt.Fprintf(stderr, "abctl: unexpected argument %q before --; the command goes after --\n", fs.Arg(0))
+		return 2
+	}
+
+	// A command or --print, never both.
+	//
+	// Not merely "the command would be ignored": the two modes disagree about how
+	// long their output is meant to last. --print emits paths for a shell to keep —
+	// the same ca.crt that `claude-code enable` writes into settings.json, plus a
+	// trust-bundle.pem beside it — and those are expected to outlive any single
+	// invocation. Running a command is the opposite: one process, one lifetime.
+	// Asking for both in one breath is a contradiction about intent, not a spare
+	// argument, so it is refused the way an argument in the wrong place is rather
+	// than warned about and half-honoured.
+	if *printOnly && len(cmdArgs) > 0 {
+		fmt.Fprintf(stderr, "abctl: --print and a command are mutually exclusive.\n"+
+			"  --print emits environment settings to keep (paths under the CA directory,\n"+
+			"  which outlive this process); running a command applies them to that one\n"+
+			"  child. Pick one:\n"+
+			"    abctl exec --print --          # print the settings\n"+
+			"    abctl exec -- %s\n",
+			strings.Join(cmdArgs, " "))
 		return 2
 	}
 
@@ -217,15 +242,6 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if *printOnly {
-		// Say so rather than silently discard it. Refusing outright would break
-		// `abctl exec --print --`, the documented form, and rejecting only the
-		// with-a-command form is a usage error for something harmless — but staying
-		// silent about an ignored command is the same discourtesy the strict check
-		// above exists to avoid.
-		if len(cmdArgs) > 0 {
-			fmt.Fprintf(stderr, "abctl: --print only prints the variables; %q was not run.\n",
-				strings.Join(cmdArgs, " "))
-		}
 		printExecEnv(inject, stdout)
 		if b := inject[execCAReplaceVars[0]]; b != "" {
 			fmt.Fprintf(stderr, "abctl: wrote the trust bundle to %s (system roots + Cortex's bridge CA).\n"+

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
@@ -137,6 +138,15 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	// command and none follows. Refused rather than quietly read as plain --print —
 	// it is the empty case of the mutual exclusion below, and the same reasoning
 	// applies, so it gets the same answer.
+	// `abctl exec --` with nothing after it is a usage error knowable from argv, so
+	// it is answered here rather than after the config fetch below. Diagnosed later,
+	// a user with Cortex down was told "no Cortex is running" and got exit 1 for what
+	// execUsage documents as exit 2 — and paid a pointless round-trip to learn it.
+	if found && !*printOnly && len(cmdArgs) == 0 {
+		fmt.Fprintln(stderr, "abctl: nothing to run after --")
+		fmt.Fprint(stderr, execUsage)
+		return 2
+	}
 	if found && *printOnly && len(cmdArgs) == 0 {
 		fmt.Fprintln(stderr, "abctl: --print takes no command, so `--` has nothing to separate.")
 		fmt.Fprintln(stderr, "  Use `abctl exec --print` on its own.")
@@ -172,38 +182,21 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	inject, err := execEnv(*statsURL)
+	inject, missingBundle, err := execEnv(*statsURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
 	}
-
-	// Neither ca.crt nor bundle.crt is written by exec any more: the proxy writes
-	// both on boot (authbridge-proxy calls tlsbridge.EnsureTrustBundle). Running
-	// before that first start is legitimate, so this is a warning rather than an
-	// error — but it is worth naming, because the failure it causes is loud and
-	// otherwise unexplained: git, curl and Python all refuse outright when the CA
-	// file they were pointed at cannot be read.
-	for _, k := range []string{envCACerts, envSSLCert} {
-		p := inject[k]
-		if p == "" {
-			continue
-		}
-		if _, serr := os.Stat(p); serr != nil {
-			fmt.Fprintf(stderr, "abctl: note: %s does not exist yet — Cortex writes it on first start.\n"+
-				"  TLS through the bridge will fail until then (abctl service start).\n", p)
-			break
-		}
+	// execEnv already dropped the replacing variables; say what that costs.
+	if missingBundle != "" {
+		fmt.Fprintf(stderr, "abctl: note: %s does not exist yet — Cortex writes it on first start.\n"+
+			"  Until then the child keeps its own trusted roots and only hosts the bridge\n"+
+			"  terminates will fail verification (abctl service start).\n", missingBundle)
 	}
 
 	if *printOnly {
 		printExecEnv(inject, stdout)
 		return 0
-	}
-	if len(cmdArgs) == 0 {
-		fmt.Fprintln(stderr, "abctl: nothing to run after --")
-		fmt.Fprint(stderr, execUsage)
-		return 2
 	}
 
 	return runChild(cmdArgs, inject, stdout, stderr)
@@ -239,32 +232,43 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	// Signal handling splits by how the signal arrives.
+	// Signal handling splits by how the signal arrives, and abctl has to survive
+	// both kinds — it is a wrapper, so dying first strands the child on the terminal.
 	//
-	// tty-generated signals (SIGINT/SIGQUIT/SIGTSTP from a keystroke) are delivered
-	// by the tty driver to the whole foreground process group, so the child already
-	// gets them and relaying would double the signal. Those are left alone —
-	// interactive children rely on handling their own Ctrl-C.
+	// tty-generated signals (SIGINT and SIGQUIT from a keystroke) go to the whole
+	// foreground process group, so the child already has them: there is no Setpgid
+	// here, deliberately, because an interactive child is supposed to see Ctrl-C.
+	// Relaying them would double the signal. But abctl must still CATCH them, or
+	// Go's default disposition kills the wrapper while the child keeps running —
+	// for `abctl exec -- claude`, where Ctrl-C interrupts a turn rather than
+	// quitting, that leaves the shell prompt and claude both reading one stdin, with
+	// the terminal in whatever mode claude left it. Verified: with SIGINT unhandled,
+	// abctl exits -2 and the child survives. SIGQUIT is the same shape and
+	// additionally dumps Go's goroutine stacks over the user's screen.
 	//
-	// A signal aimed at abctl's PID is different: `timeout 30 abctl exec -- …`, a CI
-	// runner, or systemd sends SIGTERM to abctl alone. Go's default disposition then
-	// kills abctl and leaves the child running, orphaned, with the injected
-	// environment — and `timeout` in a Makefile is exactly what "safe in a pipeline
-	// or a Makefile" claims to support. So SIGTERM and SIGHUP are relayed, then abctl
-	// keeps waiting and still reports the child's real status.
+	// So they are caught and dropped: notified, never forwarded. The runtime absorbs
+	// them, Wait keeps running, and the child's own death arrives as 128+signum —
+	// what a shell would report anyway.
 	//
-	// Notify BEFORE Start, not after: a SIGTERM landing in the window between them
-	// would hit Go's default disposition and kill abctl with the child already
-	// running — orphaning it with the injected environment, the exact failure this
-	// relay exists to prevent. The channel is buffered, so a signal arriving during
-	// that window is held and delivered to the relay below rather than dropped.
+	// NOT signal.Ignore: that sets SIG_IGN at the OS level, and exec() preserves
+	// ignored dispositions across the exec (caught ones reset to default), so the
+	// child would inherit the ignore and Ctrl-C would stop reaching it at all.
+	//
+	// A signal aimed at abctl's PID alone is the other kind: `timeout 30 abctl exec
+	// -- …`, a CI runner, or systemd sends SIGTERM to the wrapper only, and nothing
+	// reaches the child unless abctl passes it on. Those two ARE relayed.
+	//
+	// Notify BEFORE Start: a signal landing between them would hit the default
+	// disposition and kill abctl with the child already running. The channel is
+	// buffered, so one arriving in that window is held for the relay rather than
+	// dropped.
+	relayed := []os.Signal{syscall.SIGTERM, syscall.SIGHUP}
+	absorbed := []os.Signal{syscall.SIGINT, syscall.SIGQUIT}
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGHUP)
-	// Stopped before the relay goroutine is told to exit, so nothing can be queued
-	// onto a channel with no reader.
-	defer signal.Stop(sigs)
+	signal.Notify(sigs, append(append([]os.Signal{}, relayed...), absorbed...)...)
 
 	if err := cmd.Start(); err != nil {
+		signal.Stop(sigs)
 		fmt.Fprintf(stderr, "abctl: %s: %v\n", argv[0], err)
 		return 1
 	}
@@ -275,11 +279,22 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 	// means the goroutine touches nothing cmd owns.
 	proc := cmd.Process
 	relayDone := make(chan struct{})
+	// Registered AFTER the goroutine's own defer below, so LIFO order runs
+	// signal.Stop first and then closes relayDone: deliveries stop before the reader
+	// goes away, rather than the other way round. (No bug either way — sigs is
+	// buffered and os/signal drops instead of blocking on a full channel — but the
+	// previous comment claimed this order while the code did the reverse.)
 	defer close(relayDone)
+	defer signal.Stop(sigs)
 	go func() {
 		for {
 			select {
 			case sig := <-sigs:
+				// Absorbed signals are caught so abctl survives them, and deliberately
+				// NOT forwarded: the child already got them from the tty.
+				if slices.Contains(absorbed, sig) {
+					continue
+				}
 				// Best-effort: the child may have exited between the signal and here,
 				// which is a benign race, not an error worth reporting.
 				_ = proc.Signal(sig)
@@ -309,7 +324,7 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 }
 
 // execEnv builds the variables to inject for one child.
-func execEnv(statsURL string) (env map[string]string, err error) {
+func execEnv(statsURL string) (env map[string]string, missingBundle string, err error) {
 	// The RUNNING proxy's config, not ~/.cortex/config.yaml. exec's whole job is to
 	// point a child at a proxy that has to be up for it to work, so the values must
 	// come from the process that will serve it — a file can have been edited since
@@ -317,33 +332,33 @@ func execEnv(statsURL string) (env map[string]string, err error) {
 	// anything is listening.
 	cfg, err := runningConfig(statsURL)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	// wanted() still owns the derivation from a config to the env vars, so exec and
 	// `claude-code enable` produce identical values for the same Cortex; only the
 	// SOURCE of the config differs (live process here, file there — enable writes
 	// settings for sessions that outlive any one proxy run).
-	want, err := wantedFromLoaded(cfg)
+	want, err := wantedFromLoaded(cfg, "the Cortex at "+statsURL)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	proxy := want[envProxy]
 	if proxy == "" {
-		return nil, fmt.Errorf("the Cortex at %s yields no proxy address", statsURL)
+		return nil, "", fmt.Errorf("the Cortex at %s yields no proxy address", statsURL)
 	}
 
 	// The bridge posture, not just the CA path. Shared with `claude-code enable`
 	// via bridgeEnabled/errBridgeDisabled so the two commands cannot disagree about
 	// it — see errBridgeDisabled for why a disabled bridge has to be refused.
 	if !bridgeEnabled(cfg) {
-		return nil, errBridgeDisabled("the Cortex at " + statsURL)
+		return nil, "", errBridgeDisabled("the Cortex at " + statsURL)
 	}
 	if want[envCACerts] == "" {
 		// Refused rather than injecting the proxy alone. Without a trusted CA the
 		// bridge cannot terminate TLS, so every https request either fails
 		// verification or — worse, if the tool is lenient — tunnels through
 		// unparsed, which looks exactly like success while Cortex sees nothing.
-		return nil, fmt.Errorf("the Cortex at %s has no tls_bridge.ca_dir, so the child would\n"+
+		return nil, "", fmt.Errorf("the Cortex at %s has no tls_bridge.ca_dir, so the child would\n"+
 			"  have no CA to trust and https through the bridge would fail verification.\n"+
 			"  Enable the TLS bridge first", statsURL)
 	}
@@ -363,7 +378,32 @@ func execEnv(statsURL string) (env map[string]string, err error) {
 	for _, k := range execProxyVars {
 		out[k] = proxy
 	}
-	return out, nil
+
+	// Omit the REPLACING variables when the bundle is not on disk yet.
+	//
+	// Cortex writes bundle.crt on boot (tlsbridge.EnsureTrustBundle), and running
+	// before that first start is legitimate. But those four names replace the trust
+	// store rather than extend it, so pointing them at a missing file does not fall
+	// back to the platform roots — git, curl and Python refuse outright ("error
+	// setting certificate verify locations") and EVERY https request fails, bridged
+	// or not. Leaving them unset costs only the bridged hosts, which is strictly
+	// better and is what the README describes.
+	//
+	// NODE_EXTRA_CA_CERTS stays either way: it is additive, so a missing file makes
+	// Node warn and keep its own roots — the same state `claude-code enable` has
+	// always written.
+	//
+	// Here rather than in runExec, so the invariant travels with the derivation: any
+	// caller of execEnv gets an environment that is safe to hand a child.
+	if b := out[envSSLCert]; b != "" {
+		if _, serr := os.Stat(b); serr != nil {
+			for _, k := range bundleKeys {
+				delete(out, k)
+			}
+			missingBundle = b
+		}
+	}
+	return out, missingBundle, nil
 }
 
 // mergeEnv layers inject over env, replacing rather than appending.

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -59,19 +59,20 @@ interpret it, so the command's own flags need no escaping:
   abctl exec -- claude --dangerously-skip-permissions
   abctl exec -- bob
 
-The child inherits your environment plus these, read from ~/.cortex/config.yaml
-so they always match the running proxy:
+The child inherits your environment plus these, read from the RUNNING proxy's
+/config so they always match the process that will serve the request:
 
   HTTP_PROXY  HTTPS_PROXY  http_proxy  https_proxy      the forward proxy URL
-  NODE_EXTRA_CA_CERTS                                   the bridge CA (added to
-                                                        the runtime's own roots)
-  CURL_CA_BUNDLE  REQUESTS_CA_BUNDLE  SSL_CERT_FILE     a temporary bundle of the
-                                                        system roots + bridge CA
+  NODE_EXTRA_CA_CERTS                                   ca.crt, ADDED to the
+                                                        runtime's own roots
+  CURL_CA_BUNDLE  REQUESTS_CA_BUNDLE                    bundle.crt: the bridge CA
+  SSL_CERT_FILE   GIT_SSL_CAINFO                        plus the platform roots
 
-The last three REPLACE the trust store rather than extend it, so they get a
+Those last four REPLACE the trust store rather than extend it, so they get the
 bundle: naming the bridge CA alone would leave the child trusting one CA and
 break every host the bridge does not terminate (passthrough_hosts, skip_hosts,
-ports outside tls_bridge.ports). Requires tls_bridge.mode: enabled.
+ports outside tls_bridge.ports). Cortex writes both files itself, beside each
+other in tls_bridge.ca_dir. Requires tls_bridge.mode: enabled.
 
 Values already in your environment are replaced for this child only; nothing is
 exported to your shell and no file is modified. Signals go to the child, and
@@ -154,9 +155,9 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	//
 	// Not merely "the command would be ignored": the two modes disagree about how
 	// long their output is meant to last. --print emits paths for a shell to keep —
-	// the same ca.crt that `claude-code enable` writes into settings.json, plus a
-	// trust-bundle.pem beside it — and those are expected to outlive any single
-	// invocation. Running a command is the opposite: one process, one lifetime.
+	// the same ca.crt and bundle.crt that `claude-code enable` writes into
+	// settings.json — and those outlive any single invocation, because Cortex writes
+	// them, not abctl. Running a command is the opposite: one process, one lifetime.
 	// Asking for both in one breath is a contradiction about intent, not a spare
 	// argument, so it is refused the way an argument in the wrong place is rather
 	// than warned about and half-honoured.
@@ -376,9 +377,9 @@ func execEnv(statsURL string) (env map[string]string, err error) {
 //
 // Comparison is case-sensitive on every platform, which is correct here: the
 // lowercase and uppercase proxy spellings are distinct variables that we set
-// deliberately, and folding them would collapse four of the eight names into
-// one. (Windows environments are case-insensitive, but abctl's proxy/CA story is
-// a Unix one.)
+// deliberately, and folding them would collapse the four proxy names into one.
+// (Windows environments are case-insensitive, but abctl's proxy/CA story is a Unix
+// one.)
 func mergeEnv(env []string, inject map[string]string) []string {
 	out := make([]string, 0, len(env)+len(inject))
 	seen := make(map[string]bool, len(inject))

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -13,8 +13,6 @@ import (
 	"sort"
 	"strings"
 	"syscall"
-
-	"github.com/rossoctl/cortex/authbridge/authlib/config"
 )
 
 // exec runs one command with Cortex's proxy and CA already in its environment,
@@ -179,7 +177,14 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 		*cortexCfg = filepath.Join(home, cortexCfgRel)
 	}
 
-	inject, cleanup, err := execEnv(*cortexCfg)
+	inject, cleanup, err := execEnv(*cortexCfg, *printOnly)
+	// Registered before the error branches below, so "cleanup always runs" is
+	// enforced in one place. Nothing leaks today — writeTrustBundle removes its own
+	// file on every error path — but that invariant was being held in two places,
+	// and the next error return added there would have broken it silently.
+	if cleanup != nil {
+		defer cleanup()
+	}
 	// errNoSystemRoots comes back WITH a usable bundle: the bridge CA is in it, so
 	// bridged hosts verify fine; only public trust is absent, and on an image with
 	// no root store there was none to begin with. Reported, not fatal.
@@ -194,12 +199,6 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
 	}
-	// The bundle is a temp file scoped to this child, so it must go whichever way
-	// runExec returns — including the usage and not-found paths below.
-	if cleanup != nil {
-		defer cleanup()
-	}
-
 	// A CA path that does not exist yet is a warning, not an error: enabling
 	// before the first start is legitimate and the proxy writes it on boot. But
 	// unlike the settings path, here the failure is loud rather than silent —
@@ -228,6 +227,10 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 				strings.Join(cmdArgs, " "))
 		}
 		printExecEnv(inject, stdout)
+		if b := inject[execCAReplaceVars[0]]; b != "" {
+			fmt.Fprintf(stderr, "abctl: wrote the trust bundle to %s (system roots + Cortex's bridge CA).\n"+
+				"  It is rewritten on each --print, so a rotated CA is picked up.\n", b)
+		}
 		return 0
 	}
 	if len(cmdArgs) == 0 {
@@ -282,30 +285,41 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 	// environment — and `timeout` in a Makefile is exactly what "safe in a pipeline
 	// or a Makefile" claims to support. So SIGTERM and SIGHUP are relayed, then abctl
 	// keeps waiting and still reports the child's real status.
+	//
+	// Notify BEFORE Start, not after: a SIGTERM landing in the window between them
+	// would hit Go's default disposition and kill abctl with the child already
+	// running — orphaning it with the injected environment, the exact failure this
+	// relay exists to prevent. The channel is buffered, so a signal arriving during
+	// that window is held and delivered to the relay below rather than dropped.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGHUP)
+	// Stopped before the relay goroutine is told to exit, so nothing can be queued
+	// onto a channel with no reader.
+	defer signal.Stop(sigs)
+
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(stderr, "abctl: %s: %v\n", argv[0], err)
 		return 1
 	}
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGHUP)
+
+	// The relay starts only AFTER Start returns. cmd.Process is written by Start,
+	// and reading it from the goroutine concurrently is a genuine data race that
+	// -race catches — the process handle, not just a stale read. Capturing it here
+	// means the goroutine touches nothing cmd owns.
+	proc := cmd.Process
 	relayDone := make(chan struct{})
+	defer close(relayDone)
 	go func() {
 		for {
 			select {
 			case sig := <-sigs:
-				if p := cmd.Process; p != nil {
-					// Best-effort: the child may have exited between the signal and here,
-					// which is a benign race, not an error worth reporting.
-					_ = p.Signal(sig)
-				}
+				// Best-effort: the child may have exited between the signal and here,
+				// which is a benign race, not an error worth reporting.
+				_ = proc.Signal(sig)
 			case <-relayDone:
 				return
 			}
 		}
-	}()
-	defer func() {
-		signal.Stop(sigs)
-		close(relayDone)
 	}()
 
 	if err := cmd.Wait(); err != nil {
@@ -335,8 +349,11 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 // only way to guarantee that is one derivation. The telemetry key wanted() also
 // returns is dropped here — it is a Claude Code setting, and exec's child is
 // usually not Claude Code.
-func execEnv(cortexCfgPath string) (env map[string]string, cleanup func(), err error) {
-	want, err := wanted(cortexCfgPath)
+// persist selects where the trust bundle goes: a stable path beside the CA (for
+// --print, whose output must outlive this process) or a temp file removed by
+// cleanup (for a child, which reads it while running).
+func execEnv(cortexCfgPath string, persist bool) (env map[string]string, cleanup func(), err error) {
+	want, cfg, err := wantedFromConfig(cortexCfgPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -345,21 +362,11 @@ func execEnv(cortexCfgPath string) (env map[string]string, cleanup func(), err e
 		return nil, nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
 	}
 
-	// The bridge posture, not just the CA path. ca_dir is only *required* when
-	// mode is "enabled" (config.go's Validate), so `mode: disabled` with a ca_dir
-	// set is a perfectly valid config that this used to accept — and then injected
-	// a CA for a bridge that terminates nothing, so every https request in the
-	// child failed verification against the real upstream certificate. A harder
-	// break than the missing-ca_dir case, and silent about its cause.
-	cfg, cerr := config.Load(cortexCfgPath)
-	if cerr != nil {
-		return nil, nil, fmt.Errorf("reading %s: %w", cortexCfgPath, cerr)
-	}
-	// Empty mode means disabled, per TLSBridgeConfig.Mode's own documentation.
-	if cfg.TLSBridge == nil || cfg.TLSBridge.Mode != "enabled" {
-		return nil, nil, fmt.Errorf("%s has no enabled TLS bridge (tls_bridge.mode must be \"enabled\");\n"+
-			"  without it Cortex terminates no TLS, so the child would gain nothing and\n"+
-			"  every https request would fail verification. Enable the TLS bridge first", cortexCfgPath)
+	// The bridge posture, not just the CA path. Shared with `claude-code enable`
+	// via bridgeEnabled/errBridgeDisabled so the two commands cannot disagree about
+	// it — see errBridgeDisabled for why a disabled bridge has to be refused.
+	if !bridgeEnabled(cfg) {
+		return nil, nil, errBridgeDisabled(cortexCfgPath)
 	}
 
 	ca, ok := want[envCACerts]
@@ -381,7 +388,7 @@ func execEnv(cortexCfgPath string) (env map[string]string, cleanup func(), err e
 		out[k] = ca
 	}
 	// Replacing names take a bundle, so excluded hosts keep public trust.
-	bundle, cleanup, berr := writeTrustBundle(ca)
+	bundle, cleanup, berr := writeTrustBundle(ca, persist)
 	switch {
 	case errors.Is(berr, errNoBridgeCA):
 		// The CA is not on disk yet — Cortex writes it on first start, and enabling
@@ -412,7 +419,13 @@ func execEnv(cortexCfgPath string) (env map[string]string, cleanup func(), err e
 // genuinely have no root bundle, in which case the bridge CA alone is the whole
 // trust set — which is exactly right there, since such an image had no public
 // trust to lose. It is reported so the difference is not silent.
-func writeTrustBundle(caPath string) (path string, cleanup func(), err error) {
+// When persist is true the bundle is written to a STABLE path beside the CA
+// (ca_dir/trust-bundle.pem) and no cleanup is returned, because the caller is
+// --print: the exported path has to outlive this process for
+// `eval "$(abctl exec --print --)"` to mean anything. A temp file per eval would
+// also leak with no owner, so a single rewritten file beside the CA it is derived
+// from is both durable and self-limiting.
+func writeTrustBundle(caPath string, persist bool) (path string, cleanup func(), err error) {
 	caPEM, err := os.ReadFile(caPath) //nolint:gosec // path derived from the operator's own config
 	if err != nil {
 		// Signalled, not fatal: the CA is written by Cortex on first start and exec
@@ -441,6 +454,28 @@ func writeTrustBundle(caPath string) (path string, cleanup func(), err error) {
 	}
 	systemFound := len(buf) > 0
 	buf = append(buf, caPEM...)
+
+	if persist {
+		// Beside the CA, not in the temp dir: --print's output must still resolve
+		// after this process exits. Rewritten in place each run so a rotated CA is
+		// picked up, and atomically so a concurrent reader never sees a half-written
+		// trust store.
+		name := filepath.Join(filepath.Dir(caPath), "trust-bundle.pem")
+		tmp := name + ".tmp"
+		// 0644, matching ca.crt: a trust store is public material, and a file only
+		// the writing user can read would break a child running as anyone else.
+		if werr := os.WriteFile(tmp, buf, 0o644); werr != nil { //nolint:gosec // trust anchors are not secret
+			return "", func() {}, werr
+		}
+		if rerr := os.Rename(tmp, name); rerr != nil {
+			_ = os.Remove(tmp)
+			return "", func() {}, rerr
+		}
+		if !systemFound {
+			return name, func() {}, errNoSystemRoots
+		}
+		return name, func() {}, nil
+	}
 
 	// 0600 in the process's temp dir: this is a trust store, and a world-writable
 	// one would let any local user add a root the child then trusts.

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+)
+
+// exec runs one command with Cortex's proxy and CA already in its environment,
+// for the many tools that read the environment and nothing else.
+//
+// `claude-code enable` exists because Claude Code has a settings file, so the
+// variables can be written once and reach every session including background
+// agents. Nothing else has that: curl, python, node, gh, a test suite all read
+// the process environment, and the alternative is a shell export that leaks into
+// every unrelated command in that terminal until it is unset. `abctl exec`
+// scopes the routing to a single child.
+//
+// The values come from the same wanted() the enable path uses, so the two cannot
+// drift: exec and enable point at the same proxy on the same port with the same
+// CA, or they both fail for the same reason.
+
+// execProxyVars are the names that get the forward-proxy URL. Four spellings
+// because there is no agreed one: Go's http.ProxyFromEnvironment and most Unix
+// tools read the lowercase pair, Node and the JVM-adjacent world the uppercase,
+// and libcurl accepts either. A tool that reads only the spelling we omitted is
+// a tool that silently bypasses the proxy — invisible, because it keeps working.
+//
+// HTTP_PROXY and HTTPS_PROXY both get the same value, and it is deliberately the
+// http:// URL in both: the scheme in a *_PROXY variable names how to reach the
+// PROXY, not what the proxied request is. Cortex's forward proxy speaks plain
+// HTTP and CONNECT-tunnels TLS, so https:// here would make clients try TLS to
+// the proxy itself and fail the handshake.
+var execProxyVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"}
+
+// execCAVars are the names that get the bridge CA path. Same reasoning: each
+// runtime invented its own. NODE_EXTRA_CA_CERTS is Node, CURL_CA_BUNDLE is
+// libcurl, REQUESTS_CA_BUNDLE is Python requests, SSL_CERT_FILE is OpenSSL and
+// most things built on it.
+//
+// Every one is a *_FILE / *_BUNDLE, not a directory, so all four take the same
+// ca.crt path; a tool wanting a hashed CA directory (SSL_CERT_DIR) is not served
+// here.
+var execCAVars = []string{"NODE_EXTRA_CA_CERTS", "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"}
+
+const execUsage = `abctl exec — run a command with Cortex's proxy and CA in its environment
+
+Usage:
+  abctl exec [--config PATH] [--print] -- COMMAND [ARG...]
+
+Everything after -- is passed to COMMAND exactly as given; abctl does not
+interpret it, so the command's own flags need no escaping:
+
+  abctl exec -- curl -sv https://api.anthropic.com/v1/messages
+  abctl exec -- claude --dangerously-skip-permissions
+  abctl exec -- bob
+
+The child inherits your environment plus these, read from ~/.cortex/config.yaml
+so they always match the running proxy:
+
+  HTTP_PROXY  HTTPS_PROXY  http_proxy  https_proxy      the forward proxy URL
+  NODE_EXTRA_CA_CERTS  CURL_CA_BUNDLE                   the bridge CA file
+  REQUESTS_CA_BUNDLE   SSL_CERT_FILE
+
+Values already in your environment are replaced for this child only; nothing is
+exported to your shell and no file is modified. Signals go to the child, and
+abctl exits with the child's exit status, so it is safe in a pipeline or a
+Makefile.
+
+Flags:
+  --config PATH  Cortex config to read addresses from (default ~/.cortex/config.yaml)
+  --print        print the variables that would be set and exit, without running
+                 anything. Shell-quoted, so: eval "$(abctl exec --print --)"
+
+Exit status: the child's, or 1 if the command could not be started (127 if it
+was not found on PATH), or 2 for a usage error.
+`
+
+// execEnvNotFound is the exit code for "command not found", following the shell
+// convention. A caller distinguishing "my command is missing" from "my command
+// failed" gets the same answer from `abctl exec` as from `sh -c`.
+const execEnvNotFound = 127
+
+// runExec handles the `exec` subcommand. Returns the process exit code.
+func runExec(args []string, stdout, stderr io.Writer) int {
+	// Split on the first -- ourselves, before the flag package sees anything.
+	//
+	// flag.Parse stops at -- and would leave the rest in fs.Args(), which sounds
+	// like enough, but it also stops at the first non-flag argument and at any flag
+	// it does not recognise. So `abctl exec curl -x` (no --) would be accepted with
+	// "curl" as a positional, and `abctl exec -- claude --config x` risks the child's
+	// own --config being read as ours if the delimiter were ever dropped. Requiring
+	// the delimiter and cutting on it first makes the boundary syntactic: nothing
+	// after it is ever parsed, so no child flag can collide with an abctl flag,
+	// now or when a future flag is added.
+	before, cmdArgs, found := cutArgs(args, "--")
+	if !found {
+		fmt.Fprint(stderr, execUsage)
+		return 2
+	}
+
+	fs := flag.NewFlagSet("exec", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { fmt.Fprint(stderr, execUsage) }
+	cortexCfg := fs.String("config", "", "Cortex config file")
+	printOnly := fs.Bool("print", false, "print the variables instead of running a command")
+	if err := fs.Parse(before); err != nil {
+		return 2
+	}
+	// Stray positional arguments before the delimiter are a mistake, not something
+	// to ignore: `abctl exec curl -- -sv` most likely means the user typed the
+	// command in the wrong place, and silently running `-sv` is a worse answer than
+	// saying so.
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "abctl: unexpected argument %q before --; the command goes after --\n", fs.Arg(0))
+		return 2
+	}
+
+	if *cortexCfg == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			fmt.Fprintf(stderr, "abctl: cannot determine your home directory: %v\n", err)
+			return 1
+		}
+		*cortexCfg = filepath.Join(home, cortexCfgRel)
+	}
+
+	inject, err := execEnv(*cortexCfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		return 1
+	}
+
+	// A CA path that does not exist yet is a warning, not an error: enabling
+	// before the first start is legitimate and the proxy writes it on boot. But
+	// unlike the settings path, here the failure is loud rather than silent —
+	// Node and curl both refuse to start with a CA file they cannot read — so it
+	// is worth naming the cause before the child dies of it.
+	if ca := inject[execCAVars[0]]; ca != "" {
+		if _, serr := os.Stat(ca); serr != nil {
+			fmt.Fprintf(stderr, "abctl: note: %s does not exist yet — Cortex writes it on first start.\n"+
+				"  TLS verification against the bridge will fail until then (abctl service start).\n", ca)
+		}
+	}
+
+	if *printOnly {
+		printExecEnv(inject, stdout)
+		return 0
+	}
+	if len(cmdArgs) == 0 {
+		fmt.Fprintln(stderr, "abctl: nothing to run after --")
+		fmt.Fprint(stderr, execUsage)
+		return 2
+	}
+
+	return runChild(cmdArgs, inject, stdout, stderr)
+}
+
+// runChild runs argv with inject layered over the current environment and
+// returns its exit status.
+func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer) int {
+	// LookPath first, so "not found" is reported as itself with the 127 a shell
+	// would give, rather than arriving as a generic start failure.
+	path, err := exec.LookPath(argv[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "abctl: %v\n", err)
+		if errors.Is(err, exec.ErrNotFound) {
+			return execEnvNotFound
+		}
+		return 1
+	}
+
+	cmd := exec.Command(path, argv[1:]...) //nolint:gosec // the command is the user's, given after --
+	cmd.Env = mergeEnv(os.Environ(), inject)
+	// The child gets this process's real stdio, not a pipe: it may be interactive
+	// (`abctl exec -- claude`), and a pipe would cost it the terminal, so it would
+	// disable colour, refuse to prompt, or line-buffer its output. stdout/stderr
+	// are still honoured when a caller passed something else, which is what makes
+	// this testable.
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	// No signal forwarding, deliberately. The child is in this process's process
+	// group and shares the terminal, so a Ctrl-C at the keyboard is delivered by
+	// the tty driver to the whole group — the child included — and re-sending it
+	// would double the signal. Interactive children (claude, a REPL) rely on
+	// receiving SIGINT themselves; abctl dying first would orphan them mid-write.
+	// abctl has nothing of its own to clean up, so it just waits and reports.
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			// A child killed by a signal has no exit code; ExitCode() returns -1.
+			// Report it the way a shell does (128+signum) rather than passing -1 up,
+			// which os.Exit would turn into 255 and lose the cause.
+			if code := ee.ExitCode(); code >= 0 {
+				return code
+			}
+			return signaledExitCode(ee)
+		}
+		// Not an ExitError: the command existed but could not be executed at all
+		// (a directory, no exec bit, bad interpreter line).
+		fmt.Fprintf(stderr, "abctl: %s: %v\n", argv[0], err)
+		return 1
+	}
+	return 0
+}
+
+// execEnv builds the variables to inject, fanning the two values wanted()
+// derives out over the eight names tools actually read.
+//
+// Reusing wanted() rather than re-reading the config is the point: exec and
+// `claude-code enable` must agree about the proxy address and the CA, and the
+// only way to guarantee that is one derivation. The telemetry key wanted() also
+// returns is dropped here — it is a Claude Code setting, and exec's child is
+// usually not Claude Code.
+func execEnv(cortexCfgPath string) (map[string]string, error) {
+	want, err := wanted(cortexCfgPath)
+	if err != nil {
+		return nil, err
+	}
+	proxy := want[envProxy]
+	if proxy == "" {
+		return nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
+	}
+	ca, ok := want[envCACerts]
+	if !ok || ca == "" {
+		// Refused rather than injecting the proxy alone. Without a trusted CA the
+		// bridge cannot terminate TLS, so every https request either fails
+		// verification or — worse, if the tool is lenient — tunnels through
+		// unparsed, which looks exactly like success while Cortex sees nothing.
+		return nil, fmt.Errorf("%s has no tls_bridge.ca_dir, so the child would have no CA to trust;\n"+
+			"  https requests through the bridge would fail verification. Enable the TLS bridge first", cortexCfgPath)
+	}
+	out := make(map[string]string, len(execProxyVars)+len(execCAVars))
+	for _, k := range execProxyVars {
+		out[k] = proxy
+	}
+	for _, k := range execCAVars {
+		out[k] = ca
+	}
+	return out, nil
+}
+
+// mergeEnv layers inject over env, replacing rather than appending.
+//
+// exec.Cmd passes Env to execve as given, and POSIX leaves duplicate names
+// undefined: Go's own os.Getenv in a child takes the FIRST match, glibc takes the
+// first, but some runtimes and most shells take the last. Appending would
+// therefore set the variable for some children and not others depending on
+// whether the user already had HTTPS_PROXY set — the one case where getting it
+// right matters most. Replacing in place leaves exactly one entry per name.
+//
+// Comparison is case-sensitive on every platform, which is correct here: the
+// lowercase and uppercase proxy spellings are distinct variables that we set
+// deliberately, and folding them would collapse four of the eight names into
+// one. (Windows environments are case-insensitive, but abctl's proxy/CA story is
+// a Unix one.)
+func mergeEnv(env []string, inject map[string]string) []string {
+	out := make([]string, 0, len(env)+len(inject))
+	seen := make(map[string]bool, len(inject))
+	for _, kv := range env {
+		name, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			// Not a NAME=VALUE pair. Passed through untouched rather than dropped:
+			// it came from our own environment and is none of our business.
+			out = append(out, kv)
+			continue
+		}
+		if v, override := inject[name]; override {
+			if seen[name] {
+				// A duplicate of a name we are overriding: drop it, so the child sees
+				// one entry whichever end its runtime reads from.
+				continue
+			}
+			seen[name] = true
+			out = append(out, name+"="+v)
+			continue
+		}
+		out = append(out, kv)
+	}
+	// Names that were not in the environment at all.
+	rest := make([]string, 0, len(inject))
+	for k := range inject {
+		if !seen[k] {
+			rest = append(rest, k)
+		}
+	}
+	// Sorted, so the environment we hand the child is byte-identical run to run.
+	// Map order is randomised, and a non-deterministic env makes a failure that
+	// depends on it unreproducible.
+	sort.Strings(rest)
+	for _, k := range rest {
+		out = append(out, k+"="+inject[k])
+	}
+	return out
+}
+
+// printExecEnv writes the variables as shell export lines, in a fixed order:
+// proxy names then CA names, each group in the order declared, so the output is
+// diffable and reads as the two decisions it is rather than eight unrelated ones.
+func printExecEnv(inject map[string]string, stdout io.Writer) {
+	for _, k := range append(append([]string{}, execProxyVars...), execCAVars...) {
+		if v, ok := inject[k]; ok {
+			fmt.Fprintf(stdout, "export %s=%s\n", k, shellQuote(v))
+		}
+	}
+}
+
+// shellQuote makes s safe to eval. Paths can contain spaces (macOS
+// "Application Support" is the common one), and --print is documented as
+// eval-able, so an unquoted value would split mid-path and export a truncated CA
+// file — which fails verification with no hint as to why.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	// Single quotes make everything literal, so the only character needing care is
+	// the single quote itself: close, escape, reopen.
+	if !strings.ContainsAny(s, "'") && !strings.ContainsAny(s, " \t\n\"$`\\*?[]{}();&|<>#~!") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// cutArgs splits args at the first occurrence of sep, reporting whether it was
+// found. Unlike strings.Cut's byte semantics, matching is on whole arguments, so
+// a child argument that merely contains "--" is not a delimiter.
+func cutArgs(args []string, sep string) (before, after []string, found bool) {
+	for i, a := range args {
+		if a == sep {
+			return args[:i], args[i+1:], true
+		}
+	}
+	return args, nil, false
+}
+
+// signaledExitCode renders a death by signal the way a shell does: 128+signum.
+//
+// ExitCode() returns -1 for a signaled child, and os.Exit(-1) becomes 255, which
+// says "failed" but loses which signal — the difference between a Ctrl-C
+// (SIGINT, 130) and an out-of-memory kill (SIGKILL, 137) is exactly what someone
+// reading an exit status wants. Falls back to 1 when the platform does not give
+// us a WaitStatus to ask.
+func signaledExitCode(ee *exec.ExitError) int {
+	if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		return 128 + int(ws.Signal())
+	}
+	return 1
+}

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"flag"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
 )
 
 // exec runs one command with Cortex's proxy and CA already in its environment,
@@ -40,15 +43,51 @@ import (
 // the proxy itself and fail the handshake.
 var execProxyVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"}
 
-// execCAVars are the names that get the bridge CA path. Same reasoning: each
-// runtime invented its own. NODE_EXTRA_CA_CERTS is Node, CURL_CA_BUNDLE is
-// libcurl, REQUESTS_CA_BUNDLE is Python requests, SSL_CERT_FILE is OpenSSL and
-// most things built on it.
+// execCAExtraVars are the ADDITIVE trust variables: the runtime keeps its own
+// root store and adds this file to it. Node is the only one of the four that
+// works this way.
+var execCAExtraVars = []string{"NODE_EXTRA_CA_CERTS"}
+
+// execCAReplaceVars REPLACE the trust store: whatever file they name becomes the
+// complete set of roots. CURL_CA_BUNDLE is libcurl, REQUESTS_CA_BUNDLE is Python
+// requests, SSL_CERT_FILE is OpenSSL and most things built on it.
 //
-// Every one is a *_FILE / *_BUNDLE, not a directory, so all four take the same
-// ca.crt path; a tool wanting a hashed CA directory (SSL_CERT_DIR) is not served
-// here.
-var execCAVars = []string{"NODE_EXTRA_CA_CERTS", "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"}
+// This distinction is the whole reason execEnv writes a bundle instead of
+// pointing everything at ca.crt. ca.crt is a single certificate — the bridge CA
+// alone (tlsbridge/ca.go writes certPEM to it, not a chain) — so naming it here
+// would leave the child trusting exactly one CA and nothing else. Every request
+// the bridge does NOT terminate then fails verification against the real
+// upstream certificate: tls_bridge.passthrough_hosts, listener.skip_hosts, any
+// port outside tls_bridge.ports (default 443 + 8443), and the runtime
+// passthrough decisions in tlsbridge/decision.go (non-TLS bytes, skip list).
+// Verified rather than assumed: on a Linux/OpenSSL curl, CURL_CA_BUNDLE pointed
+// at a lone CA fails `curl https://example.com` with exit 77.
+//
+// So these get a concatenation of the system roots and the bridge CA, written to
+// a temp file for the child's lifetime. Bridged hosts verify against the bridge
+// CA; everything excluded from bridging still verifies against the public roots
+// it would have used anyway.
+var execCAReplaceVars = []string{"CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"}
+
+// execCAVars is every CA name, in the order --print emits them.
+var execCAVars = append(append([]string{}, execCAExtraVars...), execCAReplaceVars...)
+
+// systemRootFiles are the usual system CA bundle locations, in the order
+// crypto/x509 itself consults them (root_linux.go's certFiles, plus the common
+// BSD/macOS paths). The first one that exists is treated as the system store.
+//
+// Read from disk rather than via x509.SystemCertPool because the output has to
+// be a PEM *file* another process can open: SystemCertPool returns an opaque
+// pool whose certificates cannot be re-serialised (the DER is not retained on
+// every platform), so there is nothing to write back out.
+var systemRootFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Alpine(ish)
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+	"/etc/ssl/cert.pem",                                 // Alpine, macOS (Homebrew OpenSSL)
+}
 
 const execUsage = `abctl exec — run a command with Cortex's proxy and CA in its environment
 
@@ -66,8 +105,15 @@ The child inherits your environment plus these, read from ~/.cortex/config.yaml
 so they always match the running proxy:
 
   HTTP_PROXY  HTTPS_PROXY  http_proxy  https_proxy      the forward proxy URL
-  NODE_EXTRA_CA_CERTS  CURL_CA_BUNDLE                   the bridge CA file
-  REQUESTS_CA_BUNDLE   SSL_CERT_FILE
+  NODE_EXTRA_CA_CERTS                                   the bridge CA (added to
+                                                        the runtime's own roots)
+  CURL_CA_BUNDLE  REQUESTS_CA_BUNDLE  SSL_CERT_FILE     a temporary bundle of the
+                                                        system roots + bridge CA
+
+The last three REPLACE the trust store rather than extend it, so they get a
+bundle: naming the bridge CA alone would leave the child trusting one CA and
+break every host the bridge does not terminate (passthrough_hosts, skip_hosts,
+ports outside tls_bridge.ports). Requires tls_bridge.mode: enabled.
 
 Values already in your environment are replaced for this child only; nothing is
 exported to your shell and no file is modified. Signals go to the child, and
@@ -132,10 +178,25 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 		*cortexCfg = filepath.Join(home, cortexCfgRel)
 	}
 
-	inject, err := execEnv(*cortexCfg)
+	inject, cleanup, err := execEnv(*cortexCfg)
+	// errNoSystemRoots comes back WITH a usable bundle: the bridge CA is in it, so
+	// bridged hosts verify fine; only public trust is absent, and on an image with
+	// no root store there was none to begin with. Reported, not fatal.
+	if errors.Is(err, errNoSystemRoots) {
+		fmt.Fprintf(stderr, "abctl: note: no system CA bundle found on this machine, so the child\n"+
+			"  trusts only Cortex's bridge CA. Hosts the bridge does not terminate\n"+
+			"  (tls_bridge.passthrough_hosts, listener.skip_hosts, ports outside\n"+
+			"  tls_bridge.ports) will fail certificate verification.\n")
+		err = nil
+	}
 	if err != nil {
 		fmt.Fprintf(stderr, "abctl: %v\n", err)
 		return 1
+	}
+	// The bundle is a temp file scoped to this child, so it must go whichever way
+	// runExec returns — including the usage and not-found paths below.
+	if cleanup != nil {
+		defer cleanup()
 	}
 
 	// A CA path that does not exist yet is a warning, not an error: enabling
@@ -143,7 +204,10 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	// unlike the settings path, here the failure is loud rather than silent —
 	// Node and curl both refuse to start with a CA file they cannot read — so it
 	// is worth naming the cause before the child dies of it.
-	if ca := inject[execCAVars[0]]; ca != "" {
+	//
+	// Checked on the ADDITIVE var, which is the bridge CA itself; the replacing
+	// vars name the generated bundle, which by construction exists.
+	if ca := inject[execCAExtraVars[0]]; ca != "" {
 		if _, serr := os.Stat(ca); serr != nil {
 			fmt.Fprintf(stderr, "abctl: note: %s does not exist yet — Cortex writes it on first start.\n"+
 				"  TLS verification against the bridge will fail until then (abctl service start).\n", ca)
@@ -221,33 +285,143 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 // only way to guarantee that is one derivation. The telemetry key wanted() also
 // returns is dropped here — it is a Claude Code setting, and exec's child is
 // usually not Claude Code.
-func execEnv(cortexCfgPath string) (map[string]string, error) {
+func execEnv(cortexCfgPath string) (env map[string]string, cleanup func(), err error) {
 	want, err := wanted(cortexCfgPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	proxy := want[envProxy]
 	if proxy == "" {
-		return nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
+		return nil, nil, fmt.Errorf("%s yields no proxy address", cortexCfgPath)
 	}
+
+	// The bridge posture, not just the CA path. ca_dir is only *required* when
+	// mode is "enabled" (config.go's Validate), so `mode: disabled` with a ca_dir
+	// set is a perfectly valid config that this used to accept — and then injected
+	// a CA for a bridge that terminates nothing, so every https request in the
+	// child failed verification against the real upstream certificate. A harder
+	// break than the missing-ca_dir case, and silent about its cause.
+	cfg, cerr := config.Load(cortexCfgPath)
+	if cerr != nil {
+		return nil, nil, fmt.Errorf("reading %s: %w", cortexCfgPath, cerr)
+	}
+	// Empty mode means disabled, per TLSBridgeConfig.Mode's own documentation.
+	if cfg.TLSBridge == nil || cfg.TLSBridge.Mode != "enabled" {
+		return nil, nil, fmt.Errorf("%s has no enabled TLS bridge (tls_bridge.mode must be \"enabled\");\n"+
+			"  without it Cortex terminates no TLS, so the child would gain nothing and\n"+
+			"  every https request would fail verification. Enable the TLS bridge first", cortexCfgPath)
+	}
+
 	ca, ok := want[envCACerts]
 	if !ok || ca == "" {
 		// Refused rather than injecting the proxy alone. Without a trusted CA the
 		// bridge cannot terminate TLS, so every https request either fails
 		// verification or — worse, if the tool is lenient — tunnels through
 		// unparsed, which looks exactly like success while Cortex sees nothing.
-		return nil, fmt.Errorf("%s has no tls_bridge.ca_dir, so the child would have no CA to trust;\n"+
+		return nil, nil, fmt.Errorf("%s has no tls_bridge.ca_dir, so the child would have no CA to trust;\n"+
 			"  https requests through the bridge would fail verification. Enable the TLS bridge first", cortexCfgPath)
 	}
+
 	out := make(map[string]string, len(execProxyVars)+len(execCAVars))
 	for _, k := range execProxyVars {
 		out[k] = proxy
 	}
-	for _, k := range execCAVars {
+	// Additive names take the bridge CA directly — the runtime keeps its own roots.
+	for _, k := range execCAExtraVars {
 		out[k] = ca
 	}
-	return out, nil
+	// Replacing names take a bundle, so excluded hosts keep public trust.
+	bundle, cleanup, berr := writeTrustBundle(ca)
+	switch {
+	case errors.Is(berr, errNoBridgeCA):
+		// The CA is not on disk yet — Cortex writes it on first start, and enabling
+		// before then is legitimate (the caller warns about it). Leave the replacing
+		// vars UNSET rather than name a bundle without the bridge CA in it: unset
+		// means the child keeps its own public roots and only bridged hosts fail,
+		// which is the same state `claude-code enable` has always produced. Naming a
+		// bridge-CA-less bundle would instead break every host, bridged or not.
+		return out, cleanup, nil
+	case berr != nil && !errors.Is(berr, errNoSystemRoots):
+		return nil, cleanup, berr
+	}
+	for _, k := range execCAReplaceVars {
+		out[k] = bundle
+	}
+	// errNoSystemRoots is returned with a usable bundle; propagate it so the caller
+	// can report the missing public trust without treating it as a failure.
+	return out, cleanup, berr
 }
+
+// writeTrustBundle concatenates the system roots with the bridge CA and returns
+// the path to the result, plus a cleanup to remove it.
+//
+// Ordering is system-roots-then-bridge-CA, but only for readability: PEM trust
+// files are an unordered set, and every consumer parses all of them.
+//
+// A missing system store is not fatal. A distroless or scratch-based image may
+// genuinely have no root bundle, in which case the bridge CA alone is the whole
+// trust set — which is exactly right there, since such an image had no public
+// trust to lose. It is reported so the difference is not silent.
+func writeTrustBundle(caPath string) (path string, cleanup func(), err error) {
+	caPEM, err := os.ReadFile(caPath) //nolint:gosec // path derived from the operator's own config
+	if err != nil {
+		// Signalled, not fatal: the CA is written by Cortex on first start and exec
+		// deliberately works before that. The caller decides what to do — it leaves
+		// the replacing vars unset, because a bundle without the bridge CA is worse
+		// than no bundle at all.
+		return "", func() {}, fmt.Errorf("%w: %s: %v", errNoBridgeCA, caPath, err)
+	}
+
+	var buf []byte
+	for _, f := range systemRootFiles {
+		// Stat first: some of these paths are a DIRECTORY on some distros
+		// (/etc/ssl/certs is a hashed cert dir on Alpine), and ReadFile on a
+		// directory fails on Linux but succeeds with garbage on some systems.
+		if fi, serr := os.Stat(f); serr != nil || fi.IsDir() {
+			continue
+		}
+		b, rerr := os.ReadFile(f) //nolint:gosec // fixed list of well-known system paths
+		if rerr == nil && len(b) > 0 {
+			buf = append(buf, b...)
+			if !bytes.HasSuffix(buf, []byte("\n")) {
+				buf = append(buf, '\n')
+			}
+			break
+		}
+	}
+	systemFound := len(buf) > 0
+	buf = append(buf, caPEM...)
+
+	// 0600 in the process's temp dir: this is a trust store, and a world-writable
+	// one would let any local user add a root the child then trusts.
+	f, err := os.CreateTemp("", "abctl-trust-*.pem")
+	if err != nil {
+		return "", func() {}, err
+	}
+	name := f.Name()
+	rm := func() { _ = os.Remove(name) }
+	if _, werr := f.Write(buf); werr != nil {
+		f.Close()
+		rm()
+		return "", func() {}, werr
+	}
+	if cerr := f.Close(); cerr != nil {
+		rm()
+		return "", func() {}, cerr
+	}
+	if !systemFound {
+		return name, rm, errNoSystemRoots
+	}
+	return name, rm, nil
+}
+
+// errNoSystemRoots is returned alongside a usable bundle when no system CA store
+// was found, so the caller can say so without treating it as a failure.
+var errNoSystemRoots = errors.New("no system CA bundle found")
+
+// errNoBridgeCA means ca.crt is not on disk yet, which is an expected state
+// before Cortex's first start rather than a misconfiguration.
+var errNoBridgeCA = errors.New("bridge CA not written yet")
 
 // mergeEnv layers inject over env, replacing rather than appending.
 //

--- a/authbridge/cmd/abctl/cmd_exec.go
+++ b/authbridge/cmd/abctl/cmd_exec.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -205,9 +206,11 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	// Node and curl both refuse to start with a CA file they cannot read — so it
 	// is worth naming the cause before the child dies of it.
 	//
-	// Checked on the ADDITIVE var, which is the bridge CA itself; the replacing
-	// vars name the generated bundle, which by construction exists.
-	if ca := inject[execCAExtraVars[0]]; ca != "" {
+	// Checked on the additive name, which is the bridge CA itself; the replacing
+	// vars name the generated bundle, which by construction exists. Named
+	// explicitly rather than by list position, so this warning does not depend on
+	// the declaration order of a slice it does not own.
+	if ca := inject[envCACerts]; ca != "" {
 		if _, serr := os.Stat(ca); serr != nil {
 			fmt.Fprintf(stderr, "abctl: note: %s does not exist yet — Cortex writes it on first start.\n"+
 				"  TLS verification against the bridge will fail until then (abctl service start).\n", ca)
@@ -215,6 +218,15 @@ func runExec(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if *printOnly {
+		// Say so rather than silently discard it. Refusing outright would break
+		// `abctl exec --print --`, the documented form, and rejecting only the
+		// with-a-command form is a usage error for something harmless — but staying
+		// silent about an ignored command is the same discourtesy the strict check
+		// above exists to avoid.
+		if len(cmdArgs) > 0 {
+			fmt.Fprintf(stderr, "abctl: --print only prints the variables; %q was not run.\n",
+				strings.Join(cmdArgs, " "))
+		}
 		printExecEnv(inject, stdout)
 		return 0
 	}
@@ -242,6 +254,11 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 	}
 
 	cmd := exec.Command(path, argv[1:]...) //nolint:gosec // the command is the user's, given after --
+	// argv[0] as the user typed it, not the absolute path LookPath resolved.
+	// exec.Command would pass "/usr/bin/foo", but a shell passes "foo": multi-call
+	// binaries dispatch on argv[0], and tools echo it in their own usage and errors.
+	// cmd.Path keeps the resolved path, so the 127-on-not-found behaviour is intact.
+	cmd.Args[0] = argv[0]
 	cmd.Env = mergeEnv(os.Environ(), inject)
 	// The child gets this process's real stdio, not a pipe: it may be interactive
 	// (`abctl exec -- claude`), and a pipe would cost it the terminal, so it would
@@ -252,13 +269,46 @@ func runChild(argv []string, inject map[string]string, stdout, stderr io.Writer)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	// No signal forwarding, deliberately. The child is in this process's process
-	// group and shares the terminal, so a Ctrl-C at the keyboard is delivered by
-	// the tty driver to the whole group — the child included — and re-sending it
-	// would double the signal. Interactive children (claude, a REPL) rely on
-	// receiving SIGINT themselves; abctl dying first would orphan them mid-write.
-	// abctl has nothing of its own to clean up, so it just waits and reports.
-	if err := cmd.Run(); err != nil {
+	// Signal handling splits by how the signal arrives.
+	//
+	// tty-generated signals (SIGINT/SIGQUIT/SIGTSTP from a keystroke) are delivered
+	// by the tty driver to the whole foreground process group, so the child already
+	// gets them and relaying would double the signal. Those are left alone —
+	// interactive children rely on handling their own Ctrl-C.
+	//
+	// A signal aimed at abctl's PID is different: `timeout 30 abctl exec -- …`, a CI
+	// runner, or systemd sends SIGTERM to abctl alone. Go's default disposition then
+	// kills abctl and leaves the child running, orphaned, with the injected
+	// environment — and `timeout` in a Makefile is exactly what "safe in a pipeline
+	// or a Makefile" claims to support. So SIGTERM and SIGHUP are relayed, then abctl
+	// keeps waiting and still reports the child's real status.
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(stderr, "abctl: %s: %v\n", argv[0], err)
+		return 1
+	}
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGHUP)
+	relayDone := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case sig := <-sigs:
+				if p := cmd.Process; p != nil {
+					// Best-effort: the child may have exited between the signal and here,
+					// which is a benign race, not an error worth reporting.
+					_ = p.Signal(sig)
+				}
+			case <-relayDone:
+				return
+			}
+		}
+	}()
+	defer func() {
+		signal.Stop(sigs)
+		close(relayDone)
+	}()
+
+	if err := cmd.Wait(); err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
 			// A child killed by a signal has no exit code; ExitCode() returns -1.

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"errors"
+	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,8 +33,19 @@ func execCfg(t *testing.T) (cfgPath, caPath string) {
 	if err := os.WriteFile(caPath, []byte(testCAPEM), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// bundle.crt too: the proxy writes it on boot via tlsbridge.EnsureTrustBundle,
+	// so a fixture representing a started Cortex has both. execCfgNoCA covers the
+	// before-first-start state.
+	if err := os.WriteFile(filepath.Join(caDir, tlsbridge.TrustBundleName),
+		[]byte(testCAPEM+testRootPEM), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	return cfgPath, caPath
 }
+
+// testRootPEM stands in for the platform roots the real bundle concatenates after
+// the bridge CA.
+const testRootPEM = "-----BEGIN CERTIFICATE-----\nSYSTEMROOT\n-----END CERTIFICATE-----\n"
 
 // testCAPEM stands in for the bridge CA. Only its bytes matter here — nothing
 // under test parses it.
@@ -54,39 +65,45 @@ func execCfgNoCA(t *testing.T) (cfgPath, caPath string) {
 	return cfgPath, filepath.Join(caDir, "ca.crt")
 }
 
-// TestExecEnv_AllEightNamesFromTwoValues is the contract: eight variables, two
-// distinct values, both derived from the config rather than hardcoded.
-func TestExecEnv_AllEightNamesFromTwoValues(t *testing.T) {
+// exec injects every managed key except the Claude-Code-only telemetry switch,
+// plus the lowercase proxy spellings. Nine names, two distinct values: the proxy
+// URL, ca.crt for the one ADDITIVE variable, and bundle.crt for the four that
+// REPLACE the trust store.
+//
+// bundle.crt rather than ca.crt for those four is the property that matters — see
+// tlsbridge.TrustBundleName. Pointing them at the lone CA makes the child trust
+// the bridge and nothing else, so every unproxied TLS call fails.
+func TestExecEnv_InjectsManagedKeysPlusLowercaseProxies(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath, false)
+	env, err := execEnv(cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanup()
-	if len(env) != 8 {
-		t.Fatalf("want 8 variables, got %d: %v", len(env), env)
-	}
-	// The config fixture says forward_proxy_addr: 127.0.0.1:47600.
+
 	const wantProxy = "http://127.0.0.1:47600"
 	for _, k := range execProxyVars {
 		if env[k] != wantProxy {
 			t.Errorf("%s = %q, want %q", k, env[k], wantProxy)
 		}
 	}
-	// The additive var gets the bridge CA itself.
-	for _, k := range execCAExtraVars {
-		if env[k] != caPath {
-			t.Errorf("%s = %q, want the bridge CA %q", k, env[k], caPath)
+	// The additive variable takes the bridge CA itself.
+	if env[envCACerts] != caPath {
+		t.Errorf("%s = %q, want the bridge CA %q", envCACerts, env[envCACerts], caPath)
+	}
+	// The replacing variables take the bundle, never the lone CA.
+	wantBundle := filepath.Join(filepath.Dir(caPath), tlsbridge.TrustBundleName)
+	for _, k := range bundleKeys {
+		if env[k] == caPath {
+			t.Errorf("%s names the lone bridge CA; the child would lose all public trust", k)
+		}
+		if env[k] != wantBundle {
+			t.Errorf("%s = %q, want the bundle %q", k, env[k], wantBundle)
 		}
 	}
-	// The replacing vars must NOT name the lone CA — see execCAReplaceVars.
-	for _, k := range execCAReplaceVars {
-		if env[k] == caPath {
-			t.Errorf("%s = the lone bridge CA, which would drop all public trust", k)
-		}
-		if env[k] == "" {
-			t.Errorf("%s is unset", k)
-		}
+	// The telemetry switch is a Claude Code setting, not an environment concern for
+	// an arbitrary child.
+	if _, ok := env[envNoTelem]; ok {
+		t.Errorf("exec injected %s", envNoTelem)
 	}
 }
 
@@ -100,11 +117,10 @@ func TestExecEnv_MatchesClaudeCodeEnable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	env, cleanup, err := execEnv(cfgPath, false)
+	env, err := execEnv(cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cleanup()
 	if env["HTTPS_PROXY"] != want[envProxy] {
 		t.Errorf("exec HTTPS_PROXY = %q, enable writes %q", env["HTTPS_PROXY"], want[envProxy])
 	}
@@ -132,7 +148,7 @@ listener:
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := execEnv(cfgPath, false); err == nil {
+	if _, err := execEnv(cfgPath); err == nil {
 		t.Fatal("want an error when tls_bridge.ca_dir is absent, got nil")
 	}
 }
@@ -173,19 +189,28 @@ func TestRunExec_ChildSeesTheVariables(t *testing.T) {
 	}
 	cfgPath, caPath := execCfg(t)
 
-	// Pre-set two of the eight to wrong values, so this also proves replacement
-	// rather than "it happened to be unset".
+	// Pre-set two to wrong values, so this also proves replacement rather than
+	// "it happened to be unset".
 	t.Setenv("HTTPS_PROXY", "http://corporate.example:3128")
 	t.Setenv("SSL_CERT_FILE", "/etc/ssl/wrong.pem")
 
-	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--",
-		"/bin/sh", "-c", `for v in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy \
-			NODE_EXTRA_CA_CERTS CURL_CA_BUNDLE REQUESTS_CA_BUNDLE SSL_CERT_FILE; do
+	// The name list is built from the managed set, not written out by hand: a
+	// hardcoded list stopped covering GIT_SSL_CAINFO the moment authlib added it,
+	// and a variable this test does not name is a variable it cannot check.
+	names := append([]string{}, execProxyVars...)
+	for _, k := range managedKeys {
+		if k != envNoTelem {
+			names = append(names, k)
+		}
+	}
+	script := "for v in " + strings.Join(names, " ") + `; do
 			eval "printf '%s=%s\n' \"$v\" \"\$$v\""
 		done
-		# Prove the bundle is usable from inside the child, where it still exists.
-		grep -q BRIDGECA "$CURL_CA_BUNDLE" && echo BUNDLE_HAS_BRIDGE_CA`}, &stdout, &stderr)
+		# Prove the bundle is usable from inside the child.
+		grep -q BRIDGECA "$CURL_CA_BUNDLE" && echo BUNDLE_HAS_BRIDGE_CA`
+
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", script}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit %d: %s", code, stderr.String())
 	}
@@ -195,14 +220,14 @@ func TestRunExec_ChildSeesTheVariables(t *testing.T) {
 			t.Errorf("child did not see %s=http://127.0.0.1:47600\n%s", k, got)
 		}
 	}
-	for _, k := range execCAExtraVars {
+	for _, k := range []string{envCACerts} {
 		if !strings.Contains(got, k+"="+caPath+"\n") {
 			t.Errorf("child did not see %s=%s\n%s", k, caPath, got)
 		}
 	}
 	// The replacing vars name the generated bundle, not the lone CA, and the child
 	// must be able to read it.
-	for _, k := range execCAReplaceVars {
+	for _, k := range bundleKeys {
 		line := k + "="
 		i := strings.Index(got, line)
 		if i < 0 {
@@ -365,8 +390,17 @@ func TestRunExec_Print(t *testing.T) {
 		t.Fatalf("exit = %d: %s", code, stderr.String())
 	}
 	got := stdout.String()
-	if n := strings.Count(got, "export "); n != 8 {
-		t.Errorf("got %d export lines, want 8:\n%s", n, got)
+	// Nine: four proxy spellings, ca.crt for the additive name, and bundle.crt for
+	// the four replacing ones. Derived from the managed set rather than hardcoded,
+	// so adding a managed key does not silently go unprinted.
+	wantLines := len(execProxyVars) + len(managedKeys) - 1 // -1: HTTPS_PROXY counted once
+	for _, k := range managedKeys {
+		if k == envNoTelem {
+			wantLines-- // Claude-Code-only, never injected by exec
+		}
+	}
+	if n := strings.Count(got, "export "); n != wantLines {
+		t.Errorf("got %d export lines, want %d:\n%s", n, wantLines, got)
 	}
 	if !strings.Contains(got, "export HTTPS_PROXY=http://127.0.0.1:47600\n") {
 		t.Errorf("missing proxy export:\n%s", got)
@@ -431,97 +465,6 @@ func TestRunExec_SignaledChild(t *testing.T) {
 
 // --- Regression tests for the two blocking review findings (PR #916) ---
 
-// TestExecEnv_ReplacingVarsBundleSystemRoots is the first finding. ca.crt is a
-// single certificate, so pointing CURL_CA_BUNDLE / REQUESTS_CA_BUNDLE /
-// SSL_CERT_FILE at it replaced the child's whole trust store with one CA —
-// breaking every host the bridge does NOT terminate (passthrough_hosts,
-// skip_hosts, ports outside tls_bridge.ports). Confirmed against a Linux/OpenSSL
-// curl, which exits 77 in that configuration.
-//
-// The bundle must therefore contain the bridge CA *and*, when the machine has
-// one, the system roots.
-func TestExecEnv_ReplacingVarsBundleSystemRoots(t *testing.T) {
-	cfgPath, caPath := execCfg(t)
-	const caBody = testCAPEM
-
-	env, cleanup, err := execEnv(cfgPath, false)
-	if err != nil && !errors.Is(err, errNoSystemRoots) {
-		t.Fatal(err)
-	}
-	defer cleanup()
-
-	bundlePath := env["CURL_CA_BUNDLE"]
-	if bundlePath == caPath {
-		t.Fatal("CURL_CA_BUNDLE names the lone bridge CA; public trust would be lost")
-	}
-	// All three replacing vars must agree on the one bundle.
-	for _, k := range execCAReplaceVars {
-		if env[k] != bundlePath {
-			t.Errorf("%s = %q, want the shared bundle %q", k, env[k], bundlePath)
-		}
-	}
-
-	got, rerr := os.ReadFile(bundlePath)
-	if rerr != nil {
-		t.Fatalf("bundle unreadable: %v", rerr)
-	}
-	if !strings.Contains(string(got), "BRIDGECA") {
-		t.Error("bundle omits the bridge CA, so bridged hosts would fail verification")
-	}
-	// If this machine has a system store, the bundle must be strictly larger than
-	// the bridge CA alone — that difference IS the retained public trust.
-	var systemFound bool
-	for _, f := range systemRootFiles {
-		if b, e := os.ReadFile(f); e == nil && len(b) > 0 {
-			systemFound = true
-			break
-		}
-	}
-	if systemFound && len(got) <= len(caBody) {
-		t.Errorf("bundle is %d bytes, no larger than the bridge CA alone (%d); system roots were dropped",
-			len(got), len(caBody))
-	}
-	if !systemFound {
-		t.Logf("no system CA store on this machine; skipped the public-trust size check")
-	}
-}
-
-// TestExecEnv_CleanupRemovesBundle: the bundle is a temp file scoped to one
-// child, so it must not accumulate in the temp dir across invocations.
-func TestExecEnv_CleanupRemovesBundle(t *testing.T) {
-	cfgPath, _ := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath, false)
-	if err != nil && !errors.Is(err, errNoSystemRoots) {
-		t.Fatal(err)
-	}
-	bundle := env["CURL_CA_BUNDLE"]
-	if _, serr := os.Stat(bundle); serr != nil {
-		t.Fatalf("bundle missing before cleanup: %v", serr)
-	}
-	cleanup()
-	if _, serr := os.Stat(bundle); !os.IsNotExist(serr) {
-		t.Errorf("bundle survived cleanup at %s", bundle)
-	}
-}
-
-// TestExecEnv_BundleIsNotWorldWritable: it is a trust store. A world-writable one
-// would let any local user add a root the child then trusts.
-func TestExecEnv_BundleIsNotWorldWritable(t *testing.T) {
-	cfgPath, _ := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath, false)
-	if err != nil && !errors.Is(err, errNoSystemRoots) {
-		t.Fatal(err)
-	}
-	defer cleanup()
-	fi, serr := os.Stat(env["SSL_CERT_FILE"])
-	if serr != nil {
-		t.Fatal(serr)
-	}
-	if perm := fi.Mode().Perm(); perm&0o022 != 0 {
-		t.Errorf("bundle mode is %04o; group/other must not be writable", perm)
-	}
-}
-
 // TestExecEnv_DisabledBridgeIsRefused is the second finding. ca_dir is only
 // *required* when mode is "enabled", so `mode: disabled` with a ca_dir set is a
 // valid config that used to be accepted — injecting a CA for a bridge that
@@ -541,7 +484,7 @@ func TestExecEnv_DisabledBridgeIsRefused(t *testing.T) {
 			if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			_, _, err := execEnv(cfgPath, false)
+			_, err := execEnv(cfgPath)
 			if err == nil {
 				t.Fatal("want an error when the bridge is not enabled, got nil")
 			}
@@ -572,44 +515,6 @@ func TestRunExec_DisabledBridgeExitsBeforeRunning(t *testing.T) {
 	}
 	if _, err := os.Stat(marker); err == nil {
 		t.Error("the command ran despite the disabled bridge")
-	}
-}
-
-// TestExecEnv_BeforeFirstStart_LeavesReplacingVarsUnset. Cortex writes ca.crt on
-// boot, and enabling before that is legitimate — so exec must still run the
-// child. But the replacing vars must be left UNSET rather than pointed at a
-// bundle with no bridge CA in it: unset costs only the bridged hosts (the same
-// state `claude-code enable` has always produced), whereas a bridge-CA-less
-// bundle would break every host, bridged or not.
-//
-// This is the regression that making an unreadable CA fatal introduced.
-func TestExecEnv_BeforeFirstStart_LeavesReplacingVarsUnset(t *testing.T) {
-	cfgPath, caPath := execCfgNoCA(t)
-	if _, err := os.Stat(caPath); err == nil {
-		t.Fatal("fixture should not have created ca.crt")
-	}
-	env, cleanup, err := execEnv(cfgPath, false)
-	if err != nil {
-		t.Fatalf("a not-yet-written CA must not be fatal: %v", err)
-	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-	// The proxy is still worth setting — that half works before first start.
-	for _, k := range execProxyVars {
-		if env[k] == "" {
-			t.Errorf("%s should still be set", k)
-		}
-	}
-	// The additive var is harmless when the file is missing: Node warns, keeps its
-	// own roots. This matches what `claude-code enable` writes.
-	if env["NODE_EXTRA_CA_CERTS"] != caPath {
-		t.Errorf("NODE_EXTRA_CA_CERTS = %q, want %q", env["NODE_EXTRA_CA_CERTS"], caPath)
-	}
-	for _, k := range execCAReplaceVars {
-		if v, ok := env[k]; ok {
-			t.Errorf("%s = %q; must be unset before the CA exists, or the child loses all trust", k, v)
-		}
 	}
 }
 
@@ -812,141 +717,6 @@ func TestRunExec_PreservesInheritedNoProxy(t *testing.T) {
 
 // --- Regression tests for the second review round (PR #916) ---
 
-// TestRunExec_PrintBundleOutlivesTheProcess is the blocking finding. --print
-// emitted the temp bundle's path and then `defer cleanup()` deleted the file, so
-// the documented `eval "$(abctl exec --print --)"` exported a path to nothing and
-// every https request failed with curl's "error setting certificate verify
-// locations". Reproduced by hand before the fix.
-//
-// The check that matters is stat-ing the path AFTER runExec returns —
-// TestRunExec_Print counted export lines and grepped for the additive var, so it
-// never touched the file the three replacing vars name.
-func TestRunExec_PrintBundleOutlivesTheProcess(t *testing.T) {
-	cfgPath, _ := execCfg(t)
-	var stdout, stderr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &stdout, &stderr); code != 0 {
-		t.Fatalf("exit = %d: %s", code, stderr.String())
-	}
-
-	// Pull the bundle path back out of the printed exports, the way a shell would.
-	var bundle string
-	for _, ln := range strings.Split(stdout.String(), "\n") {
-		if rest, ok := strings.CutPrefix(ln, "export CURL_CA_BUNDLE="); ok {
-			bundle = strings.Trim(rest, "'")
-			break
-		}
-	}
-	if bundle == "" {
-		t.Fatalf("--print emitted no CURL_CA_BUNDLE:\n%s", stdout.String())
-	}
-
-	b, err := os.ReadFile(bundle)
-	if err != nil {
-		t.Fatalf("the path --print exported does not exist after abctl exits: %v\n"+
-			"  `eval \"$(abctl exec --print --)\"` would export a dangling CA path", err)
-	}
-	if !strings.Contains(string(b), "BRIDGECA") {
-		t.Error("the persisted bundle omits the bridge CA")
-	}
-}
-
-// The persisted bundle is rewritten in place rather than accumulating one file per
-// eval, and a rotated CA is picked up.
-func TestRunExec_PrintBundleIsStableAndRefreshed(t *testing.T) {
-	cfgPath, caPath := execCfg(t)
-	run := func() string {
-		var stdout, stderr bytes.Buffer
-		if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &stdout, &stderr); code != 0 {
-			t.Fatalf("exit %d: %s", code, stderr.String())
-		}
-		for _, ln := range strings.Split(stdout.String(), "\n") {
-			if rest, ok := strings.CutPrefix(ln, "export SSL_CERT_FILE="); ok {
-				return strings.Trim(rest, "'")
-			}
-		}
-		t.Fatal("no SSL_CERT_FILE in --print output")
-		return ""
-	}
-
-	first := run()
-	second := run()
-	if first != second {
-		t.Errorf("--print produced two different paths (%s, %s); every eval would leak one", first, second)
-	}
-	// It must live beside the CA, not in the temp dir.
-	if filepath.Dir(first) != filepath.Dir(caPath) {
-		t.Errorf("bundle at %s, want it beside the CA in %s", first, filepath.Dir(caPath))
-	}
-
-	// Rotate the CA; the next --print must reflect it.
-	if err := os.WriteFile(caPath, []byte("-----BEGIN CERTIFICATE-----\nROTATED\n-----END CERTIFICATE-----\n"), 0o644); err != nil { //nolint:gosec // test fixture
-		t.Fatal(err)
-	}
-	run()
-	b, err := os.ReadFile(first)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(b), "ROTATED") {
-		t.Error("the bundle was not refreshed after the CA rotated")
-	}
-}
-
-// The child path must still use a temp bundle that IS cleaned up — the persisted
-// path is only for --print.
-func TestExecEnv_ChildBundleIsStillTemporary(t *testing.T) {
-	cfgPath, caPath := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath, false)
-	if err != nil && !errors.Is(err, errNoSystemRoots) {
-		t.Fatal(err)
-	}
-	bundle := env["CURL_CA_BUNDLE"]
-	if filepath.Dir(bundle) == filepath.Dir(caPath) {
-		t.Errorf("child bundle at %s is the persisted path; it should be a temp file", bundle)
-	}
-	cleanup()
-	if _, serr := os.Stat(bundle); !os.IsNotExist(serr) {
-		t.Errorf("child bundle survived cleanup at %s", bundle)
-	}
-}
-
-// TestWriteTrustBundle_NoSystemRoots covers the errNoSystemRoots branch, which is
-// otherwise reachable only on a machine with no root store — so it never ran in
-// CI, and the test that mentions it degraded to a t.Logf there. systemRootFiles is
-// a package var precisely so it can be swapped.
-func TestWriteTrustBundle_NoSystemRoots(t *testing.T) {
-	saved := systemRootFiles
-	systemRootFiles = []string{filepath.Join(t.TempDir(), "definitely-absent")}
-	t.Cleanup(func() { systemRootFiles = saved })
-
-	cfgPath, _ := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath, false)
-	if !errors.Is(err, errNoSystemRoots) {
-		t.Fatalf("want errNoSystemRoots, got %v", err)
-	}
-	defer cleanup()
-
-	// A usable bundle comes back regardless: on an image with no root store the
-	// bridge CA alone is the whole trust set, which is correct there.
-	b, rerr := os.ReadFile(env["CURL_CA_BUNDLE"])
-	if rerr != nil {
-		t.Fatalf("no bundle despite the sentinel being advisory: %v", rerr)
-	}
-	if !strings.Contains(string(b), "BRIDGECA") {
-		t.Error("bundle omits the bridge CA")
-	}
-
-	// And runExec reports it without failing.
-	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", "echo ran"}, &stdout, &stderr)
-	if code != 0 {
-		t.Errorf("exit = %d, want 0; a missing system store is advisory", code)
-	}
-	if !strings.Contains(stderr.String(), "no system CA bundle") {
-		t.Errorf("expected the missing-roots note:\n%s", stderr.String())
-	}
-}
-
 // TestClaudeCodeEnable_DisabledBridgeIsRefused. The tls_bridge.mode gate was
 // exec-only, so the two commands drifted on exactly the check whose comment claims
 // they cannot: `abctl exec` refused `mode: disabled` + ca_dir, while
@@ -988,7 +758,7 @@ func TestBridgeGate_ExecAndEnableAgree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, execErr := execEnv(cfgPath, false)
+	_, execErr := execEnv(cfgPath)
 	if execErr == nil {
 		t.Fatal("exec accepted a disabled bridge")
 	}

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,6 +20,34 @@ func execCfg(t *testing.T) (cfgPath, caPath string) {
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	// Write ca.crt, so the fixture represents a Cortex that has started at least
+	// once — the normal case, and the only one where the replacing CA vars are set.
+	// execCfgNoCA covers the pre-first-start state.
+	if err := os.MkdirAll(caDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	caPath = filepath.Join(caDir, "ca.crt")
+	if err := os.WriteFile(caPath, []byte(testCAPEM), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath, caPath
+}
+
+// testCAPEM stands in for the bridge CA. Only its bytes matter here — nothing
+// under test parses it.
+const testCAPEM = "-----BEGIN CERTIFICATE-----\nBRIDGECA\n-----END CERTIFICATE-----\n"
+
+// execCfgNoCA is execCfg without ca.crt on disk: Cortex configured but never
+// started.
+func execCfgNoCA(t *testing.T) (cfgPath, caPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	caDir := filepath.Join(dir, "ca")
+	cfgPath = filepath.Join(dir, "config.yaml")
+	body := strings.Replace(cortexCfg, "CADIR", caDir, 1)
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	return cfgPath, filepath.Join(caDir, "ca.crt")
 }
 
@@ -26,10 +55,11 @@ func execCfg(t *testing.T) (cfgPath, caPath string) {
 // distinct values, both derived from the config rather than hardcoded.
 func TestExecEnv_AllEightNamesFromTwoValues(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
-	env, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer cleanup()
 	if len(env) != 8 {
 		t.Fatalf("want 8 variables, got %d: %v", len(env), env)
 	}
@@ -40,9 +70,19 @@ func TestExecEnv_AllEightNamesFromTwoValues(t *testing.T) {
 			t.Errorf("%s = %q, want %q", k, env[k], wantProxy)
 		}
 	}
-	for _, k := range execCAVars {
+	// The additive var gets the bridge CA itself.
+	for _, k := range execCAExtraVars {
 		if env[k] != caPath {
-			t.Errorf("%s = %q, want %q", k, env[k], caPath)
+			t.Errorf("%s = %q, want the bridge CA %q", k, env[k], caPath)
+		}
+	}
+	// The replacing vars must NOT name the lone CA — see execCAReplaceVars.
+	for _, k := range execCAReplaceVars {
+		if env[k] == caPath {
+			t.Errorf("%s = the lone bridge CA, which would drop all public trust", k)
+		}
+		if env[k] == "" {
+			t.Errorf("%s is unset", k)
 		}
 	}
 }
@@ -57,10 +97,11 @@ func TestExecEnv_MatchesClaudeCodeEnable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	env, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer cleanup()
 	if env["HTTPS_PROXY"] != want[envProxy] {
 		t.Errorf("exec HTTPS_PROXY = %q, enable writes %q", env["HTTPS_PROXY"], want[envProxy])
 	}
@@ -88,7 +129,7 @@ listener:
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := execEnv(cfgPath); err == nil {
+	if _, _, err := execEnv(cfgPath); err == nil {
 		t.Fatal("want an error when tls_bridge.ca_dir is absent, got nil")
 	}
 }
@@ -139,7 +180,9 @@ func TestRunExec_ChildSeesTheVariables(t *testing.T) {
 		"/bin/sh", "-c", `for v in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy \
 			NODE_EXTRA_CA_CERTS CURL_CA_BUNDLE REQUESTS_CA_BUNDLE SSL_CERT_FILE; do
 			eval "printf '%s=%s\n' \"$v\" \"\$$v\""
-		done`}, &stdout, &stderr)
+		done
+		# Prove the bundle is usable from inside the child, where it still exists.
+		grep -q BRIDGECA "$CURL_CA_BUNDLE" && echo BUNDLE_HAS_BRIDGE_CA`}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit %d: %s", code, stderr.String())
 	}
@@ -149,10 +192,32 @@ func TestRunExec_ChildSeesTheVariables(t *testing.T) {
 			t.Errorf("child did not see %s=http://127.0.0.1:47600\n%s", k, got)
 		}
 	}
-	for _, k := range execCAVars {
+	for _, k := range execCAExtraVars {
 		if !strings.Contains(got, k+"="+caPath+"\n") {
 			t.Errorf("child did not see %s=%s\n%s", k, caPath, got)
 		}
+	}
+	// The replacing vars name the generated bundle, not the lone CA, and the child
+	// must be able to read it.
+	for _, k := range execCAReplaceVars {
+		line := k + "="
+		i := strings.Index(got, line)
+		if i < 0 {
+			t.Errorf("child did not see %s\n%s", k, got)
+			continue
+		}
+		v := got[i+len(line):]
+		if j := strings.IndexByte(v, '\n'); j >= 0 {
+			v = v[:j]
+		}
+		if v == caPath {
+			t.Errorf("%s names the lone bridge CA; public trust would be lost", k)
+		}
+	}
+	// Asserted from the child's output: the bundle is deliberately removed when
+	// runExec returns, so it cannot be read from here.
+	if !strings.Contains(got, "BUNDLE_HAS_BRIDGE_CA") {
+		t.Errorf("the child could not read a bundle containing the bridge CA\n%s", got)
 	}
 }
 
@@ -358,5 +423,209 @@ func TestRunExec_SignaledChild(t *testing.T) {
 		"/bin/sh", "-c", "kill -9 $$"}, &stdout, &stderr)
 	if code != 137 {
 		t.Errorf("exit = %d, want 137 (128+SIGKILL)", code)
+	}
+}
+
+// --- Regression tests for the two blocking review findings (PR #916) ---
+
+// TestExecEnv_ReplacingVarsBundleSystemRoots is the first finding. ca.crt is a
+// single certificate, so pointing CURL_CA_BUNDLE / REQUESTS_CA_BUNDLE /
+// SSL_CERT_FILE at it replaced the child's whole trust store with one CA —
+// breaking every host the bridge does NOT terminate (passthrough_hosts,
+// skip_hosts, ports outside tls_bridge.ports). Confirmed against a Linux/OpenSSL
+// curl, which exits 77 in that configuration.
+//
+// The bundle must therefore contain the bridge CA *and*, when the machine has
+// one, the system roots.
+func TestExecEnv_ReplacingVarsBundleSystemRoots(t *testing.T) {
+	cfgPath, caPath := execCfg(t)
+	const caBody = testCAPEM
+
+	env, cleanup, err := execEnv(cfgPath)
+	if err != nil && !errors.Is(err, errNoSystemRoots) {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	bundlePath := env["CURL_CA_BUNDLE"]
+	if bundlePath == caPath {
+		t.Fatal("CURL_CA_BUNDLE names the lone bridge CA; public trust would be lost")
+	}
+	// All three replacing vars must agree on the one bundle.
+	for _, k := range execCAReplaceVars {
+		if env[k] != bundlePath {
+			t.Errorf("%s = %q, want the shared bundle %q", k, env[k], bundlePath)
+		}
+	}
+
+	got, rerr := os.ReadFile(bundlePath)
+	if rerr != nil {
+		t.Fatalf("bundle unreadable: %v", rerr)
+	}
+	if !strings.Contains(string(got), "BRIDGECA") {
+		t.Error("bundle omits the bridge CA, so bridged hosts would fail verification")
+	}
+	// If this machine has a system store, the bundle must be strictly larger than
+	// the bridge CA alone — that difference IS the retained public trust.
+	var systemFound bool
+	for _, f := range systemRootFiles {
+		if b, e := os.ReadFile(f); e == nil && len(b) > 0 {
+			systemFound = true
+			break
+		}
+	}
+	if systemFound && len(got) <= len(caBody) {
+		t.Errorf("bundle is %d bytes, no larger than the bridge CA alone (%d); system roots were dropped",
+			len(got), len(caBody))
+	}
+	if !systemFound {
+		t.Logf("no system CA store on this machine; skipped the public-trust size check")
+	}
+}
+
+// TestExecEnv_CleanupRemovesBundle: the bundle is a temp file scoped to one
+// child, so it must not accumulate in the temp dir across invocations.
+func TestExecEnv_CleanupRemovesBundle(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	env, cleanup, err := execEnv(cfgPath)
+	if err != nil && !errors.Is(err, errNoSystemRoots) {
+		t.Fatal(err)
+	}
+	bundle := env["CURL_CA_BUNDLE"]
+	if _, serr := os.Stat(bundle); serr != nil {
+		t.Fatalf("bundle missing before cleanup: %v", serr)
+	}
+	cleanup()
+	if _, serr := os.Stat(bundle); !os.IsNotExist(serr) {
+		t.Errorf("bundle survived cleanup at %s", bundle)
+	}
+}
+
+// TestExecEnv_BundleIsNotWorldWritable: it is a trust store. A world-writable one
+// would let any local user add a root the child then trusts.
+func TestExecEnv_BundleIsNotWorldWritable(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	env, cleanup, err := execEnv(cfgPath)
+	if err != nil && !errors.Is(err, errNoSystemRoots) {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	fi, serr := os.Stat(env["SSL_CERT_FILE"])
+	if serr != nil {
+		t.Fatal(serr)
+	}
+	if perm := fi.Mode().Perm(); perm&0o022 != 0 {
+		t.Errorf("bundle mode is %04o; group/other must not be writable", perm)
+	}
+}
+
+// TestExecEnv_DisabledBridgeIsRefused is the second finding. ca_dir is only
+// *required* when mode is "enabled", so `mode: disabled` with a ca_dir set is a
+// valid config that used to be accepted — injecting a CA for a bridge that
+// terminates nothing, which fails every https request in the child.
+func TestExecEnv_DisabledBridgeIsRefused(t *testing.T) {
+	for _, mode := range []string{"disabled", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			body := "mode: proxy-sidecar\n" +
+				"listener:\n  roles: [forward]\n  forward_proxy_addr: \"127.0.0.1:47600\"\n" +
+				"tls_bridge:\n"
+			if mode != "" {
+				body += "  mode: " + mode + "\n"
+			}
+			body += "  ca_dir: \"" + filepath.Join(dir, "ca") + "\"\n"
+			if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, _, err := execEnv(cfgPath)
+			if err == nil {
+				t.Fatal("want an error when the bridge is not enabled, got nil")
+			}
+			if !strings.Contains(err.Error(), "tls_bridge.mode") {
+				t.Errorf("error should name tls_bridge.mode, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestRunExec_DisabledBridgeExitsBeforeRunning: the guard must refuse rather than
+// run the command with broken TLS settings.
+func TestRunExec_DisabledBridgeExitsBeforeRunning(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	body := "mode: proxy-sidecar\n" +
+		"listener:\n  roles: [forward]\n  forward_proxy_addr: \"127.0.0.1:47600\"\n" +
+		"tls_bridge:\n  mode: disabled\n  ca_dir: \"" + filepath.Join(dir, "ca") + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(dir, "ran")
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--",
+		"/bin/sh", "-c", "touch " + marker}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("the command ran despite the disabled bridge")
+	}
+}
+
+// TestExecEnv_BeforeFirstStart_LeavesReplacingVarsUnset. Cortex writes ca.crt on
+// boot, and enabling before that is legitimate — so exec must still run the
+// child. But the replacing vars must be left UNSET rather than pointed at a
+// bundle with no bridge CA in it: unset costs only the bridged hosts (the same
+// state `claude-code enable` has always produced), whereas a bridge-CA-less
+// bundle would break every host, bridged or not.
+//
+// This is the regression that making an unreadable CA fatal introduced.
+func TestExecEnv_BeforeFirstStart_LeavesReplacingVarsUnset(t *testing.T) {
+	cfgPath, caPath := execCfgNoCA(t)
+	if _, err := os.Stat(caPath); err == nil {
+		t.Fatal("fixture should not have created ca.crt")
+	}
+	env, cleanup, err := execEnv(cfgPath)
+	if err != nil {
+		t.Fatalf("a not-yet-written CA must not be fatal: %v", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	// The proxy is still worth setting — that half works before first start.
+	for _, k := range execProxyVars {
+		if env[k] == "" {
+			t.Errorf("%s should still be set", k)
+		}
+	}
+	// The additive var is harmless when the file is missing: Node warns, keeps its
+	// own roots. This matches what `claude-code enable` writes.
+	if env["NODE_EXTRA_CA_CERTS"] != caPath {
+		t.Errorf("NODE_EXTRA_CA_CERTS = %q, want %q", env["NODE_EXTRA_CA_CERTS"], caPath)
+	}
+	for _, k := range execCAReplaceVars {
+		if v, ok := env[k]; ok {
+			t.Errorf("%s = %q; must be unset before the CA exists, or the child loses all trust", k, v)
+		}
+	}
+}
+
+// TestRunExec_BeforeFirstStart_StillRuns pairs with the above: the command runs,
+// and the note about the missing CA is printed.
+func TestRunExec_BeforeFirstStart_StillRuns(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfgNoCA(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", "echo ran"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "ran" {
+		t.Errorf("child did not run: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "does not exist yet") {
+		t.Errorf("expected a note about the missing CA:\n%s", stderr.String())
 	}
 }

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"sort"
@@ -940,5 +941,59 @@ func TestExecEnv_RejectsAMalformedStatsURL(t *testing.T) {
 func TestDefaultCortexStatsURL(t *testing.T) {
 	if defaultCortexStatsURL != "http://localhost:47602/" {
 		t.Errorf("defaultCortexStatsURL = %q, want http://localhost:47602/", defaultCortexStatsURL)
+	}
+}
+
+// The help block must list exactly the variables exec injects.
+//
+// Every one of the five findings in the review round that produced this test was
+// text describing an older implementation, and two of them were this specific
+// drift: the help block omitted GIT_SSL_CAINFO once authlib added it, and called
+// bundle.crt "a temporary bundle" after it stopped being one. Both were invisible
+// to the suite — the help text is a string constant nothing asserted on.
+//
+// Names only. The prose around them is a human's job to keep honest, but the set
+// of variable names is mechanical, so it should not depend on anyone remembering.
+func TestExecUsage_ListsExactlyTheInjectedVariables(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	inject, err := execEnv(execStats(t, cfgPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The block between the "child inherits" line and the paragraph after the table:
+	// the variable names live there, and nowhere else in the usage text does an
+	// ALL-CAPS env-var-shaped token appear.
+	start := strings.Index(execUsage, "The child inherits")
+	end := strings.Index(execUsage, "Those last four REPLACE")
+	if start < 0 || end < 0 || end <= start {
+		t.Fatal("could not locate the variable block in execUsage; update this test's anchors")
+	}
+	block := execUsage[start:end]
+
+	// Env-var-shaped tokens: upper or lower snake case, at least two segments, so
+	// prose words like ADDED and REPLACE do not match.
+	re := regexp.MustCompile(`\b[A-Za-z]+(?:_[A-Za-z]+)+\b`)
+	listed := map[string]bool{}
+	for _, m := range re.FindAllString(block, -1) {
+		// Only count it if it is actually one of ours or is env-var-shaped enough to
+		// be a claim about one; anything else in the block is prose.
+		if strings.ToUpper(m) == m || strings.ToLower(m) == m {
+			listed[m] = true
+		}
+	}
+
+	for name := range inject {
+		if !listed[name] {
+			t.Errorf("exec injects %s but the help block does not list it", name)
+		}
+	}
+	for name := range listed {
+		if _, ok := inject[name]; !ok {
+			t.Errorf("the help block lists %s but exec does not inject it", name)
+		}
+	}
+	if len(listed) != len(inject) {
+		t.Errorf("help lists %d names, exec injects %d", len(listed), len(inject))
 	}
 }

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -58,7 +58,7 @@ func execCfgNoCA(t *testing.T) (cfgPath, caPath string) {
 // distinct values, both derived from the config rather than hardcoded.
 func TestExecEnv_AllEightNamesFromTwoValues(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestExecEnv_MatchesClaudeCodeEnable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	env, cleanup, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ listener:
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := execEnv(cfgPath); err == nil {
+	if _, _, err := execEnv(cfgPath, false); err == nil {
 		t.Fatal("want an error when tls_bridge.ca_dir is absent, got nil")
 	}
 }
@@ -444,7 +444,7 @@ func TestExecEnv_ReplacingVarsBundleSystemRoots(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
 	const caBody = testCAPEM
 
-	env, cleanup, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath, false)
 	if err != nil && !errors.Is(err, errNoSystemRoots) {
 		t.Fatal(err)
 	}
@@ -490,7 +490,7 @@ func TestExecEnv_ReplacingVarsBundleSystemRoots(t *testing.T) {
 // child, so it must not accumulate in the temp dir across invocations.
 func TestExecEnv_CleanupRemovesBundle(t *testing.T) {
 	cfgPath, _ := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath, false)
 	if err != nil && !errors.Is(err, errNoSystemRoots) {
 		t.Fatal(err)
 	}
@@ -508,7 +508,7 @@ func TestExecEnv_CleanupRemovesBundle(t *testing.T) {
 // would let any local user add a root the child then trusts.
 func TestExecEnv_BundleIsNotWorldWritable(t *testing.T) {
 	cfgPath, _ := execCfg(t)
-	env, cleanup, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath, false)
 	if err != nil && !errors.Is(err, errNoSystemRoots) {
 		t.Fatal(err)
 	}
@@ -541,7 +541,7 @@ func TestExecEnv_DisabledBridgeIsRefused(t *testing.T) {
 			if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			_, _, err := execEnv(cfgPath)
+			_, _, err := execEnv(cfgPath, false)
 			if err == nil {
 				t.Fatal("want an error when the bridge is not enabled, got nil")
 			}
@@ -588,7 +588,7 @@ func TestExecEnv_BeforeFirstStart_LeavesReplacingVarsUnset(t *testing.T) {
 	if _, err := os.Stat(caPath); err == nil {
 		t.Fatal("fixture should not have created ca.crt")
 	}
-	env, cleanup, err := execEnv(cfgPath)
+	env, cleanup, err := execEnv(cfgPath, false)
 	if err != nil {
 		t.Fatalf("a not-yet-written CA must not be fatal: %v", err)
 	}
@@ -758,5 +758,197 @@ func TestRunExec_PreservesInheritedNoProxy(t *testing.T) {
 	if !strings.Contains(got, "NO_PROXY=internal.example.com,.corp") ||
 		!strings.Contains(got, "no_proxy=internal.example.com") {
 		t.Errorf("NO_PROXY was not preserved:\n%s", got)
+	}
+}
+
+// --- Regression tests for the second review round (PR #916) ---
+
+// TestRunExec_PrintBundleOutlivesTheProcess is the blocking finding. --print
+// emitted the temp bundle's path and then `defer cleanup()` deleted the file, so
+// the documented `eval "$(abctl exec --print --)"` exported a path to nothing and
+// every https request failed with curl's "error setting certificate verify
+// locations". Reproduced by hand before the fix.
+//
+// The check that matters is stat-ing the path AFTER runExec returns —
+// TestRunExec_Print counted export lines and grepped for the additive var, so it
+// never touched the file the three replacing vars name.
+func TestRunExec_PrintBundleOutlivesTheProcess(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr.String())
+	}
+
+	// Pull the bundle path back out of the printed exports, the way a shell would.
+	var bundle string
+	for _, ln := range strings.Split(stdout.String(), "\n") {
+		if rest, ok := strings.CutPrefix(ln, "export CURL_CA_BUNDLE="); ok {
+			bundle = strings.Trim(rest, "'")
+			break
+		}
+	}
+	if bundle == "" {
+		t.Fatalf("--print emitted no CURL_CA_BUNDLE:\n%s", stdout.String())
+	}
+
+	b, err := os.ReadFile(bundle)
+	if err != nil {
+		t.Fatalf("the path --print exported does not exist after abctl exits: %v\n"+
+			"  `eval \"$(abctl exec --print --)\"` would export a dangling CA path", err)
+	}
+	if !strings.Contains(string(b), "BRIDGECA") {
+		t.Error("the persisted bundle omits the bridge CA")
+	}
+}
+
+// The persisted bundle is rewritten in place rather than accumulating one file per
+// eval, and a rotated CA is picked up.
+func TestRunExec_PrintBundleIsStableAndRefreshed(t *testing.T) {
+	cfgPath, caPath := execCfg(t)
+	run := func() string {
+		var stdout, stderr bytes.Buffer
+		if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("exit %d: %s", code, stderr.String())
+		}
+		for _, ln := range strings.Split(stdout.String(), "\n") {
+			if rest, ok := strings.CutPrefix(ln, "export SSL_CERT_FILE="); ok {
+				return strings.Trim(rest, "'")
+			}
+		}
+		t.Fatal("no SSL_CERT_FILE in --print output")
+		return ""
+	}
+
+	first := run()
+	second := run()
+	if first != second {
+		t.Errorf("--print produced two different paths (%s, %s); every eval would leak one", first, second)
+	}
+	// It must live beside the CA, not in the temp dir.
+	if filepath.Dir(first) != filepath.Dir(caPath) {
+		t.Errorf("bundle at %s, want it beside the CA in %s", first, filepath.Dir(caPath))
+	}
+
+	// Rotate the CA; the next --print must reflect it.
+	if err := os.WriteFile(caPath, []byte("-----BEGIN CERTIFICATE-----\nROTATED\n-----END CERTIFICATE-----\n"), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	run()
+	b, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "ROTATED") {
+		t.Error("the bundle was not refreshed after the CA rotated")
+	}
+}
+
+// The child path must still use a temp bundle that IS cleaned up — the persisted
+// path is only for --print.
+func TestExecEnv_ChildBundleIsStillTemporary(t *testing.T) {
+	cfgPath, caPath := execCfg(t)
+	env, cleanup, err := execEnv(cfgPath, false)
+	if err != nil && !errors.Is(err, errNoSystemRoots) {
+		t.Fatal(err)
+	}
+	bundle := env["CURL_CA_BUNDLE"]
+	if filepath.Dir(bundle) == filepath.Dir(caPath) {
+		t.Errorf("child bundle at %s is the persisted path; it should be a temp file", bundle)
+	}
+	cleanup()
+	if _, serr := os.Stat(bundle); !os.IsNotExist(serr) {
+		t.Errorf("child bundle survived cleanup at %s", bundle)
+	}
+}
+
+// TestWriteTrustBundle_NoSystemRoots covers the errNoSystemRoots branch, which is
+// otherwise reachable only on a machine with no root store — so it never ran in
+// CI, and the test that mentions it degraded to a t.Logf there. systemRootFiles is
+// a package var precisely so it can be swapped.
+func TestWriteTrustBundle_NoSystemRoots(t *testing.T) {
+	saved := systemRootFiles
+	systemRootFiles = []string{filepath.Join(t.TempDir(), "definitely-absent")}
+	t.Cleanup(func() { systemRootFiles = saved })
+
+	cfgPath, _ := execCfg(t)
+	env, cleanup, err := execEnv(cfgPath, false)
+	if !errors.Is(err, errNoSystemRoots) {
+		t.Fatalf("want errNoSystemRoots, got %v", err)
+	}
+	defer cleanup()
+
+	// A usable bundle comes back regardless: on an image with no root store the
+	// bridge CA alone is the whole trust set, which is correct there.
+	b, rerr := os.ReadFile(env["CURL_CA_BUNDLE"])
+	if rerr != nil {
+		t.Fatalf("no bundle despite the sentinel being advisory: %v", rerr)
+	}
+	if !strings.Contains(string(b), "BRIDGECA") {
+		t.Error("bundle omits the bridge CA")
+	}
+
+	// And runExec reports it without failing.
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", "echo ran"}, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit = %d, want 0; a missing system store is advisory", code)
+	}
+	if !strings.Contains(stderr.String(), "no system CA bundle") {
+		t.Errorf("expected the missing-roots note:\n%s", stderr.String())
+	}
+}
+
+// TestClaudeCodeEnable_DisabledBridgeIsRefused. The tls_bridge.mode gate was
+// exec-only, so the two commands drifted on exactly the check whose comment claims
+// they cannot: `abctl exec` refused `mode: disabled` + ca_dir, while
+// `claude-code enable` wrote it into settings.json and produced the same silent
+// break. Both now share bridgeEnabled/errBridgeDisabled.
+func TestClaudeCodeEnable_DisabledBridgeIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	cfgPath := filepath.Join(dir, "config.yaml")
+	body := "mode: proxy-sidecar\n" +
+		"listener:\n  roles: [forward]\n  forward_proxy_addr: \"127.0.0.1:47600\"\n" +
+		"tls_bridge:\n  mode: disabled\n  ca_dir: \"" + filepath.Join(dir, "ca") + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := claudeCodeEnable(settingsPath, cfgPath, true, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 for a disabled bridge", code)
+	}
+	if !strings.Contains(stderr.String(), "tls_bridge.mode") {
+		t.Errorf("error should name tls_bridge.mode:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(settingsPath); err == nil {
+		t.Error("settings.json was written despite the disabled bridge")
+	}
+}
+
+// Both commands must refuse the same config for the same reason — the property the
+// shared helper exists to guarantee.
+func TestBridgeGate_ExecAndEnableAgree(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	body := "mode: proxy-sidecar\n" +
+		"listener:\n  roles: [forward]\n  forward_proxy_addr: \"127.0.0.1:47600\"\n" +
+		"tls_bridge:\n  mode: disabled\n  ca_dir: \"" + filepath.Join(dir, "ca") + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, execErr := execEnv(cfgPath, false)
+	if execErr == nil {
+		t.Fatal("exec accepted a disabled bridge")
+	}
+	var stdout, stderr bytes.Buffer
+	if code := claudeCodeEnable(filepath.Join(dir, "settings.json"), cfgPath, true, &stdout, &stderr); code == 0 {
+		t.Fatal("claude-code enable accepted a disabled bridge")
+	}
+	// Same message, so a user sees one explanation whichever command they reached for.
+	if !strings.Contains(stderr.String(), execErr.Error()) {
+		t.Errorf("the two commands explain it differently:\n exec:   %v\n enable: %s", execErr, stderr.String())
 	}
 }

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -720,20 +720,69 @@ func TestRunExec_PreservesArgv0AsTyped(t *testing.T) {
 	}
 }
 
-// TestRunExec_PrintWithCommandSaysSo: silently discarding the command is the same
-// discourtesy the strict pre-delimiter check exists to avoid.
-func TestRunExec_PrintWithCommandSaysSo(t *testing.T) {
+// --print and a command are mutually exclusive. The two modes disagree about how
+// long their output is meant to last: --print emits paths for a shell to keep —
+// the same ca.crt `claude-code enable` writes into settings.json, plus the
+// trust-bundle.pem beside it — while a command gets them for one process. So this
+// is a contradiction about intent, refused rather than half-honoured with a note.
+func TestRunExec_PrintWithCommandIsAUsageError(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 	var stdout, stderr bytes.Buffer
 	code := runExec([]string{"--config", cfgPath, "--print", "--", "curl", "https://x"}, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit = %d, want 0", code)
+	if code != 2 {
+		t.Errorf("exit = %d, want 2 (usage)", code)
 	}
-	if !strings.Contains(stdout.String(), "export HTTPS_PROXY=") {
-		t.Error("--print should still print the exports")
+	// Nothing printed: a caller doing `eval "$(...)"` must not get a half-answer.
+	if stdout.Len() != 0 {
+		t.Errorf("--print with a command emitted exports anyway:\n%s", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "was not run") {
-		t.Errorf("expected a note that the command was ignored:\n%s", stderr.String())
+	if !strings.Contains(stderr.String(), "mutually exclusive") {
+		t.Errorf("error should say the two are mutually exclusive:\n%s", stderr.String())
+	}
+	// The message names the command, so the user can see which half to keep.
+	if !strings.Contains(stderr.String(), "curl https://x") {
+		t.Errorf("error should echo the command:\n%s", stderr.String())
+	}
+}
+
+// A usage error must not touch the filesystem. The check is placed with the other
+// argument validation, before the config is read, so a rejected invocation does not
+// leave a trust-bundle.pem behind as a side effect of being wrong.
+func TestRunExec_PrintWithCommandWritesNothing(t *testing.T) {
+	cfgPath, caPath := execCfg(t)
+	bundle := filepath.Join(filepath.Dir(caPath), "trust-bundle.pem")
+
+	var stdout, stderr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--print", "--", "curl"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("exit = %d, want 2", code)
+	}
+	if _, err := os.Stat(bundle); err == nil {
+		t.Errorf("a rejected invocation wrote %s", bundle)
+	}
+}
+
+// Each mode alone still works: this is exclusivity, not a new restriction on
+// either form.
+func TestRunExec_PrintAloneAndCommandAloneBothWork(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfg(t)
+
+	var pout, perr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &pout, &perr); code != 0 {
+		t.Errorf("--print alone: exit %d: %s", code, perr.String())
+	}
+	if !strings.Contains(pout.String(), "export HTTPS_PROXY=") {
+		t.Errorf("--print alone printed nothing useful:\n%s", pout.String())
+	}
+
+	var cout, cerr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", "echo ran"}, &cout, &cerr); code != 0 {
+		t.Errorf("command alone: exit %d: %s", code, cerr.String())
+	}
+	if strings.TrimSpace(cout.String()) != "ran" {
+		t.Errorf("command alone did not run: %q", cout.String())
 	}
 }
 

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -59,6 +59,27 @@ const testRootPEM = "-----BEGIN CERTIFICATE-----\nSYSTEMROOT\n-----END CERTIFICA
 // under test parses it.
 const testCAPEM = "-----BEGIN CERTIFICATE-----\nBRIDGECA\n-----END CERTIFICATE-----\n"
 
+// execCfgNoBundle is execCfg with ca.crt but no bundle.crt: Cortex configured and
+// its CA present, but never started, so EnsureTrustBundle has not run.
+func execCfgNoBundle(t *testing.T) (cfgPath, caPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	caDir := filepath.Join(dir, "ca")
+	if err := os.MkdirAll(caDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	caPath = filepath.Join(caDir, "ca.crt")
+	if err := os.WriteFile(caPath, []byte(testCAPEM), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	cfgPath = filepath.Join(dir, "config.yaml")
+	body := strings.Replace(cortexCfg, "CADIR", caDir, 1)
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath, caPath
+}
+
 // execCfgNoCA is execCfg without ca.crt on disk: Cortex configured but never
 // started.
 func execCfgNoCA(t *testing.T) (cfgPath, caPath string) {
@@ -250,8 +271,11 @@ func TestRunExec_ChildSeesTheVariables(t *testing.T) {
 			t.Errorf("%s names the lone bridge CA; public trust would be lost", k)
 		}
 	}
-	// Asserted from the child's output: the bundle is deliberately removed when
-	// runExec returns, so it cannot be read from here.
+	// Asserted from the CHILD's output rather than from here, because what matters is
+	// that the child can read the bundle — the variable is only useful if the process
+	// it is handed to can open the file. (The bundle is a fixture in t.TempDir() that
+	// outlives runExec, so the parent could read it too; that just would not prove
+	// the same thing.)
 	if !strings.Contains(got, "BUNDLE_HAS_BRIDGE_CA") {
 		t.Errorf("the child could not read a bundle containing the bridge CA\n%s", got)
 	}
@@ -839,7 +863,8 @@ func execStats(t *testing.T, cfgPath string) string {
 // execEnvFor is execEnv against a stub serving the given config file.
 func execEnvFor(t *testing.T, cfgPath string) (map[string]string, error) {
 	t.Helper()
-	return execEnv(execStats(t, cfgPath))
+	env, _, err := execEnv(execStats(t, cfgPath))
+	return env, err
 }
 
 // --- The three behaviours changed in this round ---
@@ -914,7 +939,7 @@ func TestExecEnv_ReadsTheRunningProxyNotAFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env, err := execEnv(execStats(t, cfgPath))
+	env, _, err := execEnv(execStats(t, cfgPath))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -931,7 +956,7 @@ func TestExecEnv_ReadsTheRunningProxyNotAFile(t *testing.T) {
 // A stats URL that is not a URL is reported as such, rather than becoming a
 // confusing connection error.
 func TestExecEnv_RejectsAMalformedStatsURL(t *testing.T) {
-	if _, err := execEnv("not a url"); err == nil {
+	if _, _, err := execEnv("not a url"); err == nil {
 		t.Fatal("want an error for a malformed stats URL")
 	}
 }
@@ -956,7 +981,7 @@ func TestDefaultCortexStatsURL(t *testing.T) {
 // of variable names is mechanical, so it should not depend on anyone remembering.
 func TestExecUsage_ListsExactlyTheInjectedVariables(t *testing.T) {
 	cfgPath, _ := execCfg(t)
-	inject, err := execEnv(execStats(t, cfgPath))
+	inject, _, err := execEnv(execStats(t, cfgPath))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -995,5 +1020,133 @@ func TestExecUsage_ListsExactlyTheInjectedVariables(t *testing.T) {
 	}
 	if len(listed) != len(inject) {
 		t.Errorf("help lists %d names, exec injects %d", len(listed), len(inject))
+	}
+}
+
+// abctl must SURVIVE Ctrl-C, not die on it.
+//
+// SIGINT and SIGQUIT are tty-generated: they reach the whole foreground process
+// group, so the child already has them and abctl must not relay. But abctl still
+// has to CATCH them, or Go's default disposition kills the wrapper while the child
+// keeps running — for `abctl exec -- claude`, where Ctrl-C interrupts a turn rather
+// than quitting, that strands claude on the terminal with the shell prompt back and
+// two processes reading one stdin. Verified before the fix: abctl exited -2 while
+// the child survived.
+//
+// Not signal.Ignore: that sets SIG_IGN, which exec() preserves across the exec, so
+// the child would inherit it and Ctrl-C would stop reaching it at all.
+func TestRunExec_SurvivesSIGINT(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no POSIX signals")
+	}
+	cfgPath, _ := execCfg(t)
+	dir := t.TempDir()
+	started := filepath.Join(dir, "started")
+	// The child exits on its own shortly after; the point is that runExec is still
+	// there to report its status rather than having been killed by the SIGINT.
+	script := "trap 'true' INT; touch " + started +
+		"; i=0; while [ $i -lt 40 ]; do sleep 0.05; i=$((i+1)); done; exit 3"
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
+			"/bin/sh", "-c", script}, &stdout, &stderr)
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(started); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child never started")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Signal THIS process, as a tty would. If runExec did not catch SIGINT, the
+	// whole test binary would die here rather than one test failing.
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case code := <-done:
+		// The child's own exit status, proving abctl stayed alive to Wait on it.
+		if code != 3 {
+			t.Errorf("exit = %d, want 3 (the child's); abctl did not survive the SIGINT", code)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("runExec never returned after SIGINT")
+	}
+}
+
+// Before Cortex's first start, bundle.crt does not exist. The four REPLACING
+// variables must be omitted rather than pointed at a missing file.
+//
+// Those names replace the trust store, so a missing target does not fall back to
+// the platform roots — git, curl and Python refuse outright and EVERY https request
+// fails, bridged or not. Leaving them unset costs only the bridged hosts. The README
+// described this behaviour while the code only warned and continued.
+func TestExecEnv_OmitsReplacingVarsWhenTheBundleIsMissing(t *testing.T) {
+	cfgPath, caPath := execCfgNoBundle(t)
+
+	env, _, err := execEnv(execStats(t, cfgPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range bundleKeys {
+		if v, ok := env[k]; ok {
+			t.Errorf("%s = %q, but the bundle does not exist — the child would lose all trust", k, v)
+		}
+	}
+	// The additive name stays: Node warns and keeps its own roots, which is the same
+	// state `claude-code enable` has always written.
+	if env[envCACerts] != caPath {
+		t.Errorf("%s = %q, want the bridge CA %q", envCACerts, env[envCACerts], caPath)
+	}
+	// And the proxy half still works.
+	if env[envProxy] == "" {
+		t.Error("the proxy variables should still be set before first start")
+	}
+}
+
+// The note must say what the user actually gets, and the command must still run.
+func TestRunExec_BeforeFirstStartRunsAndSaysWhatIsLost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfgNoBundle(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
+		"/bin/sh", "-c", `printf 'SSL_CERT_FILE=[%s]\n' "$SSL_CERT_FILE"; echo ran`}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "SSL_CERT_FILE=[]") {
+		t.Errorf("the child inherited a bundle path that does not exist:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "keeps its own trusted roots") {
+		t.Errorf("the note should say what the child keeps:\n%s", stderr.String())
+	}
+}
+
+// `abctl exec --` is a usage error knowable from argv, so it must not depend on
+// reaching Cortex. Diagnosed after the fetch, a user with Cortex down got "no Cortex
+// is running" and exit 1 for what execUsage documents as exit 2.
+func TestRunExec_EmptyCommandIsAUsageErrorWithoutCortex(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// A URL nothing answers on: if the check were still below the fetch, this would
+	// report an outage instead.
+	code := runExec([]string{"--cortex-stats-url", "http://127.0.0.1:1/", "--"}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("exit = %d, want 2 (usage)", code)
+	}
+	if strings.Contains(stderr.String(), "no Cortex is running") {
+		t.Errorf("a usage error was diagnosed as a Cortex outage:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "nothing to run") {
+		t.Errorf("error should name the empty command:\n%s", stderr.String())
 	}
 }

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -12,6 +12,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"sort"
 	"strings"
 	"syscall"
 	"testing"
@@ -313,8 +315,8 @@ func TestMergeEnv_ReplacesRatherThanAppends(t *testing.T) {
 	}
 }
 
-// TestMergeEnv_IsCaseSensitive: the lowercase and uppercase proxy spellings are
-// eight distinct names, not four folded pairs.
+// TestMergeEnv_IsCaseSensitive: HTTP_PROXY and http_proxy are two distinct
+// variables, not one name in two casings — folding them would set only one.
 func TestMergeEnv_IsCaseSensitive(t *testing.T) {
 	out := mergeEnv([]string{"http_proxy=http://old:1"}, map[string]string{
 		"HTTP_PROXY": "http://new:2",
@@ -663,50 +665,55 @@ func TestRunExec_PrintWithCommandIsAUsageError(t *testing.T) {
 	}
 }
 
-// A usage error must not touch the filesystem. The check is placed with the other
-// argument validation, before the config is read, so a rejected invocation does not
-// leave a trust-bundle.pem behind as a side effect of being wrong.
-func TestRunExec_PrintWithCommandWritesNothing(t *testing.T) {
+// exec must not write to the CA directory at all — not on the usage-error path,
+// and not on the happy one either.
+//
+// This replaces a test that stat'd "trust-bundle.pem" after a rejected
+// invocation. That filename stopped existing when the bundle moved into
+// authlib/tlsbridge, so the assertion watched a path nothing could ever create and
+// could not fail. The property worth pinning is the stronger one that made it
+// vacuous: Cortex owns those files now, so abctl only ever reads them.
+func TestRunExec_NeverWritesToTheCADir(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
-	bundle := filepath.Join(filepath.Dir(caPath), "trust-bundle.pem")
+	caDir := filepath.Dir(caPath)
 
-	var stdout, stderr bytes.Buffer
-	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print", "--", "curl"}, &stdout, &stderr); code != 2 {
-		t.Fatalf("exit = %d, want 2", code)
+	before, err := os.ReadDir(caDir)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if _, err := os.Stat(bundle); err == nil {
-		t.Errorf("a rejected invocation wrote %s", bundle)
+	names := func(es []os.DirEntry) []string {
+		out := make([]string, 0, len(es))
+		for _, e := range es {
+			out = append(out, e.Name())
+		}
+		sort.Strings(out)
+		return out
+	}
+	want := names(before)
+
+	// Every path through runExec that gets far enough to have derived an environment.
+	stats := execStats(t, cfgPath)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"print-with-command (usage error)", []string{"--cortex-stats-url", stats, "--print", "--", "curl"}},
+		{"print-with-empty-command (usage error)", []string{"--cortex-stats-url", stats, "--print", "--"}},
+		{"print alone", []string{"--cortex-stats-url", stats, "--print"}},
+		{"running a command", []string{"--cortex-stats-url", stats, "--", "/bin/sh", "-c", "exit 0"}},
+	} {
+		var stdout, stderr bytes.Buffer
+		runExec(tc.args, &stdout, &stderr)
+		after, rerr := os.ReadDir(caDir)
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		if got := names(after); !slices.Equal(got, want) {
+			t.Errorf("%s changed the CA directory:\n before %v\n after  %v", tc.name, want, got)
+		}
 	}
 }
 
-// Each mode alone still works: this is exclusivity, not a new restriction on
-// either form.
-func TestRunExec_PrintAloneAndCommandAloneBothWork(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses /bin/sh")
-	}
-	cfgPath, _ := execCfg(t)
-
-	var pout, perr bytes.Buffer
-	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print"}, &pout, &perr); code != 0 {
-		t.Errorf("--print alone: exit %d: %s", code, perr.String())
-	}
-	if !strings.Contains(pout.String(), "export HTTPS_PROXY=") {
-		t.Errorf("--print alone printed nothing useful:\n%s", pout.String())
-	}
-
-	var cout, cerr bytes.Buffer
-	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--", "/bin/sh", "-c", "echo ran"}, &cout, &cerr); code != 0 {
-		t.Errorf("command alone: exit %d: %s", code, cerr.String())
-	}
-	if strings.TrimSpace(cout.String()) != "ran" {
-		t.Errorf("command alone did not run: %q", cout.String())
-	}
-}
-
-// TestRunExec_PreservesInheritedNoProxy. NO_PROXY is not ours to touch: a host
-// listed there bypasses Cortex, and with the replacing CA vars now carrying the
-// system roots, such a request still verifies against public trust.
 func TestRunExec_PreservesInheritedNoProxy(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("uses /bin/sh")

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// execCfg writes a Cortex config and returns its path plus the CA path it names.
+func execCfg(t *testing.T) (cfgPath, caPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	caDir := filepath.Join(dir, "ca")
+	cfgPath = filepath.Join(dir, "config.yaml")
+	body := strings.Replace(cortexCfg, "CADIR", caDir, 1)
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return cfgPath, filepath.Join(caDir, "ca.crt")
+}
+
+// TestExecEnv_AllEightNamesFromTwoValues is the contract: eight variables, two
+// distinct values, both derived from the config rather than hardcoded.
+func TestExecEnv_AllEightNamesFromTwoValues(t *testing.T) {
+	cfgPath, caPath := execCfg(t)
+	env, err := execEnv(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 8 {
+		t.Fatalf("want 8 variables, got %d: %v", len(env), env)
+	}
+	// The config fixture says forward_proxy_addr: 127.0.0.1:47600.
+	const wantProxy = "http://127.0.0.1:47600"
+	for _, k := range execProxyVars {
+		if env[k] != wantProxy {
+			t.Errorf("%s = %q, want %q", k, env[k], wantProxy)
+		}
+	}
+	for _, k := range execCAVars {
+		if env[k] != caPath {
+			t.Errorf("%s = %q, want %q", k, env[k], caPath)
+		}
+	}
+}
+
+// TestExecEnv_MatchesClaudeCodeEnable is the anti-drift check. exec and
+// `claude-code enable` must point at the same proxy and the same CA; if someone
+// changes one derivation and not the other, the two commands disagree about where
+// Cortex is and only one of them works.
+func TestExecEnv_MatchesClaudeCodeEnable(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	want, err := wanted(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := execEnv(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["HTTPS_PROXY"] != want[envProxy] {
+		t.Errorf("exec HTTPS_PROXY = %q, enable writes %q", env["HTTPS_PROXY"], want[envProxy])
+	}
+	if env["NODE_EXTRA_CA_CERTS"] != want[envCACerts] {
+		t.Errorf("exec NODE_EXTRA_CA_CERTS = %q, enable writes %q", env["NODE_EXTRA_CA_CERTS"], want[envCACerts])
+	}
+	// The telemetry key is a Claude Code setting, not an environment concern for an
+	// arbitrary child, so exec must not inject it.
+	if _, ok := env[envNoTelem]; ok {
+		t.Errorf("exec injected %s, which is a Claude Code setting", envNoTelem)
+	}
+}
+
+// TestExecEnv_NoCADirIsRefused: injecting the proxy without a CA is the silent
+// failure mode — a lenient client tunnels through unparsed and looks fine while
+// Cortex sees nothing.
+func TestExecEnv_NoCADirIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	body := `mode: proxy-sidecar
+listener:
+  roles: [forward]
+  forward_proxy_addr: "127.0.0.1:47600"
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := execEnv(cfgPath); err == nil {
+		t.Fatal("want an error when tls_bridge.ca_dir is absent, got nil")
+	}
+}
+
+// TestRunExec_PassesArgvIntactAndReturnsExitCode covers the two halves of the
+// pass-through promise at once: the child sees exactly the arguments typed after
+// --, including things that look like abctl's own flags, and its exit status
+// comes back out.
+func TestRunExec_PassesArgvIntactAndReturnsExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfg(t)
+
+	// --config and --print after -- belong to the child. If runExec's flag set ever
+	// saw them, this would fail by printing instead of running.
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{
+		"--config", cfgPath, "--",
+		"/bin/sh", "-c", `printf '%s\n' "$@"; exit 7`, "sh",
+		"--config", "--print", "-x", "a b", "",
+	}, &stdout, &stderr)
+
+	if code != 7 {
+		t.Errorf("exit code = %d, want 7 (the child's); stderr=%s", code, stderr.String())
+	}
+	want := "--config\n--print\n-x\na b\n\n"
+	if got := stdout.String(); got != want {
+		t.Errorf("child argv:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestRunExec_ChildSeesTheVariables checks the injection actually reaches the
+// process, not just the map.
+func TestRunExec_ChildSeesTheVariables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, caPath := execCfg(t)
+
+	// Pre-set two of the eight to wrong values, so this also proves replacement
+	// rather than "it happened to be unset".
+	t.Setenv("HTTPS_PROXY", "http://corporate.example:3128")
+	t.Setenv("SSL_CERT_FILE", "/etc/ssl/wrong.pem")
+
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--",
+		"/bin/sh", "-c", `for v in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy \
+			NODE_EXTRA_CA_CERTS CURL_CA_BUNDLE REQUESTS_CA_BUNDLE SSL_CERT_FILE; do
+			eval "printf '%s=%s\n' \"$v\" \"\$$v\""
+		done`}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	got := stdout.String()
+	for _, k := range execProxyVars {
+		if !strings.Contains(got, k+"=http://127.0.0.1:47600\n") {
+			t.Errorf("child did not see %s=http://127.0.0.1:47600\n%s", k, got)
+		}
+	}
+	for _, k := range execCAVars {
+		if !strings.Contains(got, k+"="+caPath+"\n") {
+			t.Errorf("child did not see %s=%s\n%s", k, caPath, got)
+		}
+	}
+}
+
+// TestRunExec_InheritsUnrelatedEnvironment: scoping the proxy to one child must
+// not mean handing it a stripped environment. PATH, HOME and the user's own
+// variables have to survive, or `abctl exec -- claude` loses its credentials.
+func TestRunExec_InheritsUnrelatedEnvironment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfg(t)
+	t.Setenv("ABCTL_EXEC_CANARY", "kept")
+
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--",
+		"/bin/sh", "-c", `printf '%s\n' "$ABCTL_EXEC_CANARY"`}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "kept" {
+		t.Errorf("canary = %q, want %q; the child's environment was not inherited",
+			stdout.String(), "kept")
+	}
+}
+
+// TestMergeEnv_ReplacesRatherThanAppends is the subtle one. Appending a second
+// HTTPS_PROXY= entry leaves the child's runtime to pick, and different runtimes
+// pick different ends, so the variable would take effect for some children and
+// not others depending on whether the user already had it set.
+func TestMergeEnv_ReplacesRatherThanAppends(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"HTTPS_PROXY=http://old:3128",
+		"HTTPS_PROXY=http://older:3128", // a duplicate, which is legal in execve
+		"KEEP=1",
+		"MALFORMED",
+	}
+	out := mergeEnv(env, map[string]string{
+		"HTTPS_PROXY":   "http://new:47600",
+		"SSL_CERT_FILE": "/ca.crt",
+	})
+
+	var proxies []string
+	for _, kv := range out {
+		if strings.HasPrefix(kv, "HTTPS_PROXY=") {
+			proxies = append(proxies, kv)
+		}
+	}
+	if len(proxies) != 1 {
+		t.Errorf("HTTPS_PROXY appears %d times (%v), want exactly 1", len(proxies), proxies)
+	}
+	if len(proxies) > 0 && proxies[0] != "HTTPS_PROXY=http://new:47600" {
+		t.Errorf("HTTPS_PROXY = %q, want the injected value", proxies[0])
+	}
+	joined := strings.Join(out, "\n")
+	for _, want := range []string{"PATH=/usr/bin", "KEEP=1", "MALFORMED", "SSL_CERT_FILE=/ca.crt"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing %q from merged env:\n%s", want, joined)
+		}
+	}
+}
+
+// TestMergeEnv_IsCaseSensitive: the lowercase and uppercase proxy spellings are
+// eight distinct names, not four folded pairs.
+func TestMergeEnv_IsCaseSensitive(t *testing.T) {
+	out := mergeEnv([]string{"http_proxy=http://old:1"}, map[string]string{
+		"HTTP_PROXY": "http://new:2",
+		"http_proxy": "http://new:2",
+	})
+	joined := strings.Join(out, "\n")
+	if !strings.Contains(joined, "HTTP_PROXY=http://new:2") ||
+		!strings.Contains(joined, "http_proxy=http://new:2") {
+		t.Errorf("both spellings must be set independently:\n%s", joined)
+	}
+}
+
+// TestRunExec_RequiresDelimiter. Without --, there is no syntactic boundary
+// between abctl's flags and the child's, so the command is refused rather than
+// guessed at.
+func TestRunExec_RequiresDelimiter(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runExec([]string{"curl", "https://example.com"}, &stdout, &stderr); code != 2 {
+		t.Errorf("exit = %d, want 2 (usage) when -- is missing", code)
+	}
+	if !strings.Contains(stderr.String(), "--") {
+		t.Errorf("usage should explain the delimiter:\n%s", stderr.String())
+	}
+}
+
+// TestRunExec_RejectsArgsBeforeDelimiter. `abctl exec curl -- -sv` is a typo, and
+// running `-sv` as the command is a worse answer than saying so.
+func TestRunExec_RejectsArgsBeforeDelimiter(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "curl", "--", "-sv"}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("exit = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "curl") {
+		t.Errorf("error should name the misplaced argument:\n%s", stderr.String())
+	}
+}
+
+// TestRunExec_EmptyAfterDelimiter: `abctl exec --` has nothing to run.
+func TestRunExec_EmptyAfterDelimiter(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--"}, &stdout, &stderr); code != 2 {
+		t.Errorf("exit = %d, want 2", code)
+	}
+}
+
+// TestRunExec_CommandNotFound reports 127, as a shell does, so a caller can tell
+// "my command is missing" from "my command failed".
+func TestRunExec_CommandNotFound(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--",
+		"abctl-no-such-command-xyzzy"}, &stdout, &stderr)
+	if code != execEnvNotFound {
+		t.Errorf("exit = %d, want %d", code, execEnvNotFound)
+	}
+}
+
+// TestRunExec_BadConfigIsAnError, not a silently unproxied child. Running the
+// command anyway would be the worst outcome: it works, bypasses Cortex, and
+// nothing says so.
+func TestRunExec_BadConfigIsAnError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", filepath.Join(t.TempDir(), "missing.yaml"), "--",
+		"/bin/sh", "-c", "exit 0"}, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
+}
+
+// TestRunExec_Print emits eval-able export lines and runs nothing.
+func TestRunExec_Print(t *testing.T) {
+	cfgPath, caPath := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr.String())
+	}
+	got := stdout.String()
+	if n := strings.Count(got, "export "); n != 8 {
+		t.Errorf("got %d export lines, want 8:\n%s", n, got)
+	}
+	if !strings.Contains(got, "export HTTPS_PROXY=http://127.0.0.1:47600\n") {
+		t.Errorf("missing proxy export:\n%s", got)
+	}
+	if !strings.Contains(got, caPath) {
+		t.Errorf("missing CA path %s:\n%s", caPath, got)
+	}
+}
+
+// TestShellQuote covers the case that motivates quoting at all: a CA path with a
+// space in it, which --print documents as eval-able and which would otherwise
+// export a truncated filename.
+func TestShellQuote(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/plain/ca.crt", "/plain/ca.crt"},
+		{"/Users/x/Application Support/ca.crt", "'/Users/x/Application Support/ca.crt'"},
+		{"/it's/ca.crt", `'/it'\''s/ca.crt'`},
+		{"", "''"},
+		{"http://127.0.0.1:47600", "http://127.0.0.1:47600"},
+	} {
+		if got := shellQuote(tc.in); got != tc.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCutArgs matches on whole arguments, so a child argument that merely
+// contains "--" is not mistaken for the delimiter.
+func TestCutArgs(t *testing.T) {
+	before, after, found := cutArgs([]string{"--config", "x", "--", "sh", "--", "y"}, "--")
+	if !found {
+		t.Fatal("delimiter not found")
+	}
+	if strings.Join(before, " ") != "--config x" {
+		t.Errorf("before = %v", before)
+	}
+	// The second -- belongs to the child and must survive.
+	if strings.Join(after, " ") != "sh -- y" {
+		t.Errorf("after = %v", after)
+	}
+
+	if _, _, found := cutArgs([]string{"--flag=--"}, "--"); found {
+		t.Error("an argument containing -- is not the delimiter")
+	}
+}
+
+// TestRunExec_SignaledChild reports 128+signum rather than the -1 ExitCode gives,
+// which os.Exit would flatten to 255 and lose the cause.
+func TestRunExec_SignaledChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no POSIX signals")
+	}
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	// 9 = SIGKILL, so 128+9 = 137.
+	code := runExec([]string{"--config", cfgPath, "--",
+		"/bin/sh", "-c", "kill -9 $$"}, &stdout, &stderr)
+	if code != 137 {
+		t.Errorf("exit = %d, want 137 (128+SIGKILL)", code)
+	}
+}

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/redact"
 	"github.com/rossoctl/cortex/authbridge/authlib/tlsbridge"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +80,7 @@ func execCfgNoCA(t *testing.T) (cfgPath, caPath string) {
 // the bridge and nothing else, so every unproxied TLS call fails.
 func TestExecEnv_InjectsManagedKeysPlusLowercaseProxies(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
-	env, err := execEnv(cfgPath)
+	env, err := execEnvFor(t, cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +122,7 @@ func TestExecEnv_MatchesClaudeCodeEnable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	env, err := execEnv(cfgPath)
+	env, err := execEnvFor(t, cfgPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +153,7 @@ listener:
 	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := execEnv(cfgPath); err == nil {
+	if _, err := execEnvFor(t, cfgPath); err == nil {
 		t.Fatal("want an error when tls_bridge.ca_dir is absent, got nil")
 	}
 }
@@ -167,7 +172,7 @@ func TestRunExec_PassesArgvIntactAndReturnsExitCode(t *testing.T) {
 	// saw them, this would fail by printing instead of running.
 	var stdout, stderr bytes.Buffer
 	code := runExec([]string{
-		"--config", cfgPath, "--",
+		"--cortex-stats-url", execStats(t, cfgPath), "--",
 		"/bin/sh", "-c", `printf '%s\n' "$@"; exit 7`, "sh",
 		"--config", "--print", "-x", "a b", "",
 	}, &stdout, &stderr)
@@ -210,7 +215,7 @@ func TestRunExec_ChildSeesTheVariables(t *testing.T) {
 		grep -q BRIDGECA "$CURL_CA_BUNDLE" && echo BUNDLE_HAS_BRIDGE_CA`
 
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", script}, &stdout, &stderr)
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--", "/bin/sh", "-c", script}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit %d: %s", code, stderr.String())
 	}
@@ -260,7 +265,7 @@ func TestRunExec_InheritsUnrelatedEnvironment(t *testing.T) {
 	t.Setenv("ABCTL_EXEC_CANARY", "kept")
 
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--",
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
 		"/bin/sh", "-c", `printf '%s\n' "$ABCTL_EXEC_CANARY"`}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit %d: %s", code, stderr.String())
@@ -340,7 +345,7 @@ func TestRunExec_RequiresDelimiter(t *testing.T) {
 func TestRunExec_RejectsArgsBeforeDelimiter(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "curl", "--", "-sv"}, &stdout, &stderr)
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "curl", "--", "-sv"}, &stdout, &stderr)
 	if code != 2 {
 		t.Errorf("exit = %d, want 2", code)
 	}
@@ -353,7 +358,7 @@ func TestRunExec_RejectsArgsBeforeDelimiter(t *testing.T) {
 func TestRunExec_EmptyAfterDelimiter(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 	var stdout, stderr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--"}, &stdout, &stderr); code != 2 {
+	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--"}, &stdout, &stderr); code != 2 {
 		t.Errorf("exit = %d, want 2", code)
 	}
 }
@@ -363,22 +368,30 @@ func TestRunExec_EmptyAfterDelimiter(t *testing.T) {
 func TestRunExec_CommandNotFound(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--",
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
 		"abctl-no-such-command-xyzzy"}, &stdout, &stderr)
 	if code != execEnvNotFound {
 		t.Errorf("exit = %d, want %d", code, execEnvNotFound)
 	}
 }
 
-// TestRunExec_BadConfigIsAnError, not a silently unproxied child. Running the
-// command anyway would be the worst outcome: it works, bypasses Cortex, and
-// nothing says so.
-func TestRunExec_BadConfigIsAnError(t *testing.T) {
+// A Cortex that is not running is an error, not a silently unproxied child.
+// Running the command anyway would be the worst outcome: it works, bypasses
+// Cortex, and nothing says so.
+func TestRunExec_NoRunningCortexIsAnError(t *testing.T) {
+	// A port nothing is listening on. httptest gives us one and closes it.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	dead := srv.URL + "/"
+	srv.Close()
+
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", filepath.Join(t.TempDir(), "missing.yaml"), "--",
+	code := runExec([]string{"--cortex-stats-url", dead, "--",
 		"/bin/sh", "-c", "exit 0"}, &stdout, &stderr)
 	if code != 1 {
 		t.Errorf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no Cortex is running") {
+		t.Errorf("error should say no Cortex is running:\n%s", stderr.String())
 	}
 }
 
@@ -386,7 +399,7 @@ func TestRunExec_BadConfigIsAnError(t *testing.T) {
 func TestRunExec_Print(t *testing.T) {
 	cfgPath, caPath := execCfg(t)
 	var stdout, stderr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &stdout, &stderr); code != 0 {
+	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d: %s", code, stderr.String())
 	}
 	got := stdout.String()
@@ -456,7 +469,7 @@ func TestRunExec_SignaledChild(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 	var stdout, stderr bytes.Buffer
 	// 9 = SIGKILL, so 128+9 = 137.
-	code := runExec([]string{"--config", cfgPath, "--",
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
 		"/bin/sh", "-c", "kill -9 $$"}, &stdout, &stderr)
 	if code != 137 {
 		t.Errorf("exit = %d, want 137 (128+SIGKILL)", code)
@@ -484,7 +497,7 @@ func TestExecEnv_DisabledBridgeIsRefused(t *testing.T) {
 			if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			_, err := execEnv(cfgPath)
+			_, err := execEnvFor(t, cfgPath)
 			if err == nil {
 				t.Fatal("want an error when the bridge is not enabled, got nil")
 			}
@@ -508,7 +521,7 @@ func TestRunExec_DisabledBridgeExitsBeforeRunning(t *testing.T) {
 	}
 	marker := filepath.Join(dir, "ran")
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--",
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
 		"/bin/sh", "-c", "touch " + marker}, &stdout, &stderr)
 	if code != 1 {
 		t.Errorf("exit = %d, want 1", code)
@@ -526,7 +539,7 @@ func TestRunExec_BeforeFirstStart_StillRuns(t *testing.T) {
 	}
 	cfgPath, _ := execCfgNoCA(t)
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", "echo ran"}, &stdout, &stderr)
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--", "/bin/sh", "-c", "echo ran"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
@@ -559,7 +572,7 @@ func TestRunExec_RelaysSIGTERM(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	done := make(chan int, 1)
 	go func() {
-		done <- runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", script}, &stdout, &stderr)
+		done <- runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--", "/bin/sh", "-c", script}, &stdout, &stderr)
 	}()
 
 	// Wait for the child to install its trap.
@@ -617,7 +630,7 @@ func TestRunExec_PreservesArgv0AsTyped(t *testing.T) {
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	var stdout, stderr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--", "argvprobe"}, &stdout, &stderr); code != 0 {
+	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--", "argvprobe"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit %d: %s", code, stderr.String())
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "argv0=argvprobe" {
@@ -633,7 +646,7 @@ func TestRunExec_PreservesArgv0AsTyped(t *testing.T) {
 func TestRunExec_PrintWithCommandIsAUsageError(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--print", "--", "curl", "https://x"}, &stdout, &stderr)
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print", "--", "curl", "https://x"}, &stdout, &stderr)
 	if code != 2 {
 		t.Errorf("exit = %d, want 2 (usage)", code)
 	}
@@ -658,7 +671,7 @@ func TestRunExec_PrintWithCommandWritesNothing(t *testing.T) {
 	bundle := filepath.Join(filepath.Dir(caPath), "trust-bundle.pem")
 
 	var stdout, stderr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--print", "--", "curl"}, &stdout, &stderr); code != 2 {
+	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print", "--", "curl"}, &stdout, &stderr); code != 2 {
 		t.Fatalf("exit = %d, want 2", code)
 	}
 	if _, err := os.Stat(bundle); err == nil {
@@ -675,7 +688,7 @@ func TestRunExec_PrintAloneAndCommandAloneBothWork(t *testing.T) {
 	cfgPath, _ := execCfg(t)
 
 	var pout, perr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--print", "--"}, &pout, &perr); code != 0 {
+	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print"}, &pout, &perr); code != 0 {
 		t.Errorf("--print alone: exit %d: %s", code, perr.String())
 	}
 	if !strings.Contains(pout.String(), "export HTTPS_PROXY=") {
@@ -683,7 +696,7 @@ func TestRunExec_PrintAloneAndCommandAloneBothWork(t *testing.T) {
 	}
 
 	var cout, cerr bytes.Buffer
-	if code := runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", "echo ran"}, &cout, &cerr); code != 0 {
+	if code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--", "/bin/sh", "-c", "echo ran"}, &cout, &cerr); code != 0 {
 		t.Errorf("command alone: exit %d: %s", code, cerr.String())
 	}
 	if strings.TrimSpace(cout.String()) != "ran" {
@@ -703,7 +716,7 @@ func TestRunExec_PreservesInheritedNoProxy(t *testing.T) {
 	t.Setenv("no_proxy", "internal.example.com")
 
 	var stdout, stderr bytes.Buffer
-	code := runExec([]string{"--config", cfgPath, "--",
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--",
 		"/bin/sh", "-c", `printf 'NO_PROXY=%s\nno_proxy=%s\n' "$NO_PROXY" "$no_proxy"`}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit %d: %s", code, stderr.String())
@@ -758,7 +771,7 @@ func TestBridgeGate_ExecAndEnableAgree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, execErr := execEnv(cfgPath)
+	_, execErr := execEnvFor(t, cfgPath)
 	if execErr == nil {
 		t.Fatal("exec accepted a disabled bridge")
 	}
@@ -766,8 +779,159 @@ func TestBridgeGate_ExecAndEnableAgree(t *testing.T) {
 	if code := claudeCodeEnable(filepath.Join(dir, "settings.json"), cfgPath, true, &stdout, &stderr); code == 0 {
 		t.Fatal("claude-code enable accepted a disabled bridge")
 	}
-	// Same message, so a user sees one explanation whichever command they reached for.
-	if !strings.Contains(stderr.String(), execErr.Error()) {
-		t.Errorf("the two commands explain it differently:\n exec:   %v\n enable: %s", execErr, stderr.String())
+	// The same EXPLANATION, from the one shared errBridgeDisabled. Not byte-identical
+	// any more, and deliberately so: each names where its config came from — a stats
+	// URL for exec, a file path for enable — because that is the thing the reader can
+	// go and change. What must not differ is the diagnosis.
+	const reason = `tls_bridge.mode must be "enabled"`
+	if !strings.Contains(execErr.Error(), reason) {
+		t.Errorf("exec's error omits the shared reason:\n%v", execErr)
+	}
+	if !strings.Contains(stderr.String(), reason) {
+		t.Errorf("enable's error omits the shared reason:\n%s", stderr.String())
+	}
+	// And both must point at their own source, so neither blames the wrong thing.
+	if !strings.Contains(stderr.String(), cfgPath) {
+		t.Errorf("enable's error should name the config file it read:\n%s", stderr.String())
+	}
+}
+
+// execStats stands up a stub /config endpoint and returns its base URL, so the
+// tests exercise the same path production does: exec fetches the RUNNING proxy's
+// config rather than reading a file.
+//
+// Serving real config YAML through config.Load and back out as JSON, rather than
+// hand-writing the JSON, keeps the fixture honest about the shape /config actually
+// returns — including that the fields exec reads survive redaction.
+func execStats(t *testing.T, cfgPath string) string {
+	t.Helper()
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("loading the fixture config: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/config" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		raw, merr := json.Marshal(cfg)
+		if merr != nil {
+			http.Error(w, merr.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Through the same redactor the real endpoint uses, so a test cannot pass on
+		// a field production would have stripped.
+		_, _ = w.Write(redact.JSON(raw))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/"
+}
+
+// execEnvFor is execEnv against a stub serving the given config file.
+func execEnvFor(t *testing.T, cfgPath string) (map[string]string, error) {
+	t.Helper()
+	return execEnv(execStats(t, cfgPath))
+}
+
+// --- The three behaviours changed in this round ---
+
+// `abctl exec --print` is a complete request: it asks for the environment, and
+// there is no command for a delimiter to separate. It used to print usage text,
+// answering a well-formed request with help.
+func TestRunExec_PrintNeedsNoDelimiter(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "export HTTPS_PROXY=") {
+		t.Errorf("--print printed no exports:\n%s", stdout.String())
+	}
+	// Specifically not usage text.
+	if strings.Contains(stdout.String(), "Usage:") || strings.Contains(stderr.String(), "Usage:") {
+		t.Errorf("--print emitted usage text:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+}
+
+// `abctl exec --print --` is the opposite mistake: the delimiter promises a command
+// and none follows. Refused rather than quietly read as plain --print.
+func TestRunExec_PrintWithEmptyCommandIsAUsageError(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--cortex-stats-url", execStats(t, cfgPath), "--print", "--"}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("exit = %d, want 2 (usage)", code)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("emitted exports despite the usage error:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "nothing to separate") {
+		t.Errorf("error should explain the empty command:\n%s", stderr.String())
+	}
+}
+
+// exec works against a running proxy, which already has a config, so there is no
+// --config flag to point at a file.
+func TestRunExec_HasNoConfigFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", "/tmp/whatever.yaml", "--", "true"}, &stdout, &stderr)
+	if code != 2 {
+		t.Errorf("exit = %d, want 2 for an unknown flag", code)
+	}
+	if !strings.Contains(stderr.String(), "not defined") {
+		t.Errorf("--config should be rejected as undefined:\n%s", stderr.String())
+	}
+}
+
+// The values must come from the RUNNING proxy, not a file. Proven by serving a
+// config whose addresses differ from anything on disk and checking they arrive.
+func TestExecEnv_ReadsTheRunningProxyNotAFile(t *testing.T) {
+	dir := t.TempDir()
+	caDir := filepath.Join(dir, "live-ca")
+	if err := os.MkdirAll(caDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"ca.crt", tlsbridge.TrustBundleName} {
+		if err := os.WriteFile(filepath.Join(caDir, n), []byte(testCAPEM), 0o644); err != nil { //nolint:gosec // test fixture
+			t.Fatal(err)
+		}
+	}
+	cfgPath := filepath.Join(dir, "live.yaml")
+	body := "mode: proxy-sidecar\n" +
+		"listener:\n  roles: [forward]\n  forward_proxy_addr: \"127.0.0.1:51999\"\n" +
+		"tls_bridge:\n  mode: enabled\n  ca_dir: \"" + caDir + "\"\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := execEnv(execStats(t, cfgPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 51999 appears in no file abctl would default to; it can only have come from
+	// the served config.
+	if got := env["HTTPS_PROXY"]; got != "http://127.0.0.1:51999" {
+		t.Errorf("HTTPS_PROXY = %q, want the running proxy's address", got)
+	}
+	if got := env[envCACerts]; got != filepath.Join(caDir, "ca.crt") {
+		t.Errorf("%s = %q, want the running proxy's CA", envCACerts, got)
+	}
+}
+
+// A stats URL that is not a URL is reported as such, rather than becoming a
+// confusing connection error.
+func TestExecEnv_RejectsAMalformedStatsURL(t *testing.T) {
+	if _, err := execEnv("not a url"); err == nil {
+		t.Fatal("want an error for a malformed stats URL")
+	}
+}
+
+// The default is the documented local address, so a plain `abctl exec` needs no
+// flag on a normal install.
+func TestDefaultCortexStatsURL(t *testing.T) {
+	if defaultCortexStatsURL != "http://localhost:47602/" {
+		t.Errorf("defaultCortexStatsURL = %q, want http://localhost:47602/", defaultCortexStatsURL)
 	}
 }

--- a/authbridge/cmd/abctl/cmd_exec_test.go
+++ b/authbridge/cmd/abctl/cmd_exec_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // execCfg writes a Cortex config and returns its path plus the CA path it names.
@@ -627,5 +630,133 @@ func TestRunExec_BeforeFirstStart_StillRuns(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "does not exist yet") {
 		t.Errorf("expected a note about the missing CA:\n%s", stderr.String())
+	}
+}
+
+// TestRunExec_RelaysSIGTERM. A signal aimed at abctl's own PID — `timeout 30
+// abctl exec -- …`, a CI runner, systemd — killed abctl under Go's default
+// disposition and left the child running with the injected environment. The
+// README claims this is safe in a pipeline or a Makefile, and `timeout` is
+// exactly that case.
+func TestRunExec_RelaysSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no POSIX signals")
+	}
+	cfgPath, _ := execCfg(t)
+	dir := t.TempDir()
+	started := filepath.Join(dir, "started")
+	// The child records that it caught SIGTERM. Without relaying it never runs the
+	// trap, and the file stays absent.
+	caught := filepath.Join(dir, "caught")
+	script := "trap 'touch " + caught + "; exit 0' TERM; touch " + started +
+		"; i=0; while [ $i -lt 100 ]; do sleep 0.1; i=$((i+1)); done"
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- runExec([]string{"--config", cfgPath, "--", "/bin/sh", "-c", script}, &stdout, &stderr)
+	}()
+
+	// Wait for the child to install its trap.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, err := os.Stat(started); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child never started")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Signal THIS process, the way `timeout` signals abctl. runExec's relay must
+	// pass it to the child.
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("runExec did not return after SIGTERM; the child was not signalled")
+	}
+	if _, err := os.Stat(caught); err != nil {
+		t.Error("the child never received SIGTERM, so it would have been orphaned")
+	}
+}
+
+// TestRunExec_PreservesArgv0AsTyped. exec.Command sets Args[0] to the resolved
+// absolute path; a shell passes the name as typed. Multi-call binaries dispatch
+// on argv[0], and tools echo it in their usage and errors.
+func TestRunExec_PreservesArgv0AsTyped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfg(t)
+	dir := t.TempDir()
+	// A compiled probe, not a shell script: /bin/sh reports $0 from its shebang
+	// invocation rather than the argv[0] it was handed, so a script cannot observe
+	// what is under test here.
+	src := filepath.Join(dir, "argvprobe.go")
+	if err := os.WriteFile(src, []byte(
+		"package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc main() { fmt.Printf(\"argv0=%s\\n\", os.Args[0]) }\n"),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "argvprobe")
+	build := exec.Command("go", "build", "-o", bin, src)
+	build.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=-mod=mod")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Skipf("cannot build the probe here: %v\n%s", err, out)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	if code := runExec([]string{"--config", cfgPath, "--", "argvprobe"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "argv0=argvprobe" {
+		t.Errorf("got %q, want argv0 as typed (%q), not the resolved path", got, "argv0=argvprobe")
+	}
+}
+
+// TestRunExec_PrintWithCommandSaysSo: silently discarding the command is the same
+// discourtesy the strict pre-delimiter check exists to avoid.
+func TestRunExec_PrintWithCommandSaysSo(t *testing.T) {
+	cfgPath, _ := execCfg(t)
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--print", "--", "curl", "https://x"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "export HTTPS_PROXY=") {
+		t.Error("--print should still print the exports")
+	}
+	if !strings.Contains(stderr.String(), "was not run") {
+		t.Errorf("expected a note that the command was ignored:\n%s", stderr.String())
+	}
+}
+
+// TestRunExec_PreservesInheritedNoProxy. NO_PROXY is not ours to touch: a host
+// listed there bypasses Cortex, and with the replacing CA vars now carrying the
+// system roots, such a request still verifies against public trust.
+func TestRunExec_PreservesInheritedNoProxy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	cfgPath, _ := execCfg(t)
+	t.Setenv("NO_PROXY", "internal.example.com,.corp")
+	t.Setenv("no_proxy", "internal.example.com")
+
+	var stdout, stderr bytes.Buffer
+	code := runExec([]string{"--config", cfgPath, "--",
+		"/bin/sh", "-c", `printf 'NO_PROXY=%s\nno_proxy=%s\n' "$NO_PROXY" "$no_proxy"`}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, stderr.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "NO_PROXY=internal.example.com,.corp") ||
+		!strings.Contains(got, "no_proxy=internal.example.com") {
+		t.Errorf("NO_PROXY was not preserved:\n%s", got)
 	}
 }

--- a/authbridge/cmd/abctl/local_endpoint.go
+++ b/authbridge/cmd/abctl/local_endpoint.go
@@ -119,6 +119,20 @@ var errNoRunningCortex = errors.New("no Cortex is running on this machine")
 // process means the values describe the thing that will actually serve the request,
 // and a proxy that is down is reported as down rather than yielding an environment
 // that points at nothing.
+// TRUST NOTE, considered rather than missed: this moves the trust anchor from a
+// file only the user can write to whatever answers on a TCP port. The response
+// carries tls_bridge.ca_dir, from which exec derives a CA path it injects into four
+// variables that REPLACE the child's trust store — so anything able to bind 47602
+// before Cortex does (no privileges needed, any local account) could hand back a
+// proxy URL and a CA of its choosing. `claude-code enable` reads a file instead, so
+// this is new surface rather than a regression.
+//
+// Not hardened further here: on a single-user workstation a local process that can
+// squat a port can generally also write ~/.cortex, so the file path is not much
+// stronger, and requiring the response to "look like Cortex" is a speed bump rather
+// than a boundary. Worth revisiting if abctl ever runs somewhere multi-tenant —
+// checking that ca_dir is where abctl expects Cortex's own to be would be the
+// cheapest first step.
 func runningConfig(base string) (*config.Config, error) {
 	u, perr := url.Parse(base)
 	if perr != nil || u.Host == "" {

--- a/authbridge/cmd/abctl/local_endpoint.go
+++ b/authbridge/cmd/abctl/local_endpoint.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,4 +87,73 @@ func dialable(endpoint string) bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+// runningConfigTimeout bounds the fetch of a running proxy's live config. Longer
+// than localProbeTimeout because this one is not a speculative "is anything
+// there?" on a hot path — the user has explicitly asked to run something through
+// the proxy, so a slow answer beats a wrong one.
+const runningConfigTimeout = 2 * time.Second
+
+// defaultCortexStatsURL is where a local Cortex serves its stats endpoints.
+//
+// A fixed default rather than a value read from ~/.cortex/config.yaml. The file
+// would only ever tell us where to ask, and reading it for that reintroduces the
+// staleness the live fetch exists to avoid: an edited stats address would send
+// abctl to the wrong port and have it report "nothing running" about a proxy that
+// is running fine. One well-known port, with --cortex-stats-url for a non-default
+// install.
+const defaultCortexStatsURL = "http://localhost:47602/"
+
+// errNoRunningCortex means nothing answered at the stats URL.
+var errNoRunningCortex = errors.New("no Cortex is running on this machine")
+
+// runningConfig returns the config of the Cortex actually running, fetched from
+// the stats server's /config endpoint under base.
+//
+// Read from the running process rather than from ~/.cortex/config.yaml on purpose.
+// `abctl exec` hands its child the addresses of a proxy that must be up for the
+// child to work at all, so the file is the wrong source of truth twice over: it can
+// have been edited since the proxy started (listener addresses are not hot-reloaded
+// at all), and it says nothing about whether anything is listening. Asking the
+// process means the values describe the thing that will actually serve the request,
+// and a proxy that is down is reported as down rather than yielding an environment
+// that points at nothing.
+func runningConfig(base string) (*config.Config, error) {
+	u, perr := url.Parse(base)
+	if perr != nil || u.Host == "" {
+		return nil, fmt.Errorf("%q is not a URL like %s", base, defaultCortexStatsURL)
+	}
+	// JoinPath rather than concatenation, so a base with or without a trailing
+	// slash — and the documented default has one — yields exactly one "/config".
+	cfgURL := u.JoinPath("config").String()
+
+	c := &http.Client{Timeout: runningConfigTimeout}
+	resp, err := c.Get(cfgURL) //nolint:noctx // bounded by Timeout
+	if err != nil {
+		return nil, fmt.Errorf("%w (nothing answered at %s)", errNoRunningCortex, cfgURL)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%w (%s returned %s)", errNoRunningCortex, cfgURL, resp.Status)
+	}
+
+	// Capped read: a local endpoint, but a wrong service holding the port should not
+	// stream unbounded JSON into abctl.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", cfgURL, err)
+	}
+	var cfg config.Config
+	if uerr := json.Unmarshal(body, &cfg); uerr != nil {
+		return nil, fmt.Errorf("%s did not return a Cortex config: %w", cfgURL, uerr)
+	}
+	// /config redacts values whose keys end in secret/password/token/key/credential.
+	// Nothing exec reads is redacted — forward_proxy_addr, tls_bridge.mode and
+	// tls_bridge.ca_dir all survive — but an empty proxy address would otherwise
+	// surface as a confusing downstream error, so it is named here.
+	if cfg.Listener.ForwardProxyAddr == "" {
+		return nil, fmt.Errorf("the Cortex at %s reports no listener.forward_proxy_addr", cfgURL)
+	}
+	return &cfg, nil
 }

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -36,7 +36,7 @@ var version = "dev"
 // One list rather than two: the unknown-subcommand error used to hardcode its own
 // copy, so adding a subcommand meant editing both and forgetting one left a typo
 // getting an incomplete list. A test holds the usage block to this slice.
-var dispatchableSubcommands = []string{"observe", "service", "claude-code", "tools"}
+var dispatchableSubcommands = []string{"observe", "service", "claude-code", "exec", "tools"}
 
 // unknownSubcommandMessage is the error for an unrecognised first argument.
 func unknownSubcommandMessage(name string) string {
@@ -56,6 +56,8 @@ Usage:
   abctl service <action>     run Cortex as a service: install, uninstall,
                              status, stop, start, restart
   abctl claude-code <action> point Claude Code at Cortex: enable, disable, status
+  abctl exec -- CMD [ARG...] run CMD with Cortex's proxy and CA in its
+                             environment, for tools with no settings file
   abctl tools <action>       tool-definition costs: scan
 
   abctl                      deprecated: same as "abctl observe". Bare abctl
@@ -80,6 +82,8 @@ func main() {
 			os.Exit(runTools(os.Args[2:], os.Stdout, os.Stderr))
 		case "claude-code":
 			os.Exit(runClaudeCode(os.Args[2:], os.Stdout, os.Stderr))
+		case "exec":
+			os.Exit(runExec(os.Args[2:], os.Stdout, os.Stderr))
 		case "service":
 			os.Exit(runService(os.Args[2:], os.Stdout, os.Stderr))
 		case "observe":


### PR DESCRIPTION
Routes a single child process through Cortex, for the agents and tools that have no settings file to persist env vars in.

```sh
abctl exec -- bob
abctl exec -- claude --dangerously-skip-permissions
abctl exec -- curl -sv https://api.anthropic.com/v1/messages
```

Everything after `--` is passed to the child untouched, and its exit status is returned (127 not found, 128+signum signaled). Nine variables are injected from three values: `HTTP_PROXY`/`HTTPS_PROXY` + the lowercase pair get the forward proxy URL; `NODE_EXTRA_CA_CERTS` gets `ca.crt` (it *adds* to the runtime's roots); and `CURL_CA_BUNDLE`/`REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE`/`GIT_SSL_CAINFO` get `bundle.crt`, the bridge CA plus the platform roots, because those four *replace* the trust store and the bare CA would leave the child trusting nothing else. All derived from the same `wanted()` that `claude-code enable` uses, so the two commands cannot drift. `--print` emits eval-able exports.

Also fixes a nil deref in `wanted()`: `tls_bridge` is an `omitempty` pointer, so `abctl claude-code enable` segfaulted on a valid config with no `tls_bridge:` block rather than reporting it cleanly.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `abctl exec` to run commands with Cortex proxy and TLS bridge settings.
  - Added `--print` mode for shell-compatible proxy and trust-bundle exports.
  - Preserves command arguments, signals, exit statuses, and inherited proxy exclusions.
  - Supports combined system and bridge certificates for CA settings.

- **Bug Fixes**
  - Rejects execution and enablement when the TLS bridge is disabled or unavailable.
  - Handles missing certificates safely before the bridge’s first start.

- **Documentation**
  - Clarified TLS bridge requirements, certificate persistence, cleanup, and command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Behaviour change to `abctl claude-code enable`

`enable` now refuses a config with `tls_bridge.mode: disabled` and a `ca_dir` set,
which it previously accepted. That combination is valid YAML (`ca_dir` is only
*required* when the mode is `enabled`), but the bridge then terminates no TLS, so
the CA it wrote into `settings.json` bought nothing while breaking https for
Claude Code. `exec` grew the check first; it now lives in shared
`bridgeEnabled`/`errBridgeDisabled` helpers so the two commands cannot disagree
about the bridge posture.

`enable` also now points the four replacing variables at `bundle.crt` rather than
`ca.crt` — see the `tlsbridge.TrustBundleName` docs for why the bare CA breaks
every unproxied TLS call.
