### PR TITLE
Docs: Require a per-session git worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,33 @@ This file provides context for Claude (AI assistant) when working with the `cort
 
 ## AI Assistant Instructions
 
+- **Always work in your own git worktree — never in the shared top-level checkout.**
+  Several Claude Code sessions run against this repo at once. They share one object
+  store, which is fine, but a shared *working tree* is not: `git checkout` in one
+  session rewrites files under another, and two sessions' uncommitted edits land in one
+  index. Before starting work:
+
+  ```sh
+  git fetch https://github.com/rossoctl/cortex.git main
+  git rev-parse --short FETCH_HEAD          # verify what you are branching from
+  git worktree add .worktrees/<topic> -b <branch> FETCH_HEAD
+  ```
+
+  Then stay in that directory. Leave the top-level checkout alone — treat it as a
+  reference copy someone else may be using.
+
+  Three things learned the hard way:
+  - **Verify `FETCH_HEAD` before branching from it.** It is shared across worktrees, so
+    a stale one silently branches from an ancient commit. That has already reverted
+    `CLAUDE.md` mid-session to a pre-rename state.
+  - **Git refuses to check out one branch in two worktrees.** That is a feature, not an
+    obstacle — if it refuses, another session has the branch.
+  - **Worktrees do not isolate the running Cortex.** One `~/.cortex/config.yaml`, one
+    launchd label, one proxy on `:47600`, and every session's `HTTPS_PROXY` points at
+    it. `abctl service install`, `service restart` and `--ref=main` all replace that
+    single instance and cut every other session's traffic. Coordinate before touching
+    it.
+
 - **Use `Assisted-By` for attribution** — never add `Co-Authored-By`, `Generated with Claude Code`, or similar trailers. See [Commit Attribution Policy](#commit-attribution-policy) below.
 
 ## Repository Overview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,24 +12,38 @@ This file provides context for Claude (AI assistant) when working with the `cort
 
   ```sh
   git fetch https://github.com/rossoctl/cortex.git main
-  git rev-parse --short FETCH_HEAD          # verify what you are branching from
-  git worktree add .worktrees/<topic> -b <branch> FETCH_HEAD
+  # Capture the commit now. FETCH_HEAD is one file per repository, not per
+  # worktree, so reading it twice can hand you two different commits.
+  base=$(git rev-parse --short FETCH_HEAD) && echo "$base"
+  git worktree add .worktrees/<topic> -b <branch> "$base"
   ```
 
   Then stay in that directory. Leave the top-level checkout alone — treat it as a
-  reference copy someone else may be using.
+  reference copy someone else may be using. When the branch is merged or abandoned,
+  clean up after yourself: `git worktree remove .worktrees/<topic>` (add `--force` if it
+  still has untracked files), then `git worktree prune`. An abandoned worktree keeps its
+  branch checked out forever, which is what turns the next session's `worktree add` into
+  a puzzling failure.
 
   Three things learned the hard way:
-  - **Verify `FETCH_HEAD` before branching from it.** It is shared across worktrees, so
-    a stale one silently branches from an ancient commit. That has already reverted
-    `CLAUDE.md` mid-session to a pre-rename state.
-  - **Git refuses to check out one branch in two worktrees.** That is a feature, not an
-    obstacle — if it refuses, another session has the branch.
+  - **Capture the base commit; do not name `FETCH_HEAD` twice.** A concurrent fetch
+    between your `rev-parse` and your `worktree add` moves it underneath you, so the
+    verification passes and you still branch from the wrong commit. A stale one has
+    already reverted `CLAUDE.md` mid-session to a pre-rename state.
+  - **A refused `worktree add` does not always mean another session holds the branch.**
+    `-b <branch>` also fails when the branch merely exists with nothing checking it out
+    — including branches left behind by worktrees that were deleted rather than removed.
+    `git worktree list` says who actually holds what; the error text does not. When it
+    does show a live worktree on that branch, the refusal is a feature: pick another
+    name, do not force past it.
   - **Worktrees do not isolate the running Cortex.** One `~/.cortex/config.yaml`, one
     launchd label, one proxy on `:47600`, and every session's `HTTPS_PROXY` points at
-    it. `abctl service install`, `service restart` and `--ref=main` all replace that
-    single instance and cut every other session's traffic. Coordinate before touching
-    it.
+    it. `abctl service restart` always replaces that instance and cuts every attached
+    session. `abctl service install` only does so when it has something to change or a
+    running proxy to adopt — with nothing to do it prints `Already current` and leaves
+    the proxy alone. `--ref=main` is an `install.sh` flag, not an `abctl` one; it picks
+    which installer script runs, so whether it interrupts anything depends on what that
+    install then finds. Coordinate before any of it.
 
 - **Use `Assisted-By` for attribution** — never add `Co-Authored-By`, `Generated with Claude Code`, or similar trailers. See [Commit Attribution Policy](#commit-attribution-policy) below.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,20 +11,19 @@ This file provides context for Claude (AI assistant) when working with the `cort
   index. Before starting work:
 
   ```sh
-  git fetch https://github.com/rossoctl/cortex.git main
-  # This bootstrap necessarily runs in the shared top-level checkout, so its
-  # FETCH_HEAD is shared too. Capture the commit rather than reading it twice.
-  base=$(git rev-parse --short FETCH_HEAD) && echo "$base"
-  git worktree add .worktrees/<topic> -b <branch> "$base"
+  # Fetch into a ref only you write, so nothing can move it underneath you.
+  git fetch https://github.com/rossoctl/cortex.git main:refs/base/<topic>
+  git worktree add .worktrees/<topic> -b <branch> refs/base/<topic>
   ```
 
   Then stay in that directory. Leave the top-level checkout alone — treat it as a
   reference copy someone else may be using. When the branch is merged or abandoned, tear
-  down both halves:
+  down all three things you created:
 
   ```sh
   git worktree remove .worktrees/<topic>   # --force if untracked files remain
-  git branch -d <branch>                   # -D if you abandoned it unmerged
+  git branch -d <branch>
+  git update-ref -d refs/base/<topic>
   ```
 
   `remove` cleans up its own bookkeeping, so `git worktree prune` is not needed here —
@@ -33,14 +32,21 @@ This file provides context for Claude (AI assistant) when working with the `cort
   name fail. Deleting the worktree directory instead of removing it is worse: the branch
   stays checked out indefinitely.
 
+  When `branch -d` answers *not fully merged*, that is usually not what happened. It
+  judges reachability from the HEAD of whichever tree you run it in, which is normally
+  the top-level checkout you were told not to touch — so it is simply behind. PRs land
+  here as merge commits, so bring `main` up to date and `-d` will accept the branch.
+  Save `-D` for work you really are discarding: it drops unpushed commits silently.
+
   Three things learned the hard way:
-  - **Capture the base commit; do not name `FETCH_HEAD` twice.** `FETCH_HEAD` is
-    per-worktree, but the bootstrap above has to run in the shared top-level checkout, so
-    every session fetching there writes that one file. A concurrent fetch between your
-    `rev-parse` and your `worktree add` moves it underneath you: the verification passes
-    and you branch from the wrong commit anyway. That is how `CLAUDE.md` got reverted
-    mid-session to a pre-rename state. Once you are inside your own worktree,
-    `FETCH_HEAD` is private and this stops being a concern.
+  - **Fetch into your own ref; never branch from `FETCH_HEAD`.** `FETCH_HEAD` is
+    per-worktree, but this bootstrap has to run in the shared top-level checkout, so
+    every session fetching there writes that one file — and a fetch landing between your
+    reading it and your using it hands you a different commit than the one you checked.
+    That is how `CLAUDE.md` got reverted mid-session to a pre-rename state. Nothing but
+    you writes `refs/base/<topic>`, so there is no window to lose and no verification
+    step to remember. Do not use `refs/worktree/` for this — git reserves that namespace
+    for per-worktree refs.
   - **A refused `worktree add` does not always mean another session holds the branch.**
     `-b <branch>` also fails when the branch merely exists with nothing checking it out —
     which is what a `worktree remove` without the matching `branch -d` leaves behind.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,27 +12,38 @@ This file provides context for Claude (AI assistant) when working with the `cort
 
   ```sh
   git fetch https://github.com/rossoctl/cortex.git main
-  # Capture the commit now. FETCH_HEAD is one file per repository, not per
-  # worktree, so reading it twice can hand you two different commits.
+  # This bootstrap necessarily runs in the shared top-level checkout, so its
+  # FETCH_HEAD is shared too. Capture the commit rather than reading it twice.
   base=$(git rev-parse --short FETCH_HEAD) && echo "$base"
   git worktree add .worktrees/<topic> -b <branch> "$base"
   ```
 
   Then stay in that directory. Leave the top-level checkout alone — treat it as a
-  reference copy someone else may be using. When the branch is merged or abandoned,
-  clean up after yourself: `git worktree remove .worktrees/<topic>` (add `--force` if it
-  still has untracked files), then `git worktree prune`. An abandoned worktree keeps its
-  branch checked out forever, which is what turns the next session's `worktree add` into
-  a puzzling failure.
+  reference copy someone else may be using. When the branch is merged or abandoned, tear
+  down both halves:
+
+  ```sh
+  git worktree remove .worktrees/<topic>   # --force if untracked files remain
+  git branch -d <branch>                   # -D if you abandoned it unmerged
+  ```
+
+  `remove` cleans up its own bookkeeping, so `git worktree prune` is not needed here —
+  that is for a worktree directory someone deleted by hand. What `remove` does leave is
+  the branch, and a leftover branch is enough to make the next `worktree add -b` of that
+  name fail. Deleting the worktree directory instead of removing it is worse: the branch
+  stays checked out indefinitely.
 
   Three things learned the hard way:
-  - **Capture the base commit; do not name `FETCH_HEAD` twice.** A concurrent fetch
-    between your `rev-parse` and your `worktree add` moves it underneath you, so the
-    verification passes and you still branch from the wrong commit. A stale one has
-    already reverted `CLAUDE.md` mid-session to a pre-rename state.
+  - **Capture the base commit; do not name `FETCH_HEAD` twice.** `FETCH_HEAD` is
+    per-worktree, but the bootstrap above has to run in the shared top-level checkout, so
+    every session fetching there writes that one file. A concurrent fetch between your
+    `rev-parse` and your `worktree add` moves it underneath you: the verification passes
+    and you branch from the wrong commit anyway. That is how `CLAUDE.md` got reverted
+    mid-session to a pre-rename state. Once you are inside your own worktree,
+    `FETCH_HEAD` is private and this stops being a concern.
   - **A refused `worktree add` does not always mean another session holds the branch.**
-    `-b <branch>` also fails when the branch merely exists with nothing checking it out
-    — including branches left behind by worktrees that were deleted rather than removed.
+    `-b <branch>` also fails when the branch merely exists with nothing checking it out —
+    which is what a `worktree remove` without the matching `branch -d` leaves behind.
     `git worktree list` says who actually holds what; the error text does not. When it
     does show a live worktree on that branch, the refusal is a feature: pick another
     name, do not force past it.


### PR DESCRIPTION
Several Claude Code sessions run against this repo at once. They share one object store — fine — but a shared **working tree** is not: `git checkout` in one session rewrites files under another, and two sessions' uncommitted edits land in one index.

## Why it is written down

It already went wrong, twice, in one session:

- I branched from a stale `FETCH_HEAD` in the shared top-level checkout and landed that checkout on a **pre-rename commit**, which reverted both `CLAUDE.md` files mid-session. Any other session in that directory would have seen its files rewritten underneath it.
- I switched the shared checkout off `fix/ca-trust-bundle` without knowing whose branch it was.

Neither was a git problem. Both were treating a shared worktree as private.

## What the convention says

```sh
# Fetch into a ref only you write, so nothing can move it underneath you.
git fetch https://github.com/rossoctl/cortex.git main:refs/base/<topic>
git worktree add .worktrees/<topic> -b <branch> refs/base/<topic>
```

Then stay there and leave the top-level checkout alone as a reference copy. Tear down all three things you created when the branch is merged or abandoned: `git worktree remove .worktrees/<topic>`, `git branch -d <branch>`, `git update-ref -d refs/base/<topic>`.

## Three non-obvious specifics

- **Fetch into your own ref; never branch from `FETCH_HEAD`.** `FETCH_HEAD` is per-worktree, but this bootstrap has to run in the shared top-level checkout — so that one file is what several sessions collide over, and a fetch landing between reading it and using it hands you someone else's commit. That is the failure above. Nothing but you writes `refs/base/<topic>`, so there is no window to lose and no verification step to remember.
- **A refused `worktree add -b` is not proof another session holds the branch.** It also fails when the branch merely exists unchecked-out — exactly what a `worktree remove` without the matching `branch -d` leaves behind. `git worktree list` is the real answer; when it does show a live worktree there, the refusal is a feature — do not force past it.
- **Worktrees do not isolate the running Cortex.** One `~/.cortex/config.yaml`, one launchd label, one proxy on `:47600`, and every session's `HTTPS_PROXY` points at it. `abctl service restart` always replaces that instance and cuts every attached session. `abctl service install` only does when it has something to change or a running proxy to adopt — otherwise it prints `Already current` and leaves it alone. `--ref=main` is an `install.sh` flag, not an `abctl` one. That needs coordination, not tooling.

In `CLAUDE.md` rather than assistant memory so every session inherits it, not just the one that learned it.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for using isolated worktrees and verifying repository state before creating branches.
  * Added coordination guidance for shared runtime resources and service-related commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
