### PR TITLE
Feat: Report per-request cost and coverage on /v1/usage

### DIFF
--- a/authbridge/authlib/costevent/costevent.go
+++ b/authbridge/authlib/costevent/costevent.go
@@ -1,0 +1,76 @@
+// Package costevent is the canonical wire shape of the per-request cost that
+// litellm-budget-track publishes onto a session event.
+//
+// It lives in its own package because the producer is a plugin while the
+// consumers are the usage aggregator and abctl, and none of those should import
+// each other. Before this package existed the struct was declared once in the
+// plugin, again in abctl, and was about to be declared a third time in the
+// aggregator — which is the duplication cortex #910 exists to remove.
+//
+// Dependency-light on purpose: the aggregator links this on every build,
+// including the trimmed "lite" images that exclude the plugin entirely.
+package costevent
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// PluginName is the session-event key the cost event is published under. It must
+// equal litellm_budgettrack.BudgetTrack.Name(); a test in that package asserts it.
+const PluginName = "litellm-budget-track"
+
+// Source names how the cost was arrived at.
+const (
+	// SourceGatewayHeader is the gateway's own post-discount figure, read from
+	// x-litellm-response-cost. Authoritative.
+	SourceGatewayHeader = "gateway-header"
+	// SourceUsageFallback is priced from token counters because the header
+	// reported 0 — which every streamed response does, so for a streaming agent
+	// this is the common case, not the exception.
+	SourceUsageFallback = "usage-fallback"
+)
+
+// Event is one request's settled cost. Unlike tool-prune's event, which carries
+// rates and leaves the arithmetic to the consumer, this carries a finished
+// figure.
+type Event struct {
+	CostUSD float64 `json:"cost_usd"`
+	// Source is SourceGatewayHeader or SourceUsageFallback. A consumer that
+	// distinguishes authoritative from modelled figures reads this.
+	Source        string  `json:"source"`
+	DailyTotalUSD float64 `json:"daily_total_usd"`
+	DailyMaxUSD   float64 `json:"daily_max_usd"`
+}
+
+// Micros converts CostUSD to millionths of a dollar, rounded to nearest.
+//
+// The integer unit is what usage.Counts accumulates: it keeps bucket addition
+// exact and JSON round-tripping lossless, which float dollars are not. A cost
+// below half a micro rounds to 0 while still counting as priced — a real
+// sub-micro charge, not an unknown one.
+func (e Event) Micros() int64 { return int64(math.Round(e.CostUSD * 1e6)) }
+
+// Decode pulls the cost event off a session event.
+//
+// A false return is the normal case, not an error: the plugin may not be in the
+// pipeline, and a request that charged nothing (cache hit, error) emits nothing.
+// A non-positive cost also returns false — "free" and "unknown" must not be
+// conflated, and a consumer that treated 0 as priced would render $0.00 for
+// traffic it simply cannot price.
+func Decode(e *pipeline.SessionEvent) (Event, bool) {
+	if e == nil || len(e.Plugins) == 0 {
+		return Event{}, false
+	}
+	raw, ok := e.Plugins[PluginName]
+	if !ok {
+		return Event{}, false
+	}
+	var ev Event
+	if err := json.Unmarshal(raw, &ev); err != nil || ev.CostUSD <= 0 {
+		return Event{}, false
+	}
+	return ev, true
+}

--- a/authbridge/authlib/costevent/costevent_test.go
+++ b/authbridge/authlib/costevent/costevent_test.go
@@ -1,0 +1,131 @@
+package costevent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// eventWith builds a SessionEvent carrying raw JSON under the cost-event key.
+func eventWith(t *testing.T, key, raw string) *pipeline.SessionEvent {
+	t.Helper()
+	return &pipeline.SessionEvent{
+		Plugins: map[string]json.RawMessage{key: json.RawMessage(raw)},
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *pipeline.SessionEvent
+		wantOK   bool
+		wantCost float64
+		wantSrc  string
+	}{
+		{
+			name:     "gateway header cost",
+			event:    eventWith(t, PluginName, `{"cost_usd":0.0421,"source":"gateway-header","daily_total_usd":1.5,"daily_max_usd":10}`),
+			wantOK:   true,
+			wantCost: 0.0421,
+			wantSrc:  SourceGatewayHeader,
+		},
+		{
+			name:     "usage fallback cost",
+			event:    eventWith(t, PluginName, `{"cost_usd":0.01,"source":"usage-fallback"}`),
+			wantOK:   true,
+			wantCost: 0.01,
+			wantSrc:  SourceUsageFallback,
+		},
+		{
+			// A cache hit or error charges nothing and the plugin emits nothing;
+			// a zero that does arrive must not read as a priced free request.
+			name:   "zero cost is not priced",
+			event:  eventWith(t, PluginName, `{"cost_usd":0,"source":"gateway-header"}`),
+			wantOK: false,
+		},
+		{
+			name:   "negative cost rejected",
+			event:  eventWith(t, PluginName, `{"cost_usd":-1,"source":"gateway-header"}`),
+			wantOK: false,
+		},
+		{
+			name:   "malformed JSON rejected",
+			event:  eventWith(t, PluginName, `{"cost_usd":`),
+			wantOK: false,
+		},
+		{
+			name:   "different plugin key ignored",
+			event:  eventWith(t, "tool-prune", `{"cost_usd":5}`),
+			wantOK: false,
+		},
+		{
+			name:   "no plugins map",
+			event:  &pipeline.SessionEvent{},
+			wantOK: false,
+		},
+		{
+			name:   "nil event",
+			event:  nil,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Decode(tc.event)
+			if ok != tc.wantOK {
+				t.Fatalf("Decode ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.CostUSD != tc.wantCost {
+				t.Errorf("CostUSD = %v, want %v", got.CostUSD, tc.wantCost)
+			}
+			if got.Source != tc.wantSrc {
+				t.Errorf("Source = %q, want %q", got.Source, tc.wantSrc)
+			}
+		})
+	}
+}
+
+// TestEventJSONTagsArePinned guards the wire format. abctl decodes these exact
+// tags from a separate module that this phase does not rebuild, so a rename here
+// would silently blank its COST column.
+func TestEventJSONTagsArePinned(t *testing.T) {
+	b, err := json.Marshal(Event{
+		CostUSD:       0.25,
+		Source:        SourceGatewayHeader,
+		DailyTotalUSD: 3.5,
+		DailyMaxUSD:   10,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"cost_usd":0.25,"source":"gateway-header","daily_total_usd":3.5,"daily_max_usd":10}`
+	if string(b) != want {
+		t.Errorf("wire format changed:\n got %s\nwant %s", b, want)
+	}
+}
+
+func TestMicros(t *testing.T) {
+	tests := []struct {
+		name string
+		usd  float64
+		want int64
+	}{
+		{"whole dollar", 1, 1_000_000},
+		{"typical request", 0.0421, 42_100},
+		{"rounds to nearest", 0.0000005, 1},
+		{"sub-micro rounds to zero", 0.0000001, 0},
+		{"large", 1234.5678, 1_234_567_800},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Event{CostUSD: tc.usd}).Micros(); got != tc.want {
+				t.Errorf("Micros() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 )
@@ -83,27 +84,9 @@ func (c budgetTrackConfig) cacheReadRate() float64 {
 // streaming frames until the terminal frame prices it.
 const stateKey = "litellm-budget-track"
 
-// Wire values for costEvent.Source — consumers branch on these.
-const (
-	sourceGatewayHeader = "gateway-header"
-	sourceUsageFallback = "usage-fallback"
-)
-
-// costEvent surfaces one priced response. Emitted per response when
-// cost > 0; consumers see it as SessionEvent.Plugins["litellm-budget-track"].
-type costEvent struct {
-	CostUSD float64 `json:"cost_usd"`
-
-	// Source is sourceGatewayHeader (authoritative x-litellm-response-cost)
-	// or sourceUsageFallback (priced from token counters, used for streamed
-	// responses whose header always reports 0).
-	Source string `json:"source"`
-
-	// DailyTotalUSD is the ledger total after this response was added.
-	// DailyMaxUSD is the configured cap.
-	DailyTotalUSD float64 `json:"daily_total_usd"`
-	DailyMaxUSD   float64 `json:"daily_max_usd"`
-}
+// The per-response cost event this plugin publishes lives in authlib/costevent:
+// the usage aggregator and abctl both decode it, so the shape belongs where all
+// three can share one declaration rather than in this package.
 
 // usageState accumulates the largest token counts seen across a stream's
 // frames. Anthropic reports input_tokens in message_start and the cumulative
@@ -201,7 +184,7 @@ func (p *BudgetTrack) OnRequest(_ context.Context, pctx *pipeline.Context) pipel
 func (p *BudgetTrack) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
 	if cost, _ := headerCost(pctx); cost > 0 {
 		if total, ok := p.accumulate(cost); ok {
-			p.emitCost(pctx, cost, sourceGatewayHeader, total)
+			p.emitCost(pctx, cost, costevent.SourceGatewayHeader, total)
 		}
 	}
 	return pipeline.Action{Type: pipeline.Continue}
@@ -252,7 +235,7 @@ func (p *BudgetTrack) OnResponseFrame(_ context.Context, pctx *pipeline.Context,
 	st.settled = true
 
 	cost, present := headerCost(pctx)
-	source := sourceGatewayHeader
+	source := costevent.SourceGatewayHeader
 	if cost <= 0 {
 		// Fall back to per-token pricing only when there is no authoritative
 		// header cost: the header is absent, or this is a streamed response
@@ -267,7 +250,7 @@ func (p *BudgetTrack) OnResponseFrame(_ context.Context, pctx *pipeline.Context,
 				float64(st.cacheWriteTokens)*p.cfg.cacheWriteRate() +
 				float64(st.cacheReadTokens)*p.cfg.cacheReadRate() +
 				float64(st.outputTokens)*p.cfg.OutputCostPerToken
-			source = sourceUsageFallback
+			source = costevent.SourceUsageFallback
 		}
 	}
 	if cost > 0 {
@@ -304,7 +287,7 @@ func (p *BudgetTrack) emitCost(pctx *pipeline.Context, cost float64, source stri
 	if pctx.Extensions.Custom == nil {
 		pctx.Extensions.Custom = map[string]any{}
 	}
-	pctx.Extensions.Custom[p.Name()+pipeline.PluginEventSuffix] = costEvent{
+	pctx.Extensions.Custom[p.Name()+pipeline.PluginEventSuffix] = costevent.Event{
 		CostUSD:       cost,
 		Source:        source,
 		DailyTotalUSD: dailyTotal,

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+	"github.com/rossoctl/cortex/authbridge/authlib/usage"
 )
 
 // configure builds a BudgetTrack with a temp-dir spend file and the given budget.
@@ -663,5 +665,91 @@ func TestEmitCost_NoEmitWhenUnpriced(t *testing.T) {
 				t.Errorf("costEvent emitted on unpriced response: %+v", *ev)
 			}
 		})
+	}
+}
+
+// TestEndToEnd_CostReachesUsageAggregator closes the loop this plugin's cost
+// event depends on but no unit test covers: the plugin writes to
+// pctx.Extensions.Custom, a listener promotes that to SessionEvent.Plugins via
+// pipeline.SnapshotPlugins, and session.Store.Append fans the event out to the
+// usage Aggregator as a Recorder.
+//
+// Every step there is a separate package, and the ordering matters — if the
+// listener appended before snapshotting the plugin map, or SnapshotPlugins
+// dropped the key, /v1/usage would silently report no cost while every unit test
+// still passed. This asserts the composed path, not the pieces.
+func TestEndToEnd_CostReachesUsageAggregator(t *testing.T) {
+	p := configure(t, 10)
+	agg := usage.New()
+	store := session.New(time.Hour, 100, 10)
+	store.AddRecorder(agg)
+
+	// The plugin prices a response, exactly as OnResponse would in a pipeline.
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.0421"}}}
+	p.OnResponse(context.Background(), pctx)
+
+	// The listener's promotion step, verbatim from forwardproxy/server.go.
+	store.Append("sess-e2e", pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionResponse,
+		RequestID: "req-e2e",
+		Host:      "litellm.corp",
+		Inference: &pipeline.InferenceExtension{Model: "claude-opus-5", TotalTokens: 1000},
+		Plugins:   pipeline.SnapshotPlugins(pctx.Extensions.Custom),
+	})
+
+	snap := agg.Snapshot(usage.BucketWidth, usage.BucketWidth, "", usage.GroupNone)
+	if !snap.Priced {
+		t.Error("Priced = false: the cost never reached the aggregator")
+	}
+	if snap.Totals.CostMicros != 42_100 {
+		t.Errorf("CostMicros = %d, want 42100", snap.Totals.CostMicros)
+	}
+	if snap.Totals.PricedRequests != 1 {
+		t.Errorf("PricedRequests = %d, want 1", snap.Totals.PricedRequests)
+	}
+}
+
+// TestEndToEnd_UnpricedResponseReachesAggregatorUnpriced is the negative control
+// for the test above. Same composed path, same assertions, only the plugin does
+// not price the response (no cost header, no configured rates). Without it, a
+// wiring bug that made everything look priced — or an assertion that could not
+// fail — would pass unnoticed.
+func TestEndToEnd_UnpricedResponseReachesAggregatorUnpriced(t *testing.T) {
+	p := configure(t, 10)
+	agg := usage.New()
+	store := session.New(time.Hour, 100, 10)
+	store.AddRecorder(agg)
+
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{}} // nothing to price
+	p.OnResponse(context.Background(), pctx)
+
+	store.Append("sess-e2e-unpriced", pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionResponse,
+		RequestID: "req-e2e-unpriced",
+		Host:      "litellm.corp",
+		Inference: &pipeline.InferenceExtension{Model: "claude-opus-5", TotalTokens: 1000},
+		Plugins:   pipeline.SnapshotPlugins(pctx.Extensions.Custom),
+	})
+
+	snap := agg.Snapshot(usage.BucketWidth, usage.BucketWidth, "", usage.GroupNone)
+	if snap.Priced {
+		t.Error("Priced = true for a response the plugin never priced")
+	}
+	if snap.Totals.CostMicros != 0 {
+		t.Errorf("CostMicros = %d, want 0", snap.Totals.CostMicros)
+	}
+	if snap.Totals.PricedRequests != 0 {
+		t.Errorf("PricedRequests = %d, want 0", snap.Totals.PricedRequests)
+	}
+	// The request still counted as traffic — unpriced is not invisible.
+	if snap.Totals.Requests != 1 {
+		t.Errorf("Requests = %d, want 1", snap.Totals.Requests)
+	}
+	if snap.Totals.Tokens != 1000 {
+		t.Errorf("Tokens = %d, want 1000", snap.Totals.Tokens)
 	}
 }

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
@@ -522,18 +523,50 @@ func TestZeroCostHeaderStreamedPricesFromUsage(t *testing.T) {
 	}
 }
 
-// getCostEvent pulls the emitted costEvent out of pctx.Extensions.Custom
+// getCostEvent pulls the emitted cost event out of pctx.Extensions.Custom
 // under the same key the listener would read. Nil when nothing was emitted.
-func getCostEvent(t *testing.T, pctx *pipeline.Context) *costEvent {
+func getCostEvent(t *testing.T, pctx *pipeline.Context) *costevent.Event {
 	t.Helper()
 	if pctx.Extensions.Custom == nil {
 		return nil
 	}
-	v, ok := pctx.Extensions.Custom["litellm-budget-track"+pipeline.PluginEventSuffix].(costEvent)
+	v, ok := pctx.Extensions.Custom["litellm-budget-track"+pipeline.PluginEventSuffix].(costevent.Event)
 	if !ok {
 		return nil
 	}
 	return &v
+}
+
+// TestPluginNameMatchesCostEventKey pins the plugin name to the constant the
+// aggregator and abctl look the event up by. A rename on one side only would
+// make every consumer silently stop seeing costs.
+func TestPluginNameMatchesCostEventKey(t *testing.T) {
+	if got := New().Name(); got != costevent.PluginName {
+		t.Errorf("Name() = %q, costevent.PluginName = %q", got, costevent.PluginName)
+	}
+}
+
+// TestEmitCostWireFormatUnchanged is the independent proof that promoting the
+// event struct into authlib/costevent did not alter the bytes on the wire. abctl
+// decodes these exact tags from a separate module that this change does not
+// rebuild, so a drift here would silently blank its COST column.
+func TestEmitCostWireFormatUnchanged(t *testing.T) {
+	p := configure(t, 10)
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.25"}}}
+	p.OnResponse(context.Background(), pctx)
+
+	ev := getCostEvent(t, pctx)
+	if ev == nil {
+		t.Fatal("no cost event emitted")
+	}
+	b, err := json.Marshal(*ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"cost_usd":0.25,"source":"gateway-header","daily_total_usd":0.25,"daily_max_usd":10}`
+	if string(b) != want {
+		t.Errorf("wire format changed:\n got %s\nwant %s", b, want)
+	}
 }
 
 // TestEmitCost_HeaderPath: OnResponse (buffered) prices from the header
@@ -551,8 +584,8 @@ func TestEmitCost_HeaderPath(t *testing.T) {
 	if ev.CostUSD != 0.0025 {
 		t.Errorf("CostUSD = %v, want 0.0025", ev.CostUSD)
 	}
-	if ev.Source != sourceGatewayHeader {
-		t.Errorf("Source = %q, want %s", ev.Source, sourceGatewayHeader)
+	if ev.Source != costevent.SourceGatewayHeader {
+		t.Errorf("Source = %q, want %s", ev.Source, costevent.SourceGatewayHeader)
 	}
 	if ev.DailyTotalUSD != 0.0025 {
 		t.Errorf("DailyTotalUSD = %v, want 0.0025", ev.DailyTotalUSD)
@@ -594,8 +627,8 @@ func TestEmitCost_UsageFallback(t *testing.T) {
 	if ev == nil {
 		t.Fatal("no costEvent emitted")
 	}
-	if ev.Source != sourceUsageFallback {
-		t.Errorf("Source = %q, want %s", ev.Source, sourceUsageFallback)
+	if ev.Source != costevent.SourceUsageFallback {
+		t.Errorf("Source = %q, want %s", ev.Source, costevent.SourceUsageFallback)
 	}
 	want := 100*1e-6 + 40*5e-6
 	if ev.CostUSD < want-1e-12 || ev.CostUSD > want+1e-12 {

--- a/authbridge/authlib/sessionapi/usage.go
+++ b/authbridge/authlib/sessionapi/usage.go
@@ -43,24 +43,24 @@ import (
 // it is written down so the decision to expose it is a decision rather than an
 // oversight.
 //
-// TODO(cost): costMicros is on the wire format but nothing populates it yet —
-// no Pricer is wired at construction, so Snapshot reports priced:false and omits
-// every cost field. The rates exist already, in the toolprune plugin's
-// defaultPatterns table, but they are package-private there and explicitly
-// documented as gateway-specific: that table measures the rossoctl LiteLLM
-// gateway, which bills well below vendor list, so applying it to a
-// direct-to-Anthropic deployment would understate cost by roughly 4x on the
-// input tier. Publishing a number that wrong is worse than publishing none.
+// costMicros is populated from the per-request figure litellm-budget-track
+// settles and publishes on the session event: it prefers LiteLLM's own
+// X-Litellm-Response-Cost header — the authoritative post-discount cost — and
+// falls back to pricing the parsed usage block when the header reports 0, which
+// every streamed response does. The figure is therefore that plugin's
+// measurement rather than a rate table's guess, and this package models no rates
+// itself.
 //
-// The shape of the fix is either to promote those rates into a shared package
-// both toolprune and this aggregator consume, or — better — to have a plugin
-// that already knows the true cost report it per response, which
-// litellm-budget-track effectively does: it reads LiteLLM's own
-// X-Litellm-Response-Cost header, the authoritative post-discount figure. That
-// would need the cost surfaced onto the session event, where the aggregator can
-// see it; today it stays inside the plugin. Until then the field is reserved so
-// adding it later is not a wire-format break, and priced:false tells a client to
-// render "cost unavailable" rather than $0.00.
+// Requests the plugin did not price contribute no cost and appear as the gap
+// between totals.pricedRequests and totals.requests. Where those differ the
+// dollar total covers only the priced subset, so a client rendering it must
+// present it as partial rather than complete. priced:false means nothing at all
+// was priced — render "cost unavailable", never $0.00, which would read as "this
+// traffic was free".
+//
+// Modelled rates for traffic with no cost event (no litellm-budget-track in the
+// pipeline, or an endpoint it cannot price) arrive with the pricing resolver; see
+// docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md.
 func (s *Server) handleUsage(w http.ResponseWriter, r *http.Request) {
 	if s.usage == nil {
 		// Aggregation not wired up (session store disabled, or an older binary

--- a/authbridge/authlib/sessionapi/usage_test.go
+++ b/authbridge/authlib/sessionapi/usage_test.go
@@ -61,7 +61,7 @@ func TestHandleUsage_Defaults(t *testing.T) {
 		t.Errorf("bucketSeconds = %d, want 60", snap.BucketSeconds)
 	}
 	if snap.Priced {
-		t.Error("priced = true with no Pricer wired")
+		t.Error("priced = true when no request carried a cost event")
 	}
 }
 

--- a/authbridge/authlib/usage/snapshot.go
+++ b/authbridge/authlib/usage/snapshot.go
@@ -151,7 +151,7 @@ func fold(src []Bucket, width time.Duration) []Bucket {
 		series := map[string]Counts{}
 
 		for _, b := range src[i:end] {
-			acc.Counts.add(b.Counts)
+			acc.Counts.Add(b.Counts)
 			// Weighted by LatSamples, not Requests: the source mean was computed
 			// over measured requests only, so reconstituting with Requests would
 			// re-introduce the dilution latStats exists to avoid.
@@ -166,7 +166,7 @@ func fold(src []Bucket, width time.Duration) []Bucket {
 			}
 			for k, v := range b.Series {
 				cur := series[k]
-				cur.add(v)
+				cur.Add(v)
 				series[k] = cur
 			}
 		}
@@ -242,7 +242,7 @@ func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string
 				b.Series = src.series(group)
 			}
 		}
-		out.Totals.add(b.Counts)
+		out.Totals.Add(b.Counts)
 		out.Buckets = append(out.Buckets, b)
 	}
 	// Derived after the loop: Totals is only complete once every bucket has been

--- a/authbridge/authlib/usage/snapshot.go
+++ b/authbridge/authlib/usage/snapshot.go
@@ -55,9 +55,16 @@ type Snapshot struct {
 	// Totals sums every bucket, so a client need not re-add them to render a
 	// summary line.
 	Totals Counts `json:"totals"`
-	// Priced reports whether a Pricer was configured. Without it CostMicros is
-	// absent everywhere, and a client must say "cost unavailable" rather than
-	// display $0.00 — which would read as "this traffic was free".
+	// Priced reports whether ANY request in this window produced a cost. False
+	// means CostMicros is absent everywhere, and a client must say "cost
+	// unavailable" rather than display $0.00 — which would read as "this traffic
+	// was free".
+	//
+	// True does NOT mean every request was priced. Compare Totals.PricedRequests
+	// against Totals.Requests: cost comes from a plugin that may not be in the
+	// pipeline for all traffic, and once rates are per-endpoint a deployment can
+	// price some endpoints and not others. Where those differ the dollar total
+	// covers only the priced subset, and a client showing it must say so.
 	Priced bool `json:"priced"`
 }
 
@@ -221,7 +228,6 @@ func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string
 		BucketSeconds: int(resolution / time.Second),
 		Session:       sessionID,
 		Group:         group,
-		Priced:        a.pricer != nil,
 		Buckets:       make([]Bucket, 0, n),
 	}
 
@@ -239,6 +245,10 @@ func (a *Aggregator) Snapshot(window, resolution time.Duration, sessionID string
 		out.Totals.add(b.Counts)
 		out.Buckets = append(out.Buckets, b)
 	}
+	// Derived after the loop: Totals is only complete once every bucket has been
+	// added, so this cannot be set in the literal above.
+	out.Priced = out.Totals.PricedRequests > 0
+
 	// Fold last: totals are summed from the raw buckets above and are unaffected
 	// by grouping width, so a client's summary line agrees with its chart no
 	// matter which resolution it asked for.

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -65,7 +65,17 @@ type Counts struct {
 	PricedRequests int64 `json:"pricedRequests,omitempty"`
 }
 
-func (c *Counts) add(o Counts) {
+// Add accumulates o into c, field by field.
+//
+// Exported because consumers fold these too — abctl collapses low-volume series
+// into an "(other)" band — and an unexported version left them hand-summing the
+// fields in another module. That copy silently missed PricedRequests when it was
+// added, under a comment explaining that every field had to be carried. One
+// summation, in the same file as the struct, is the only way that stays true.
+//
+// Pointer receiver and mutating, matching how the aggregator accumulates on the
+// hot path. For a map value, read-modify-write: `v := m[k]; v.Add(o); m[k] = v`.
+func (c *Counts) Add(o Counts) {
 	c.Requests += o.Requests
 	c.Errors += o.Errors
 	c.Tokens += o.Tokens
@@ -282,9 +292,16 @@ func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
 	// Decoded before the lock, for the same reason the guards above are: it
 	// touches no aggregator state, and foldInto runs up to twice per event (the
 	// all-sessions ring and this session's ring), which would otherwise unmarshal
-	// the same JSON twice while holding mu. Near-free for a request event, whose
-	// Plugins map carries no cost key to unmarshal.
-	ec := decodeEventCost(e)
+	// the same JSON twice while holding mu.
+	//
+	// Skipped for request events, which return below without ever reaching
+	// foldInto. The cost is only ever published on the response pass, so this
+	// would find nothing anyway — but not calling it at all beats calling it and
+	// relying on that.
+	var ec eventCost
+	if e.Phase != pipeline.SessionRequest {
+		ec = decodeEventCost(e)
+	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -434,7 +451,7 @@ func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEve
 	if e.StatusCode >= 400 || e.Phase == pipeline.SessionDenied {
 		one.Errors = 1
 	}
-	b.Counts.add(one)
+	b.Counts.Add(one)
 
 	// Latency: only from events that actually carry one. A zero duration is
 	// "not measured", not "instant", and folding it in would drag the mean down.
@@ -527,7 +544,7 @@ func addLabel(m *map[string]Counts, key string, c Counts) {
 		key = overflowLabel
 	}
 	cur := (*m)[key]
-	cur.add(c)
+	cur.Add(c)
 	(*m)[key] = cur
 }
 

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -114,6 +114,9 @@ type bucket struct {
 	byPlugin map[string]Counts
 }
 
+// eventCost is one event's settled cost, decoded once per Record and passed to
+// each ring's foldInto.
+//
 // Cost is read from the figure litellm-budget-track settles per response and
 // publishes on the session event (see authlib/costevent): it prefers the
 // gateway's own post-discount cost header and falls back to pricing the usage
@@ -125,6 +128,23 @@ type bucket struct {
 // between Counts.PricedRequests and Counts.Requests. Modelled rates for that
 // traffic arrive with the pricing resolver; see
 // docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md.
+type eventCost struct {
+	micros int64
+	// priced is 1 when a cost was found and 0 otherwise, so it sums into
+	// Counts.PricedRequests as a coverage count rather than needing a separate
+	// branch at every accumulation site.
+	priced int64
+}
+
+// decodeEventCost reads the cost event off e, if any. Zero value means unpriced,
+// which is not the same as a zero cost — see Counts.PricedRequests.
+func decodeEventCost(e *pipeline.SessionEvent) eventCost {
+	ce, ok := costevent.Decode(e)
+	if !ok {
+		return eventCost{}
+	}
+	return eventCost{micros: ce.Micros(), priced: 1}
+}
 
 // Aggregator is a fixed ring of per-minute buckets. Safe for concurrent use.
 //
@@ -259,6 +279,13 @@ func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
 		at = a.now()
 	}
 
+	// Decoded before the lock, for the same reason the guards above are: it
+	// touches no aggregator state, and foldInto runs up to twice per event (the
+	// all-sessions ring and this session's ring), which would otherwise unmarshal
+	// the same JSON twice while holding mu. Near-free for a request event, whose
+	// Plugins map carries no cost key to unmarshal.
+	ec := decodeEventCost(e)
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -280,11 +307,11 @@ func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
 	}
 
 	t := at.Truncate(BucketWidth)
-	a.foldInto(a.all, t, e, requestPlugins)
+	a.foldInto(a.all, t, e, requestPlugins, ec)
 
 	if ring, ok := a.sessions[sessionID]; ok {
 		ring.lastSeen = at
-		a.foldInto(ring.buckets, t, e, requestPlugins)
+		a.foldInto(ring.buckets, t, e, requestPlugins, ec)
 		return
 	}
 	// maxSess == 0 means no per-session rings at all — see WithMaxSessions. The
@@ -302,7 +329,7 @@ func (a *Aggregator) Record(sessionID string, e *pipeline.SessionEvent) {
 	}
 	ring := &sessionRing{buckets: make([]bucket, NumBuckets), lastSeen: at}
 	a.sessions[sessionID] = ring
-	a.foldInto(ring.buckets, t, e, requestPlugins)
+	a.foldInto(ring.buckets, t, e, requestPlugins, ec)
 }
 
 // holdRequestPluginsLocked stashes a request event's plugin names until its
@@ -390,7 +417,7 @@ func (a *Aggregator) evictColdestLocked() {
 	}
 }
 
-func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEvent, requestPlugins []string) {
+func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEvent, requestPlugins []string, ec eventCost) {
 	b := &ring[slot(t)]
 	if !b.start.Equal(t) {
 		*b = bucket{start: t} // stale lap: reset rather than accumulate onto old data
@@ -403,18 +430,7 @@ func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEve
 		model = e.Inference.Model
 	}
 
-	// Cost comes from the plugin that already settled it, not from a rate table
-	// here: litellm-budget-track prefers the gateway's own post-discount figure
-	// and falls back to pricing the usage block, then publishes the result on the
-	// event. Absent means unpriced, which is not the same as free — hence the
-	// separate PricedRequests counter rather than inferring coverage from a zero.
-	var cost, priced int64
-	if ce, ok := costevent.Decode(e); ok {
-		cost = ce.Micros()
-		priced = 1
-	}
-
-	one := Counts{Requests: 1, Tokens: tokens, CostMicros: cost, PricedRequests: priced}
+	one := Counts{Requests: 1, Tokens: tokens, CostMicros: ec.micros, PricedRequests: ec.priced}
 	if e.StatusCode >= 400 || e.Phase == pipeline.SessionDenied {
 		one.Errors = 1
 	}
@@ -441,6 +457,13 @@ func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEve
 	// plugins touched one message. Tokens are attributed whole to each plugin
 	// for the same reason: there is no defensible way to split one response's
 	// usage between the plugins that observed it.
+	//
+	// CostMicros and PricedRequests are duplicated the same way, and both are
+	// exposed under group=plugin. Summing cost across the per-plugin series
+	// therefore over-reports dollars by the number of plugins that touched each
+	// turn — a worse error than over-reporting tokens, because it reads as spend.
+	// Use Totals for any dollar figure; the per-plugin values answer "what did
+	// traffic this plugin saw cost", not "what did this plugin cost".
 	// Invocations is a POINTER and is nil whenever no plugin appended a record —
 	// which is the common case for a plain proxied response. Dereferencing it
 	// unguarded panics inside Store.Append, i.e. on the request hot path.

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
@@ -113,29 +114,17 @@ type bucket struct {
 	byPlugin map[string]Counts
 }
 
-// Pricer converts a model name and token count to millionths of a dollar.
-// Optional: a nil Pricer leaves CostMicros zero and the API omits it.
+// Cost is read from the figure litellm-budget-track settles per response and
+// publishes on the session event (see authlib/costevent): it prefers the
+// gateway's own post-discount cost header and falls back to pricing the usage
+// block. So the number here is a plugin's measurement, not a rate table's guess,
+// and this package holds no rates of its own — deployment-specific pricing is
+// not something authlib should assert.
 //
-// Injected rather than implemented here because rates are deployment-specific —
-// a gateway bills differently from the vendor's list price — and authlib has no
-// business asserting one.
-//
-// TODO(cost): no caller supplies one yet, so CostMicros is always zero and
-// Snapshot reports priced:false. Two candidate sources, neither reachable from
-// here today:
-//
-//   - toolprune's defaultPatterns table has per-family rates, but it is
-//     package-private and measured against the rossoctl LiteLLM gateway, which
-//     bills well below vendor list. Applying it to a direct-to-Anthropic
-//     deployment understates cost by roughly 4x on the input tier.
-//   - litellm-budget-track already reads the authoritative post-discount figure
-//     from LiteLLM's X-Litellm-Response-Cost header, but keeps it inside the
-//     plugin. Surfacing it onto the session event would let the aggregator use a
-//     real number instead of a modelled one, which is the better fix.
-//
-// The field is reserved on the wire now so adding it later is not a breaking
-// change.
-type Pricer func(model string, tokens int64) int64
+// Traffic the plugin did not price contributes no cost and is visible as the gap
+// between Counts.PricedRequests and Counts.Requests. Modelled rates for that
+// traffic arrive with the pricing resolver; see
+// docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md.
 
 // Aggregator is a fixed ring of per-minute buckets. Safe for concurrent use.
 //
@@ -151,7 +140,6 @@ type Aggregator struct {
 	all      []bucket
 	sessions map[string]*sessionRing
 	maxSess  int
-	pricer   Pricer
 	now      func() time.Time
 
 	// pending holds request-phase plugin names awaiting their response event,
@@ -197,9 +185,6 @@ type sessionRing struct {
 
 // Option configures an Aggregator.
 type Option func(*Aggregator)
-
-// WithPricer supplies cost rates. Without it, CostMicros stays zero.
-func WithPricer(p Pricer) Option { return func(a *Aggregator) { a.pricer = p } }
 
 // WithClock overrides time.Now, for deterministic tests.
 func WithClock(now func() time.Time) Option { return func(a *Aggregator) { a.now = now } }
@@ -411,17 +396,25 @@ func (a *Aggregator) foldInto(ring []bucket, t time.Time, e *pipeline.SessionEve
 		*b = bucket{start: t} // stale lap: reset rather than accumulate onto old data
 	}
 
-	var tokens, cost int64
+	var tokens int64
 	var model string
 	if e.Inference != nil {
 		tokens = int64(e.Inference.TotalTokens)
 		model = e.Inference.Model
-		if a.pricer != nil && tokens > 0 {
-			cost = a.pricer(model, tokens)
-		}
 	}
 
-	one := Counts{Requests: 1, Tokens: tokens, CostMicros: cost}
+	// Cost comes from the plugin that already settled it, not from a rate table
+	// here: litellm-budget-track prefers the gateway's own post-discount figure
+	// and falls back to pricing the usage block, then publishes the result on the
+	// event. Absent means unpriced, which is not the same as free — hence the
+	// separate PricedRequests counter rather than inferring coverage from a zero.
+	var cost, priced int64
+	if ce, ok := costevent.Decode(e); ok {
+		cost = ce.Micros()
+		priced = 1
+	}
+
+	one := Counts{Requests: 1, Tokens: tokens, CostMicros: cost, PricedRequests: priced}
 	if e.StatusCode >= 400 || e.Phase == pipeline.SessionDenied {
 		one.Errors = 1
 	}

--- a/authbridge/authlib/usage/usage.go
+++ b/authbridge/authlib/usage/usage.go
@@ -50,10 +50,18 @@ type Counts struct {
 	Tokens   int64 `json:"tokens,omitempty"`
 	// CostMicros is millionths of a US dollar. An integer unit keeps bucket
 	// addition exact and JSON round-tripping lossless, which float dollars do
-	// not; a client divides by 1e6 to display. Zero when no pricer is
-	// configured, which is not the same as "this traffic was free" — the API
-	// omits the field entirely in that case rather than asserting $0.
+	// not; a client divides by 1e6 to display. Zero when nothing here could be
+	// priced, which is not the same as "this traffic was free" — the API omits
+	// the field entirely in that case rather than asserting $0.
 	CostMicros int64 `json:"costMicros,omitempty"`
+	// PricedRequests counts the requests that actually produced a cost. Coverage
+	// is a counter rather than a flag because buckets are summed when a client
+	// asks for a coarser resolution, and because a deployment can price some of
+	// its traffic and not the rest: several endpoints, rates known for some.
+	//
+	// Requests-minus-PricedRequests is the gap, correct at every resolution, and
+	// it is what stops a partial total being presented as a complete one.
+	PricedRequests int64 `json:"pricedRequests,omitempty"`
 }
 
 func (c *Counts) add(o Counts) {
@@ -61,6 +69,7 @@ func (c *Counts) add(o Counts) {
 	c.Errors += o.Errors
 	c.Tokens += o.Tokens
 	c.CostMicros += o.CostMicros
+	c.PricedRequests += o.PricedRequests
 }
 
 // Bucket is one BucketWidth slice of time, as served to clients.

--- a/authbridge/authlib/usage/usage_test.go
+++ b/authbridge/authlib/usage/usage_test.go
@@ -1,12 +1,14 @@
 package usage
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
@@ -26,6 +28,57 @@ func respEvent(at time.Time, status int, dur time.Duration, model string, tokens
 		e.Inference = &pipeline.InferenceExtension{Model: model, TotalTokens: tokens}
 	}
 	return e
+}
+
+// withCost attaches the cost event litellm-budget-track publishes, exactly as a
+// listener would after SnapshotPlugins. Returns e so it composes with respEvent.
+func withCost(t *testing.T, e *pipeline.SessionEvent, costUSD float64) *pipeline.SessionEvent {
+	t.Helper()
+	raw, err := json.Marshal(costevent.Event{
+		CostUSD: costUSD,
+		Source:  costevent.SourceGatewayHeader,
+	})
+	if err != nil {
+		t.Fatalf("marshal cost event: %v", err)
+	}
+	if e.Plugins == nil {
+		e.Plugins = map[string]json.RawMessage{}
+	}
+	e.Plugins[costevent.PluginName] = raw
+	return e
+}
+
+// TestCountsAddFoldsPricedRequests is why coverage is a counter and not a
+// boolean: buckets are summed when a client asks for a coarser resolution, and
+// a bool cannot express "12 of 40 requests in this window were priced".
+func TestCountsAddFoldsPricedRequests(t *testing.T) {
+	a := Counts{Requests: 10, CostMicros: 500, PricedRequests: 4}
+	a.add(Counts{Requests: 5, CostMicros: 250, PricedRequests: 3})
+
+	if a.Requests != 15 {
+		t.Errorf("Requests = %d, want 15", a.Requests)
+	}
+	if a.CostMicros != 750 {
+		t.Errorf("CostMicros = %d, want 750", a.CostMicros)
+	}
+	if a.PricedRequests != 7 {
+		t.Errorf("PricedRequests = %d, want 7", a.PricedRequests)
+	}
+	if unpriced := a.Requests - a.PricedRequests; unpriced != 8 {
+		t.Errorf("unpriced = %d, want 8", unpriced)
+	}
+}
+
+// TestCountsPricedRequestsOmittedWhenZero keeps the wire quiet for deployments
+// that price nothing.
+func TestCountsPricedRequestsOmittedWhenZero(t *testing.T) {
+	b, err := json.Marshal(Counts{Requests: 3})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "pricedRequests") {
+		t.Errorf("zero PricedRequests should be omitted, got %s", b)
+	}
 }
 
 // An idle minute must come back as a present, zeroed bucket. A client cannot

--- a/authbridge/authlib/usage/usage_test.go
+++ b/authbridge/authlib/usage/usage_test.go
@@ -53,7 +53,7 @@ func withCost(t *testing.T, e *pipeline.SessionEvent, costUSD float64) *pipeline
 // a bool cannot express "12 of 40 requests in this window were priced".
 func TestCountsAddFoldsPricedRequests(t *testing.T) {
 	a := Counts{Requests: 10, CostMicros: 500, PricedRequests: 4}
-	a.add(Counts{Requests: 5, CostMicros: 250, PricedRequests: 3})
+	a.Add(Counts{Requests: 5, CostMicros: 250, PricedRequests: 3})
 
 	if a.Requests != 15 {
 		t.Errorf("Requests = %d, want 15", a.Requests)

--- a/authbridge/authlib/usage/usage_test.go
+++ b/authbridge/authlib/usage/usage_test.go
@@ -81,6 +81,93 @@ func TestCountsPricedRequestsOmittedWhenZero(t *testing.T) {
 	}
 }
 
+// The cost is taken from the figure litellm-budget-track already settled and
+// published, not modelled here from a rate table.
+func TestRecord_PricesFromCostEvent(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 30, 0, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", withCost(t, respEvent(now, 200, time.Second, "claude-opus-5", 1000), 0.0421))
+
+	snap := a.Snapshot(time.Minute, BucketWidth, "", GroupNone)
+	if snap.Totals.Requests != 1 {
+		t.Fatalf("Requests = %d, want 1", snap.Totals.Requests)
+	}
+	if snap.Totals.CostMicros != 42_100 {
+		t.Errorf("CostMicros = %d, want 42100", snap.Totals.CostMicros)
+	}
+	if snap.Totals.PricedRequests != 1 {
+		t.Errorf("PricedRequests = %d, want 1", snap.Totals.PricedRequests)
+	}
+}
+
+// Partial coverage: the dollar total covers only the priced subset, and the gap
+// between PricedRequests and Requests is what tells a client to say so rather
+// than present the figure as complete.
+func TestRecord_MixedCoverage(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 30, 0, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", withCost(t, respEvent(now, 200, time.Second, "claude-opus-5", 1000), 0.02))
+	a.Record("s1", respEvent(now, 200, time.Second, "unpriced-model", 500)) // no cost event
+
+	snap := a.Snapshot(time.Minute, BucketWidth, "", GroupNone)
+	if snap.Totals.Requests != 2 {
+		t.Fatalf("Requests = %d, want 2", snap.Totals.Requests)
+	}
+	if snap.Totals.PricedRequests != 1 {
+		t.Errorf("PricedRequests = %d, want 1", snap.Totals.PricedRequests)
+	}
+	if snap.Totals.CostMicros != 20_000 {
+		t.Errorf("CostMicros = %d, want 20000 (only the priced request)", snap.Totals.CostMicros)
+	}
+	// Tokens are unaffected by pricing: a request nobody could price is still a
+	// request that sent tokens.
+	if snap.Totals.Tokens != 1500 {
+		t.Errorf("Tokens = %d, want 1500 (both requests)", snap.Totals.Tokens)
+	}
+}
+
+func TestRecord_UnpricedContributesNoCost(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 30, 0, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", respEvent(now, 200, time.Second, "claude-opus-5", 700))
+
+	snap := a.Snapshot(time.Minute, BucketWidth, "", GroupNone)
+	if snap.Totals.CostMicros != 0 {
+		t.Errorf("CostMicros = %d, want 0", snap.Totals.CostMicros)
+	}
+	if snap.Totals.PricedRequests != 0 {
+		t.Errorf("PricedRequests = %d, want 0", snap.Totals.PricedRequests)
+	}
+	if snap.Totals.Tokens != 700 {
+		t.Errorf("Tokens = %d, want 700", snap.Totals.Tokens)
+	}
+}
+
+// Coverage must survive folding to a coarser resolution, which is the whole
+// reason it is a counter.
+func TestRecord_CoverageFoldsAcrossBuckets(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 2, 30, 0, time.UTC)
+	a := New(WithClock(fixedClock(now)))
+
+	a.Record("s1", withCost(t, respEvent(now.Add(-time.Minute), 200, time.Second, "m", 100), 0.01))
+	a.Record("s1", respEvent(now.Add(-time.Minute), 200, time.Second, "m", 100))
+	a.Record("s1", withCost(t, respEvent(now, 200, time.Second, "m", 100), 0.02))
+
+	folded := a.Snapshot(2*time.Minute, 2*time.Minute, "", GroupNone).Buckets[0]
+	if folded.Requests != 3 {
+		t.Fatalf("folded Requests = %d, want 3", folded.Requests)
+	}
+	if folded.PricedRequests != 2 {
+		t.Errorf("folded PricedRequests = %d, want 2", folded.PricedRequests)
+	}
+	if folded.CostMicros != 30_000 {
+		t.Errorf("folded CostMicros = %d, want 30000", folded.CostMicros)
+	}
+}
+
 // An idle minute must come back as a present, zeroed bucket. A client cannot
 // otherwise tell "no traffic" from "fell off the ring", and that distinction is
 // what makes a gap visible in a bar chart.
@@ -271,32 +358,66 @@ func TestSnapshot_AllGroupingsPopulatedFromOnePass(t *testing.T) {
 	}
 }
 
-// Cost is opt-in. Without a Pricer, CostMicros stays zero AND Priced is false,
-// so a client can say "unavailable" instead of rendering $0.00.
-func TestSnapshot_CostRequiresPricer(t *testing.T) {
+// Cost needs a source. Without a cost event on the request, CostMicros stays
+// zero AND Priced is false, so a client can say "unavailable" instead of
+// rendering $0.00 — which would read as "this traffic was free".
+//
+// Formerly TestSnapshot_CostRequiresPricer: the assertions are unchanged, but the
+// source is now the figure litellm-budget-track publishes rather than an injected
+// Pricer that no production caller ever supplied.
+func TestSnapshot_CostRequiresACostSource(t *testing.T) {
 	now := time.Date(2026, 9, 4, 23, 30, 30, 0, time.UTC)
 
 	unpriced := New(WithClock(fixedClock(now)))
 	unpriced.Record("s1", respEvent(now, 200, time.Second, "claude-sonnet-5", 1000))
 	snap := unpriced.Snapshot(time.Minute, BucketWidth, "", GroupNone)
 	if snap.Priced {
-		t.Error("Priced = true with no pricer configured")
+		t.Error("Priced = true with no cost event on any request")
 	}
 	if snap.Totals.CostMicros != 0 {
 		t.Errorf("costMicros = %d, want 0", snap.Totals.CostMicros)
 	}
 
-	// 1520 micros per 1000 tokens (roughly sonnet input at $1.52/Mtok).
-	priced := New(WithClock(fixedClock(now)),
-		WithPricer(func(_ string, tokens int64) int64 { return tokens * 1520 / 1000 }))
-	priced.Record("s1", respEvent(now, 200, time.Second, "claude-sonnet-5", 1000))
+	// $0.00152 — roughly 1000 sonnet input tokens at $1.52/Mtok.
+	priced := New(WithClock(fixedClock(now)))
+	priced.Record("s1", withCost(t, respEvent(now, 200, time.Second, "claude-sonnet-5", 1000), 0.00152))
 	snap = priced.Snapshot(time.Minute, BucketWidth, "", GroupNone)
 	if !snap.Priced {
-		t.Error("Priced = false with a pricer configured")
+		t.Error("Priced = false after a request carried a cost event")
 	}
 	if snap.Totals.CostMicros != 1520 {
 		t.Errorf("costMicros = %d, want 1520", snap.Totals.CostMicros)
 	}
+}
+
+// Priced is derived from what actually happened, not from whether a hook was
+// installed. Partial coverage still reports Priced — the caller distinguishes
+// complete from partial by comparing PricedRequests against Requests.
+func TestSnapshot_PricedDerivedFromCoverage(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 30, 0, 0, time.UTC)
+
+	t.Run("nothing priced", func(t *testing.T) {
+		a := New(WithClock(fixedClock(now)))
+		a.Record("s", respEvent(now, 200, time.Second, "m", 100))
+		if a.Snapshot(time.Minute, BucketWidth, "", GroupNone).Priced {
+			t.Error("Priced = true, want false when no request was priced")
+		}
+	})
+
+	t.Run("partially priced still reports priced", func(t *testing.T) {
+		a := New(WithClock(fixedClock(now)))
+		a.Record("s", withCost(t, respEvent(now, 200, time.Second, "m", 100), 0.01))
+		a.Record("s", respEvent(now, 200, time.Second, "n", 100))
+
+		snap := a.Snapshot(time.Minute, BucketWidth, "", GroupNone)
+		if !snap.Priced {
+			t.Error("Priced = false, want true")
+		}
+		if snap.Totals.PricedRequests != 1 || snap.Totals.Requests != 2 {
+			t.Errorf("coverage = %d/%d, want 1/2",
+				snap.Totals.PricedRequests, snap.Totals.Requests)
+		}
+	})
 }
 
 // Per-session rings must isolate: one session's traffic cannot appear in

--- a/authbridge/cmd/abctl/tui/cost_event.go
+++ b/authbridge/cmd/abctl/tui/cost_event.go
@@ -1,56 +1,42 @@
 package tui
 
 import (
-	"encoding/json"
-
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
-// costEvent is the litellm-budget-track per-response event as published under
-// "litellm-budget-track". Mirrors the plugin's shape; a decode test guards the
-// tags.
+// costEvent is the litellm-budget-track per-response event.
 //
 // Unlike tool-prune's event, this one carries a finished dollar figure rather
 // than rates, so a consumer has no arithmetic left to do. It is NOT always an
 // authoritative figure though: the plugin prefers the cost LiteLLM stamps on the
 // response, but a streamed response always reports 0 there, so those are priced
 // from the plugin's own per-token rates instead. Source says which happened.
-type costEvent struct {
-	CostUSD float64 `json:"cost_usd"`
-	// Source is "gateway-header" (the gateway's own post-discount figure) or
-	// "usage-fallback" (priced from token counters by the plugin, used for
-	// streamed responses whose header reports 0 — for a streaming agent this is
-	// the common case, not the exception).
-	//
-	// Decoded but deliberately not rendered: the COST column shows modelled and
-	// gateway-stamped figures identically, matching the request-side cost, which
-	// is modelled too. Marking one and not the other would be the inconsistency.
-	Source string `json:"source"`
-	// DailyTotalUSD / DailyMaxUSD are decoded for wire coverage — nothing renders
-	// them yet. Kept so the decode test pins every field the plugin publishes,
-	// which is what makes a tag rename fail here rather than silently blank a
-	// column later.
-	DailyTotalUSD float64 `json:"daily_total_usd"`
-	DailyMaxUSD   float64 `json:"daily_max_usd"`
-}
+//
+// An ALIAS, not a copy: this is authlib's costevent.Event, so the compiler — not
+// a decode test — is what keeps abctl and the producer agreeing on the wire. This
+// file used to redeclare the struct and its decoder, which meant a field rename
+// in the plugin silently blanked a column here until a test happened to catch it.
+//
+// Source is "gateway-header" (the gateway's own post-discount figure) or
+// "usage-fallback" (priced from token counters by the plugin, used for streamed
+// responses whose header reports 0 — for a streaming agent this is the common
+// case, not the exception). It is decoded but deliberately not rendered: the COST
+// column shows modelled and gateway-stamped figures identically, matching the
+// request-side cost, which is modelled too. Marking one and not the other would be
+// the inconsistency. DailyTotalUSD / DailyMaxUSD are likewise carried but not yet
+// rendered.
+type costEvent = costevent.Event
 
 // decodeCostEvent pulls the litellm-budget-track event off a response event, if
 // present. Absent whenever the plugin is not in the pipeline, or the response
 // was not priced (a cache hit / error charges nothing and emits nothing) — so a
 // false return is the normal case, not an error.
+//
+// Kept as a local name because the TUI reads better for it; the logic, the
+// lookup key and the non-positive-cost rejection all live in authlib/costevent.
 func decodeCostEvent(e *pipeline.SessionEvent) (costEvent, bool) {
-	if e == nil || len(e.Plugins) == 0 {
-		return costEvent{}, false
-	}
-	raw, ok := e.Plugins["litellm-budget-track"]
-	if !ok {
-		return costEvent{}, false
-	}
-	var ce costEvent
-	if err := json.Unmarshal(raw, &ce); err != nil || ce.CostUSD <= 0 {
-		return costEvent{}, false
-	}
-	return ce, true
+	return costevent.Decode(e)
 }
 
 // promptCost models what the prompt of one request cost, from the response's

--- a/authbridge/cmd/abctl/tui/usage_render.go
+++ b/authbridge/cmd/abctl/tui/usage_render.go
@@ -327,14 +327,30 @@ func renderUsageSummary(snap *usage.Snapshot) string {
 		parts = append(parts, fmt.Sprintf("LATENCY %.2fs", latSum/float64(latN)/1000))
 	}
 
-	// Cost is reserved on the wire but nothing populates it yet. Say so rather
-	// than render $0.00, which reads as "this traffic was free".
-	if snap.Priced {
-		parts = append(parts, fmt.Sprintf("COST $%.4f", float64(snap.Totals.CostMicros)/1e6))
-	} else {
-		parts = append(parts, "COST unavailable")
-	}
+	parts = append(parts, renderCostSummary(snap))
 	return "  " + strings.Join(parts, "    ")
+}
+
+// renderCostSummary is the COST cell, in one of three states.
+//
+// Nothing priced: say so rather than render $0.00, which reads as "this traffic
+// was free" — a zero cost and an unknown cost are different answers.
+//
+// Partially priced: show the figure AND the coverage, because the total only
+// covers the requests that carried a cost. Cost comes from litellm-budget-track,
+// which may not be in the pipeline for all traffic and cannot price every
+// endpoint, so a window mixing priced and unpriced requests is the normal case
+// rather than an edge one. Presenting its subtotal as if it were the whole spend
+// is the failure this coverage count exists to prevent.
+func renderCostSummary(snap *usage.Snapshot) string {
+	if !snap.Priced {
+		return "COST unavailable"
+	}
+	cell := fmt.Sprintf("COST $%.4f", float64(snap.Totals.CostMicros)/1e6)
+	if snap.Totals.PricedRequests < snap.Totals.Requests {
+		cell += fmt.Sprintf(" (%d/%d priced)", snap.Totals.PricedRequests, snap.Totals.Requests)
+	}
+	return cell
 }
 
 // usageWindows are the spans the [w] key cycles.

--- a/authbridge/cmd/abctl/tui/usage_render_test.go
+++ b/authbridge/cmd/abctl/tui/usage_render_test.go
@@ -284,3 +284,52 @@ func TestRenderBars_TicksFallOnBarBoundaries(t *testing.T) {
 		}
 	}
 }
+
+// The COST cell has three states, and the partial one is the reason
+// usage.Counts.PricedRequests exists: cost comes from litellm-budget-track, which
+// need not be in the pipeline for all traffic, so a window that mixes priced and
+// unpriced requests is normal. Showing its subtotal bare would read as total spend.
+func TestRenderCostSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		snap usage.Snapshot
+		want string
+	}{
+		{
+			name: "nothing priced",
+			snap: usage.Snapshot{Totals: usage.Counts{Requests: 40}, Priced: false},
+			want: "COST unavailable",
+		},
+		{
+			name: "fully priced omits the coverage note",
+			snap: usage.Snapshot{
+				Totals: usage.Counts{Requests: 40, PricedRequests: 40, CostMicros: 1_842_100},
+				Priced: true,
+			},
+			want: "COST $1.8421",
+		},
+		{
+			name: "partially priced names the coverage",
+			snap: usage.Snapshot{
+				Totals: usage.Counts{Requests: 57, PricedRequests: 42, CostMicros: 1_842_100},
+				Priced: true,
+			},
+			want: "COST $1.8421 (42/57 priced)",
+		},
+		{
+			name: "one priced request out of many",
+			snap: usage.Snapshot{
+				Totals: usage.Counts{Requests: 100, PricedRequests: 1, CostMicros: 500},
+				Priced: true,
+			},
+			want: "COST $0.0005 (1/100 priced)",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderCostSummary(&tc.snap); got != tc.want {
+				t.Errorf("renderCostSummary() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/authbridge/cmd/abctl/tui/usage_stacked.go
+++ b/authbridge/cmd/abctl/tui/usage_stacked.go
@@ -79,27 +79,18 @@ func foldTailSeries(buckets []usage.Bucket, series []seriesKey, keep int) ([]ser
 		var acc usage.Counts
 		for label, c := range b.Series {
 			if tail[label] {
-				// Summed field-wise: usage.Counts.add is unexported, and every field
-				// must be carried or a folded band would under-report. PricedRequests
-				// included — dropping it would make the folded band report zero
-				// coverage for traffic that was priced, i.e. claim its cost is
-				// incomplete when it is not.
-				acc.Requests += c.Requests
-				acc.Errors += c.Errors
-				acc.Tokens += c.Tokens
-				acc.CostMicros += c.CostMicros
-				acc.PricedRequests += c.PricedRequests
+				// usage.Counts.Add rather than summing the fields here: this used to
+				// be a field-by-field copy, which silently dropped PricedRequests
+				// when that field was added — under a comment asserting every field
+				// was carried. One summation, next to the struct, cannot drift.
+				acc.Add(c)
 				continue
 			}
 			merged[label] = c
 		}
 		if acc.Requests > 0 || acc.Tokens > 0 || acc.Errors > 0 {
 			cur := merged[tailLabel]
-			cur.Requests += acc.Requests
-			cur.Errors += acc.Errors
-			cur.Tokens += acc.Tokens
-			cur.CostMicros += acc.CostMicros
-			cur.PricedRequests += acc.PricedRequests
+			cur.Add(acc)
 			merged[tailLabel] = cur
 		}
 		out[i].Series = merged

--- a/authbridge/cmd/abctl/tui/usage_stacked.go
+++ b/authbridge/cmd/abctl/tui/usage_stacked.go
@@ -80,11 +80,15 @@ func foldTailSeries(buckets []usage.Bucket, series []seriesKey, keep int) ([]ser
 		for label, c := range b.Series {
 			if tail[label] {
 				// Summed field-wise: usage.Counts.add is unexported, and every field
-				// must be carried or a folded band would under-report.
+				// must be carried or a folded band would under-report. PricedRequests
+				// included — dropping it would make the folded band report zero
+				// coverage for traffic that was priced, i.e. claim its cost is
+				// incomplete when it is not.
 				acc.Requests += c.Requests
 				acc.Errors += c.Errors
 				acc.Tokens += c.Tokens
 				acc.CostMicros += c.CostMicros
+				acc.PricedRequests += c.PricedRequests
 				continue
 			}
 			merged[label] = c
@@ -95,6 +99,7 @@ func foldTailSeries(buckets []usage.Bucket, series []seriesKey, keep int) ([]ser
 			cur.Errors += acc.Errors
 			cur.Tokens += acc.Tokens
 			cur.CostMicros += acc.CostMicros
+			cur.PricedRequests += acc.PricedRequests
 			merged[tailLabel] = cur
 		}
 		out[i].Series = merged

--- a/authbridge/cmd/abctl/tui/usage_stacked_test.go
+++ b/authbridge/cmd/abctl/tui/usage_stacked_test.go
@@ -690,11 +690,15 @@ func TestRenderStacked_FullyUnlabelledBucketMatchesItsLegend(t *testing.T) {
 	}
 }
 
-// foldTailSeries sums usage.Counts field-wise, because Counts.add is unexported.
-// That makes it silently incomplete whenever Counts grows a field: the folded
-// "(other)" band would under-report whatever was missed. PricedRequests is the
-// case that matters most, since dropping it makes the band claim zero coverage
-// for traffic that WAS priced — i.e. report its cost as partial when it is whole.
+// The folded "(other)" band must carry every Counts field, PricedRequests
+// included: a band reporting zero coverage for traffic that WAS priced would
+// claim its cost is partial when it is whole.
+//
+// This once summed the fields by hand in this package and silently missed
+// PricedRequests when that field was added. It now delegates to usage.Counts.Add,
+// so the arithmetic lives once, beside the struct. This test covers the behaviour;
+// what makes it stay correct is the delegation, not the assertion — a field added
+// to Counts and to Add is carried here with no change to this file.
 func TestFoldTailSeries_CarriesEveryCountsField(t *testing.T) {
 	// Two series beyond keep=1, so both fold into "(other)".
 	buckets := []usage.Bucket{{

--- a/authbridge/cmd/abctl/tui/usage_stacked_test.go
+++ b/authbridge/cmd/abctl/tui/usage_stacked_test.go
@@ -689,3 +689,39 @@ func TestRenderStacked_FullyUnlabelledBucketMatchesItsLegend(t *testing.T) {
 		t.Error("legend does not name the remainder band that is drawn")
 	}
 }
+
+// foldTailSeries sums usage.Counts field-wise, because Counts.add is unexported.
+// That makes it silently incomplete whenever Counts grows a field: the folded
+// "(other)" band would under-report whatever was missed. PricedRequests is the
+// case that matters most, since dropping it makes the band claim zero coverage
+// for traffic that WAS priced — i.e. report its cost as partial when it is whole.
+func TestFoldTailSeries_CarriesEveryCountsField(t *testing.T) {
+	// Two series beyond keep=1, so both fold into "(other)".
+	buckets := []usage.Bucket{{
+		Counts: usage.Counts{Requests: 30, Errors: 3, Tokens: 3000, CostMicros: 900, PricedRequests: 21},
+		Series: map[string]usage.Counts{
+			"keep-me": {Requests: 10, Errors: 1, Tokens: 1000, CostMicros: 300, PricedRequests: 7},
+			"tail-a":  {Requests: 12, Errors: 1, Tokens: 1200, CostMicros: 400, PricedRequests: 9},
+			"tail-b":  {Requests: 8, Errors: 1, Tokens: 800, CostMicros: 200, PricedRequests: 5},
+		},
+	}}
+
+	// Ordered as the caller supplies them; keep=1 retains only the first, so
+	// tail-a and tail-b fold into "(other)".
+	series := []seriesKey{
+		{label: "keep-me", total: 10},
+		{label: "tail-a", total: 12},
+		{label: "tail-b", total: 8},
+	}
+
+	_, out := foldTailSeries(buckets, series, 1)
+	other, ok := out[0].Series[tailLabel]
+	if !ok {
+		t.Fatalf("no %q band; series = %v", tailLabel, out[0].Series)
+	}
+
+	want := usage.Counts{Requests: 20, Errors: 2, Tokens: 2000, CostMicros: 600, PricedRequests: 14}
+	if other != want {
+		t.Errorf("folded %q = %+v, want %+v", tailLabel, other, want)
+	}
+}

--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -171,6 +171,27 @@ See [`plugin-reference.md#emitting-session-events`](./plugin-reference.md#emitti
 for how the listener promotes `pctx.Extensions.Custom` entries to
 `SessionEvent.Plugins`.
 
+### Consumers
+
+The event's wire shape is declared once, in `authlib/costevent` (`costevent.Event`,
+published under `costevent.PluginName`). Producer and consumers share that
+declaration rather than each keeping a private copy:
+
+- **The usage aggregator** (`authlib/usage`) records `cost_usd` into
+  `Counts.CostMicros` and increments `Counts.PricedRequests`, so `/v1/usage`
+  reports the same figure this plugin enforces its budget against.
+- **`abctl`** renders the per-request figure in its events pane.
+
+Two consequences for reading `/v1/usage`. Cost is reported only for traffic this
+plugin priced, so requests it did not price appear as the gap between
+`totals.pricedRequests` and `totals.requests` — a client rendering a dollar total
+from a window where those differ must present it as partial, not complete. And
+`priced:false` means nothing at all was priced: render "cost unavailable", never
+`$0.00`, which would read as "this traffic was free".
+
+Modelled rates for traffic with no cost event arrive with the pricing resolver —
+see [`superpowers/specs/2026-09-09-pricing-consolidation-design.md`](./superpowers/specs/2026-09-09-pricing-consolidation-design.md).
+
 ## Build
 
 The plugin is included by default in `authbridge-proxy` builds. To exclude:

--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -174,13 +174,16 @@ for how the listener promotes `pctx.Extensions.Custom` entries to
 ### Consumers
 
 The event's wire shape is declared once, in `authlib/costevent` (`costevent.Event`,
-published under `costevent.PluginName`). Producer and consumers share that
-declaration rather than each keeping a private copy:
+published under `costevent.PluginName`). Producer and consumers share that one
+declaration rather than each keeping a private copy, so a field rename is a
+compile error rather than a silently blank column:
 
 - **The usage aggregator** (`authlib/usage`) records `cost_usd` into
   `Counts.CostMicros` and increments `Counts.PricedRequests`, so `/v1/usage`
   reports the same figure this plugin enforces its budget against.
-- **`abctl`** renders the per-request figure in its events pane.
+- **`abctl`** renders the per-request figure in its events pane, and the window
+  total plus coverage in the usage footer. Its `tui.costEvent` is a type *alias*
+  for `costevent.Event`, not a copy.
 
 Two consequences for reading `/v1/usage`. Cost is reported only for traffic this
 plugin priced, so requests it did not price appear as the gap between

--- a/authbridge/docs/superpowers/plans/2026-09-09-pricing-consolidation-phase0.md
+++ b/authbridge/docs/superpowers/plans/2026-09-09-pricing-consolidation-phase0.md
@@ -1,0 +1,917 @@
+# Consolidated Model Pricing — Phase 0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/v1/usage` and `abctl` report real per-request cost by having the usage aggregator consume the cost event `litellm-budget-track` already publishes, and report *coverage* so a partially-priced window is never presented as a complete total.
+
+**Architecture:** `litellm-budget-track` already emits a settled per-request dollar figure onto the session event (`emitCost`, `plugin.go:303-309`). The aggregator ignores it and instead offers an unused `Pricer` hook. This phase promotes that event's wire shape into a new `authlib/costevent` package consumed by both producer and aggregator, adds a `PricedRequests` counter to `Counts` so coverage folds correctly across buckets, decodes the event in `foldInto`, and deletes the dead `Pricer` seam. No pricing tables, no rate resolution, no discovery — those are phases 1-7.
+
+**Tech Stack:** Go 1.26.5, multi-module workspace (`authbridge/go.work`). Stdlib only — no new dependencies.
+
+**Spec:** `authbridge/docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md` (see its *Phasing* section, phase 0, and *What has already landed upstream*)
+
+**Issue:** cortex #910
+
+## Global Constraints
+
+- **Go version:** 1.26.5 (`authbridge/go.work`). Do not raise it.
+- **Module:** all code in this phase lives in `github.com/rossoctl/cortex/authbridge/authlib`. No changes to other modules — `abctl` adopts `costevent` in a later phase.
+- **No new dependencies.** Stdlib `encoding/json` and `math` only.
+- **Test command:** `cd authbridge/authlib && go test -race ./...` — matches CI (`.github/workflows/ci.yaml:49,67`).
+- **Lint:** `make lint` from the repo root (pre-commit hooks) before each commit.
+- **DCO:** every commit uses `git commit -s`. Required or CI fails.
+- **Attribution:** use `Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>`. **Never** `Co-Authored-By` — a `commit-msg` hook rejects it.
+- **Wire compatibility is mandatory.** The four JSON tags `cost_usd`, `source`, `daily_total_usd`, `daily_max_usd` must not change. `abctl` decodes them today (`cmd/abctl/tui/cost_event.go:18-35`) under a test that pins every field, and `abctl` is a separate module not being rebuilt in this phase.
+- **Unpriced must never render as `$0.00`.** A zero cost and an unknown cost are different answers. This is existing house style — see `cost_event.go:65-68` and `usage/snapshot.go:58-61`.
+- **Redirect verbose command output to a file** and report only the exit code, per the repo's context-budget rule. `export LOG_DIR=/tmp/rossoctl/tdd/pricing-phase0 && mkdir -p $LOG_DIR`.
+
+---
+
+## File Structure
+
+**Create**
+
+- `authbridge/authlib/costevent/costevent.go` — canonical wire shape of the per-request cost event, plus its decoder and the `USD → micros` conversion. Its own package (not inside `usage` or the plugin) because the producer is a plugin, the consumers are the aggregator and later `abctl`, and none of those should import each other. Small and dependency-light: it imports only `encoding/json`, `math`, and `authlib/pipeline`.
+- `authbridge/authlib/costevent/costevent_test.go` — decode cases and the tag-pinning test.
+
+**Modify**
+
+- `authbridge/authlib/plugins/litellm_budgettrack/plugin.go:88-101,303-315` — drop the local `costEvent` struct and `source*` constants; emit `costevent.Event`.
+- `authbridge/authlib/usage/usage.go:46-64` — add `Counts.PricedRequests` and fold it in `add`.
+- `authbridge/authlib/usage/usage.go:399-420` — decode the cost event in `foldInto`.
+- `authbridge/authlib/usage/usage.go:107-129,192-193` — delete `Pricer`, `WithPricer`, and the `pricer` field; retire the stale `TODO(cost)`.
+- `authbridge/authlib/usage/snapshot.go:56-61,224` — re-derive `Priced` from `PricedRequests`.
+- `authbridge/authlib/sessionapi/usage.go:46-63` — retire the stale `TODO(cost)`.
+- `authbridge/docs/session-events.md` *(if it documents the wire)* and `authbridge/docs/litellm-budgettrack-plugin.md` — note the shared event package.
+
+---
+
+## Task 1: `authlib/costevent` — canonical cost-event wire shape
+
+**Files:**
+- Create: `authbridge/authlib/costevent/costevent.go`
+- Test: `authbridge/authlib/costevent/costevent_test.go`
+
+**Interfaces:**
+- Consumes: `pipeline.SessionEvent` (its `Plugins map[string]json.RawMessage` field, `pipeline/session.go:108`).
+- Produces: `costevent.PluginName`, `costevent.SourceGatewayHeader`, `costevent.SourceUsageFallback`, `costevent.Event{CostUSD, Source, DailyTotalUSD, DailyMaxUSD}`, `Event.Micros() int64`, `costevent.Decode(*pipeline.SessionEvent) (Event, bool)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `authbridge/authlib/costevent/costevent_test.go`:
+
+```go
+package costevent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// eventWith builds a SessionEvent carrying raw JSON under the cost-event key.
+func eventWith(t *testing.T, key, raw string) *pipeline.SessionEvent {
+	t.Helper()
+	return &pipeline.SessionEvent{
+		Plugins: map[string]json.RawMessage{key: json.RawMessage(raw)},
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *pipeline.SessionEvent
+		wantOK   bool
+		wantCost float64
+		wantSrc  string
+	}{
+		{
+			name:     "gateway header cost",
+			event:    eventWith(t, PluginName, `{"cost_usd":0.0421,"source":"gateway-header","daily_total_usd":1.5,"daily_max_usd":10}`),
+			wantOK:   true,
+			wantCost: 0.0421,
+			wantSrc:  SourceGatewayHeader,
+		},
+		{
+			name:     "usage fallback cost",
+			event:    eventWith(t, PluginName, `{"cost_usd":0.01,"source":"usage-fallback"}`),
+			wantOK:   true,
+			wantCost: 0.01,
+			wantSrc:  SourceUsageFallback,
+		},
+		{
+			// A cache hit or error charges nothing and the plugin emits nothing;
+			// a zero that does arrive must not read as a priced free request.
+			name:   "zero cost is not priced",
+			event:  eventWith(t, PluginName, `{"cost_usd":0,"source":"gateway-header"}`),
+			wantOK: false,
+		},
+		{
+			name:   "negative cost rejected",
+			event:  eventWith(t, PluginName, `{"cost_usd":-1,"source":"gateway-header"}`),
+			wantOK: false,
+		},
+		{
+			name:   "malformed JSON rejected",
+			event:  eventWith(t, PluginName, `{"cost_usd":`),
+			wantOK: false,
+		},
+		{
+			name:   "different plugin key ignored",
+			event:  eventWith(t, "tool-prune", `{"cost_usd":5}`),
+			wantOK: false,
+		},
+		{
+			name:   "no plugins map",
+			event:  &pipeline.SessionEvent{},
+			wantOK: false,
+		},
+		{
+			name:   "nil event",
+			event:  nil,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Decode(tc.event)
+			if ok != tc.wantOK {
+				t.Fatalf("Decode ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.CostUSD != tc.wantCost {
+				t.Errorf("CostUSD = %v, want %v", got.CostUSD, tc.wantCost)
+			}
+			if got.Source != tc.wantSrc {
+				t.Errorf("Source = %q, want %q", got.Source, tc.wantSrc)
+			}
+		})
+	}
+}
+
+// TestEventJSONTagsArePinned guards the wire format. abctl decodes these exact
+// tags from a separate module that this phase does not rebuild, so a rename here
+// would silently blank its COST column.
+func TestEventJSONTagsArePinned(t *testing.T) {
+	b, err := json.Marshal(Event{
+		CostUSD:       0.25,
+		Source:        SourceGatewayHeader,
+		DailyTotalUSD: 3.5,
+		DailyMaxUSD:   10,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"cost_usd":0.25,"source":"gateway-header","daily_total_usd":3.5,"daily_max_usd":10}`
+	if string(b) != want {
+		t.Errorf("wire format changed:\n got %s\nwant %s", b, want)
+	}
+}
+
+func TestMicros(t *testing.T) {
+	tests := []struct {
+		name string
+		usd  float64
+		want int64
+	}{
+		{"whole dollar", 1, 1_000_000},
+		{"typical request", 0.0421, 42_100},
+		{"rounds to nearest", 0.0000005, 1},
+		{"sub-micro rounds to zero", 0.0000001, 0},
+		{"large", 1234.5678, 1_234_567_800},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (Event{CostUSD: tc.usd}).Micros(); got != tc.want {
+				t.Errorf("Micros() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd authbridge/authlib && go test ./costevent/ 2>&1 | tail -5
+```
+
+Expected: FAIL — the `costevent` package does not exist yet (`no Go files in .../costevent`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `authbridge/authlib/costevent/costevent.go`:
+
+```go
+// Package costevent is the canonical wire shape of the per-request cost that
+// litellm-budget-track publishes onto a session event.
+//
+// It lives in its own package because the producer is a plugin while the
+// consumers are the usage aggregator and abctl, and none of those should import
+// each other. Before this package existed the struct was declared three times —
+// once in the plugin, once in abctl, and about to be a third time in the
+// aggregator — which is the duplication cortex #910 exists to remove.
+//
+// Dependency-light on purpose: the aggregator links this on every build,
+// including the trimmed "lite" images that exclude the plugin entirely.
+package costevent
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// PluginName is the session-event key the cost event is published under. It must
+// equal litellm_budgettrack.BudgetTrack.Name(); a test in that package asserts it.
+const PluginName = "litellm-budget-track"
+
+// Source names how the cost was arrived at.
+const (
+	// SourceGatewayHeader is the gateway's own post-discount figure, read from
+	// x-litellm-response-cost. Authoritative.
+	SourceGatewayHeader = "gateway-header"
+	// SourceUsageFallback is priced from token counters because the header
+	// reported 0 — which every streamed response does, so for a streaming agent
+	// this is the common case, not the exception.
+	SourceUsageFallback = "usage-fallback"
+)
+
+// Event is one request's settled cost. Unlike tool-prune's event, which carries
+// rates and leaves the arithmetic to the consumer, this carries a finished
+// figure.
+type Event struct {
+	CostUSD float64 `json:"cost_usd"`
+	// Source is SourceGatewayHeader or SourceUsageFallback. A consumer that
+	// distinguishes authoritative from modelled figures reads this.
+	Source        string  `json:"source"`
+	DailyTotalUSD float64 `json:"daily_total_usd"`
+	DailyMaxUSD   float64 `json:"daily_max_usd"`
+}
+
+// Micros converts CostUSD to millionths of a dollar, rounded to nearest.
+//
+// The integer unit is what usage.Counts accumulates: it keeps bucket addition
+// exact and JSON round-tripping lossless, which float dollars are not. A cost
+// below half a micro rounds to 0 while still counting as priced — a real
+// sub-micro charge, not an unknown one.
+func (e Event) Micros() int64 { return int64(math.Round(e.CostUSD * 1e6)) }
+
+// Decode pulls the cost event off a session event.
+//
+// A false return is the normal case, not an error: the plugin may not be in the
+// pipeline, and a request that charged nothing (cache hit, error) emits nothing.
+// A non-positive cost also returns false — "free" and "unknown" must not be
+// conflated, and a consumer that treated 0 as priced would render $0.00 for
+// traffic it simply cannot price.
+func Decode(e *pipeline.SessionEvent) (Event, bool) {
+	if e == nil || len(e.Plugins) == 0 {
+		return Event{}, false
+	}
+	raw, ok := e.Plugins[PluginName]
+	if !ok {
+		return Event{}, false
+	}
+	var ev Event
+	if err := json.Unmarshal(raw, &ev); err != nil || ev.CostUSD <= 0 {
+		return Event{}, false
+	}
+	return ev, true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd authbridge/authlib && go test -race ./costevent/ 2>&1 | tail -5
+```
+
+Expected: `ok  github.com/rossoctl/cortex/authbridge/authlib/costevent`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add authbridge/authlib/costevent/
+git commit -s -m "feat: Add costevent, the canonical per-request cost wire shape
+
+The cost litellm-budget-track publishes was declared once in the plugin
+and again in abctl, and the usage aggregator was about to add a third
+copy. One package, one struct, one decoder.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `litellm-budget-track` emits `costevent.Event`
+
+**Files:**
+- Modify: `authbridge/authlib/plugins/litellm_budgettrack/plugin.go:88-101` (delete local struct + constants), `:303-315` (`emitCost`)
+- Test: `authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go`
+
+**Interfaces:**
+- Consumes: `costevent.Event`, `costevent.PluginName`, `costevent.SourceGatewayHeader`, `costevent.SourceUsageFallback` from Task 1.
+- Produces: no new exported API. The published JSON is byte-identical to before.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go`:
+
+```go
+// TestPluginNameMatchesCostEventKey pins the plugin name to the constant the
+// aggregator and abctl look the event up by. A rename on one side only would
+// make every consumer silently stop seeing costs.
+func TestPluginNameMatchesCostEventKey(t *testing.T) {
+	if got := (&BudgetTrack{}).Name(); got != costevent.PluginName {
+		t.Errorf("Name() = %q, costevent.PluginName = %q", got, costevent.PluginName)
+	}
+}
+
+// TestEmitCostPublishesCostEvent asserts the published value is a
+// costevent.Event and that its JSON is unchanged from the local struct it
+// replaces.
+func TestEmitCostPublishesCostEvent(t *testing.T) {
+	p := &BudgetTrack{}
+	p.cfg.MaxBudget = 10
+	pctx := &pipeline.Context{}
+
+	p.emitCost(pctx, 0.25, costevent.SourceGatewayHeader, 3.5)
+
+	raw, ok := pctx.Extensions.Custom[p.Name()+pipeline.PluginEventSuffix]
+	if !ok {
+		t.Fatalf("no event published under %q", p.Name()+pipeline.PluginEventSuffix)
+	}
+	ev, ok := raw.(costevent.Event)
+	if !ok {
+		t.Fatalf("published value is %T, want costevent.Event", raw)
+	}
+	if ev.CostUSD != 0.25 || ev.Source != costevent.SourceGatewayHeader ||
+		ev.DailyTotalUSD != 3.5 || ev.DailyMaxUSD != 10 {
+		t.Errorf("unexpected event: %+v", ev)
+	}
+
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"cost_usd":0.25,"source":"gateway-header","daily_total_usd":3.5,"daily_max_usd":10}`
+	if string(b) != want {
+		t.Errorf("wire format changed:\n got %s\nwant %s", b, want)
+	}
+}
+```
+
+Add these imports to the test file if absent: `encoding/json`, and `"github.com/rossoctl/cortex/authbridge/authlib/costevent"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd authbridge/authlib && go test ./plugins/litellm_budgettrack/ -run 'TestPluginNameMatchesCostEventKey|TestEmitCostPublishesCostEvent' 2>&1 | tail -8
+```
+
+Expected: FAIL — the published value is the package-local `costEvent`, not `costevent.Event`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `plugin.go`, delete the local `costEvent` struct and the two `source*` constants (currently `:88-101`), then re-point `emitCost`:
+
+```go
+func (p *BudgetTrack) emitCost(pctx *pipeline.Context, cost float64, source string, dailyTotal float64) {
+	if pctx.Extensions.Custom == nil {
+		pctx.Extensions.Custom = map[string]any{}
+	}
+	pctx.Extensions.Custom[p.Name()+pipeline.PluginEventSuffix] = costevent.Event{
+		CostUSD:       cost,
+		Source:        source,
+		DailyTotalUSD: dailyTotal,
+		DailyMaxUSD:   p.cfg.MaxBudget,
+	}
+}
+```
+
+Replace the two call sites' constants (`plugin.go:204`, `:255`, `:270`) with the `costevent.` forms:
+
+```go
+p.emitCost(pctx, cost, costevent.SourceGatewayHeader, total)   // header path
+source := costevent.SourceGatewayHeader                         // terminal-frame path
+source = costevent.SourceUsageFallback                          // when priced from usage
+```
+
+Add the import:
+
+```go
+"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd authbridge/authlib && go test -race ./plugins/litellm_budgettrack/ > $LOG_DIR/budgettrack.log 2>&1; echo "EXIT:$?"
+```
+
+Expected: `EXIT:0`. The pre-existing tests in this package are the regression oracle — every one must still pass unchanged. If any fail, the wire shape or a constant changed; fix rather than update the expectation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add authbridge/authlib/plugins/litellm_budgettrack/
+git commit -s -m "refactor: Emit the shared costevent.Event from litellm-budget-track
+
+Same four JSON fields, same values, one fewer declaration of them.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `Counts.PricedRequests` coverage counter
+
+**Files:**
+- Modify: `authbridge/authlib/usage/usage.go:46-64`
+- Test: `authbridge/authlib/usage/usage_test.go`
+
+**Interfaces:**
+- Produces: `usage.Counts.PricedRequests int64`, summed by the existing unexported `(*Counts).add`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `authbridge/authlib/usage/usage_test.go`:
+
+```go
+// TestCountsAddFoldsPricedRequests is why coverage is a counter and not a
+// boolean: buckets are summed when a client asks for a coarser resolution, and
+// a bool cannot express "12 of 40 requests in this window were priced".
+func TestCountsAddFoldsPricedRequests(t *testing.T) {
+	a := Counts{Requests: 10, CostMicros: 500, PricedRequests: 4}
+	a.add(Counts{Requests: 5, CostMicros: 250, PricedRequests: 3})
+
+	if a.Requests != 15 {
+		t.Errorf("Requests = %d, want 15", a.Requests)
+	}
+	if a.CostMicros != 750 {
+		t.Errorf("CostMicros = %d, want 750", a.CostMicros)
+	}
+	if a.PricedRequests != 7 {
+		t.Errorf("PricedRequests = %d, want 7", a.PricedRequests)
+	}
+	if unpriced := a.Requests - a.PricedRequests; unpriced != 8 {
+		t.Errorf("unpriced = %d, want 8", unpriced)
+	}
+}
+
+// TestCountsPricedRequestsOmittedWhenZero keeps the wire quiet for deployments
+// that price nothing.
+func TestCountsPricedRequestsOmittedWhenZero(t *testing.T) {
+	b, err := json.Marshal(Counts{Requests: 3})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "pricedRequests") {
+		t.Errorf("zero PricedRequests should be omitted, got %s", b)
+	}
+}
+```
+
+Add `encoding/json` and `strings` to the test file's imports if absent.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd authbridge/authlib && go test ./usage/ -run TestCounts 2>&1 | tail -6
+```
+
+Expected: FAIL — `unknown field PricedRequests in struct literal`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `usage.go`, add the field to `Counts` after `CostMicros`:
+
+```go
+	// PricedRequests counts the requests that actually produced a cost. Coverage
+	// is a counter rather than a flag because buckets are summed when a client
+	// asks for a coarser resolution, and because a deployment can price some of
+	// its traffic and not the rest: several endpoints, rates known for some.
+	// Requests-minus-PricedRequests is the gap, correct at every resolution, and
+	// it is what stops a partial total being presented as a complete one.
+	PricedRequests int64 `json:"pricedRequests,omitempty"`
+```
+
+and to `add`:
+
+```go
+	c.PricedRequests += o.PricedRequests
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd authbridge/authlib && go test -race ./usage/ > $LOG_DIR/usage-counts.log 2>&1; echo "EXIT:$?"
+```
+
+Expected: `EXIT:0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add authbridge/authlib/usage/
+git commit -s -m "feat: Count priced requests per bucket
+
+Coverage has to fold with the buckets, so it is a counter. A snapshot
+boolean cannot say '12 of 40 were priced'.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `foldInto` records the cost event
+
+**Files:**
+- Modify: `authbridge/authlib/usage/usage.go:399-420`
+- Test: `authbridge/authlib/usage/usage_test.go`
+
+**Interfaces:**
+- Consumes: `costevent.Decode`, `Event.Micros` (Task 1); `Counts.PricedRequests` (Task 3).
+- Produces: `Aggregator.Record` now populates `CostMicros` and `PricedRequests` with no `Pricer` configured.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `authbridge/authlib/usage/usage_test.go`:
+
+```go
+// responseEventWithCost builds the response-phase event a listener would append,
+// carrying the plugin cost event under its published key.
+func responseEventWithCost(t *testing.T, model string, totalTokens int, costUSD float64) *pipeline.SessionEvent {
+	t.Helper()
+	ev := &pipeline.SessionEvent{
+		At:        time.Now(),
+		Phase:     pipeline.SessionResponse,
+		RequestID: "req-1",
+		Host:      "litellm.corp",
+		Inference: &pipeline.InferenceExtension{Model: model, TotalTokens: totalTokens},
+	}
+	if costUSD > 0 {
+		raw, err := json.Marshal(costevent.Event{
+			CostUSD: costUSD,
+			Source:  costevent.SourceGatewayHeader,
+		})
+		if err != nil {
+			t.Fatalf("marshal cost event: %v", err)
+		}
+		ev.Plugins = map[string]json.RawMessage{costevent.PluginName: raw}
+	}
+	return ev
+}
+
+func TestRecordPricesFromCostEvent(t *testing.T) {
+	a := New()
+	a.Record("sess-1", responseEventWithCost(t, "claude-opus-5", 1000, 0.0421))
+
+	snap := a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+	if snap.Totals.Requests != 1 {
+		t.Fatalf("Requests = %d, want 1", snap.Totals.Requests)
+	}
+	if snap.Totals.CostMicros != 42_100 {
+		t.Errorf("CostMicros = %d, want 42100", snap.Totals.CostMicros)
+	}
+	if snap.Totals.PricedRequests != 1 {
+		t.Errorf("PricedRequests = %d, want 1", snap.Totals.PricedRequests)
+	}
+}
+
+// A request with no cost event still counts, and still contributes tokens — it
+// just contributes no dollars. This is the partial-coverage case.
+func TestRecordMixedCoverage(t *testing.T) {
+	a := New()
+	a.Record("sess-1", responseEventWithCost(t, "claude-opus-5", 1000, 0.02))
+	a.Record("sess-1", responseEventWithCost(t, "some-other-model", 500, 0))
+
+	snap := a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+	if snap.Totals.Requests != 2 {
+		t.Fatalf("Requests = %d, want 2", snap.Totals.Requests)
+	}
+	if snap.Totals.PricedRequests != 1 {
+		t.Errorf("PricedRequests = %d, want 1", snap.Totals.PricedRequests)
+	}
+	if snap.Totals.CostMicros != 20_000 {
+		t.Errorf("CostMicros = %d, want 20000 (only the priced request)", snap.Totals.CostMicros)
+	}
+	if snap.Totals.Tokens != 1500 {
+		t.Errorf("Tokens = %d, want 1500 (both requests)", snap.Totals.Tokens)
+	}
+}
+
+// Tokens are unaffected by pricing: a request with no cost event is not a
+// request with no traffic.
+func TestRecordUnpricedContributesNoCost(t *testing.T) {
+	a := New()
+	a.Record("sess-1", responseEventWithCost(t, "claude-opus-5", 700, 0))
+
+	snap := a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+	if snap.Totals.CostMicros != 0 {
+		t.Errorf("CostMicros = %d, want 0", snap.Totals.CostMicros)
+	}
+	if snap.Totals.PricedRequests != 0 {
+		t.Errorf("PricedRequests = %d, want 0", snap.Totals.PricedRequests)
+	}
+	if snap.Totals.Tokens != 700 {
+		t.Errorf("Tokens = %d, want 700", snap.Totals.Tokens)
+	}
+}
+```
+
+Add imports if absent: `encoding/json`, `time`, `"github.com/rossoctl/cortex/authbridge/authlib/costevent"`, `"github.com/rossoctl/cortex/authbridge/authlib/pipeline"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd authbridge/authlib && go test ./usage/ -run TestRecord 2>&1 | tail -10
+```
+
+Expected: FAIL — `CostMicros = 0, want 42100`. Nothing populates cost yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `foldInto`, replace the tokens/cost block (`usage.go:405-415`) with:
+
+```go
+	var tokens int64
+	var model string
+	if e.Inference != nil {
+		tokens = int64(e.Inference.TotalTokens)
+		model = e.Inference.Model
+	}
+
+	// Cost comes from the plugin that already settled it, not from a rate table
+	// here: litellm-budget-track prefers the gateway's own post-discount figure
+	// and falls back to pricing the usage block, and it publishes the result on
+	// the event. Absent means unpriced, which is not the same as free — see
+	// Counts.PricedRequests.
+	var cost, priced int64
+	if ce, ok := costevent.Decode(e); ok {
+		cost = ce.Micros()
+		priced = 1
+	}
+
+	one := Counts{Requests: 1, Tokens: tokens, CostMicros: cost, PricedRequests: priced}
+```
+
+Add the import:
+
+```go
+"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd authbridge/authlib && go test -race ./usage/ ./sessionapi/ > $LOG_DIR/usage-fold.log 2>&1; echo "EXIT:$?"
+```
+
+Expected: `EXIT:0`. Every pre-existing test in both packages must pass unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add authbridge/authlib/usage/
+git commit -s -m "feat: Record per-request cost in the usage aggregator
+
+The figure was already on the session event; the aggregator just never
+read it. /v1/usage reports real dollars now, plus how many of the
+requests in the window contributed one.
+
+Closes the TODO(cost) in usage.go and sessionapi/usage.go.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Derive `Priced`, delete the dead `Pricer` seam
+
+**Files:**
+- Modify: `authbridge/authlib/usage/usage.go:107-129` (delete `Pricer`), `:145` (`pricer` field), `:192-193` (`WithPricer`), `authbridge/authlib/usage/snapshot.go:56-61,224`, `authbridge/authlib/sessionapi/usage.go:46-63`
+- Test: `authbridge/authlib/usage/snapshot_test.go`
+
+**Interfaces:**
+- Consumes: `Counts.PricedRequests` (Task 3), populated by `foldInto` (Task 4).
+- Produces: `Snapshot.Priced` now means "at least one request in this window was priced". `usage.Pricer`, `usage.WithPricer` and the `Aggregator.pricer` field no longer exist.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `authbridge/authlib/usage/snapshot_test.go`:
+
+```go
+// Priced is derived from what actually happened, not from whether a hook was
+// installed. A window that priced nothing must report false so a client renders
+// "cost unavailable" rather than $0.00.
+func TestSnapshotPricedDerivedFromCoverage(t *testing.T) {
+	t.Run("nothing priced", func(t *testing.T) {
+		a := New()
+		a.Record("s", responseEventWithCost(t, "m", 100, 0))
+		snap := a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+		if snap.Priced {
+			t.Error("Priced = true, want false when no request was priced")
+		}
+	})
+
+	t.Run("something priced", func(t *testing.T) {
+		a := New()
+		a.Record("s", responseEventWithCost(t, "m", 100, 0.01))
+		snap := a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+		if !snap.Priced {
+			t.Error("Priced = false, want true when a request was priced")
+		}
+	})
+
+	t.Run("partially priced still reports priced", func(t *testing.T) {
+		a := New()
+		a.Record("s", responseEventWithCost(t, "m", 100, 0.01))
+		a.Record("s", responseEventWithCost(t, "n", 100, 0))
+		snap := a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+		if !snap.Priced {
+			t.Error("Priced = false, want true")
+		}
+		if snap.Totals.PricedRequests != 1 || snap.Totals.Requests != 2 {
+			t.Errorf("coverage = %d/%d, want 1/2",
+				snap.Totals.PricedRequests, snap.Totals.Requests)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd authbridge/authlib && go test ./usage/ -run TestSnapshotPricedDerived 2>&1 | tail -8
+```
+
+Expected: FAIL on the "something priced" subtest — `Priced` is still `a.pricer != nil`, which is always `nil`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`Priced` is currently set in the `Snapshot{...}` literal at `snapshot.go:224`, which runs *before* the loop that accumulates `out.Totals`. It cannot be derived there. **Delete the line from the literal:**
+
+```go
+		Priced:        a.pricer != nil,   // <- delete this line
+```
+
+and set it after the accumulation loop, immediately before the `fold` call at `snapshot.go:244`:
+
+```go
+	// Derived after the loop: Totals is only complete once every bucket has been
+	// added. Placed before fold because fold rewrites Buckets, not Totals.
+	out.Priced = out.Totals.PricedRequests > 0
+
+	// Fold last: totals are summed from the raw buckets above and are unaffected
+	// by grouping width, so a client's summary line agrees with its chart no
+	// matter which resolution it asked for.
+	out.Buckets = fold(out.Buckets, resolution)
+	return out
+```
+
+Replace the `Priced` doc comment (`snapshot.go:58-61`):
+
+```go
+	// Priced reports whether ANY request in this window produced a cost. False
+	// means CostMicros is absent everywhere and a client must say "cost
+	// unavailable" rather than display $0.00 — which would read as "this traffic
+	// was free".
+	//
+	// True does NOT mean every request was priced. Compare Totals.PricedRequests
+	// against Totals.Requests: rates are per-endpoint, so a deployment talking to
+	// several endpoints can price some traffic and not the rest, and the total
+	// then covers only the priced subset. A client showing a dollar figure from a
+	// partial window must say so.
+	Priced bool `json:"priced"`
+```
+
+Delete the `Pricer` type and its `TODO(cost)` block (`usage.go:107-129`), the `pricer Pricer` field (`usage.go:145`), and `WithPricer` (`usage.go:192-193`).
+
+Replace the stale `TODO(cost)` in `sessionapi/usage.go:46-63` with:
+
+```go
+// Cost is populated from the per-request figure litellm-budget-track publishes on
+// the session event: it prefers the gateway's own post-discount cost header and
+// falls back to pricing the usage block, so the number here is the plugin's, not
+// a rate table's. Requests the plugin did not price contribute no cost and are
+// counted in the gap between totals.pricedRequests and totals.requests; a client
+// rendering a dollar figure from a window where those differ must present it as
+// partial. priced:false means nothing was priced at all — render "cost
+// unavailable", not $0.00.
+//
+// Modelled rates for traffic that has no cost event (no litellm-budget-track in
+// the pipeline) arrive with the pricing resolver — see
+// docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md.
+```
+
+- [ ] **Step 4: Run the full module test suite**
+
+```bash
+cd authbridge/authlib && go test -race ./... > $LOG_DIR/authlib-full.log 2>&1; echo "EXIT:$?"
+```
+
+Expected: `EXIT:0`. If a test referenced `WithPricer`, delete that test — it was asserting on a seam that never had a producer.
+
+Then confirm the other modules still build, since `go.work` links them:
+
+```bash
+cd authbridge && go build ./... > $LOG_DIR/build-all.log 2>&1; echo "EXIT:$?"
+cd cmd/abctl && go build ./... > $LOG_DIR/build-abctl.log 2>&1; echo "EXIT:$?"
+```
+
+Expected: `EXIT:0` for both. `abctl` keeps its own copy of the event struct in this phase, so it must be unaffected.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+make lint > $LOG_DIR/lint.log 2>&1; echo "EXIT:$?"
+git add authbridge/authlib/usage/ authbridge/authlib/sessionapi/
+git commit -s -m "refactor: Derive Priced from coverage, delete the unused Pricer seam
+
+Priced meant 'a Pricer was installed' and no caller ever installed one,
+so it was always false. It now reports whether anything was actually
+priced, and Totals.PricedRequests says how much of the window that
+covers.
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Document the wire change
+
+**Files:**
+- Modify: `authbridge/docs/litellm-budgettrack-plugin.md`, `authbridge/CLAUDE.md:453-510` (the Session Events API section, `/v1/usage` row)
+
+**Interfaces:**
+- Consumes: nothing. Documentation only.
+- Produces: nothing.
+
+- [ ] **Step 1: Find the surfaces that document the wire**
+
+```bash
+cd authbridge && grep -rn "priced\|costMicros\|cost_usd" docs/ CLAUDE.md | grep -v superpowers
+```
+
+Record the hits — those are the places that now describe stale behaviour.
+
+- [ ] **Step 2: Update each hit**
+
+For every occurrence, apply these facts:
+
+- `costMicros` is populated whenever `litellm-budget-track` ran and priced the request.
+- `pricedRequests` is new on `Counts`; `requests - pricedRequests` is the unpriced gap.
+- `priced` now means "at least one request was priced", not "a pricer is configured".
+- The event shape lives in `authlib/costevent` and is shared by the plugin and the aggregator.
+
+In `docs/litellm-budgettrack-plugin.md`, add to the session-event section:
+
+```markdown
+The event's wire shape is defined once in `authlib/costevent` (`costevent.Event`)
+and consumed by the usage aggregator, so `/v1/usage` reports the same figure this
+plugin enforces its budget against.
+```
+
+- [ ] **Step 3: Verify no stale statement remains**
+
+```bash
+cd authbridge && grep -rn "Pricer\|WithPricer" docs/ CLAUDE.md | grep -v superpowers || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add authbridge/docs/ authbridge/CLAUDE.md
+git commit -s -m "docs: Record that /v1/usage now reports cost and coverage
+
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>"
+```
+
+---
+
+## Definition of done
+
+- [ ] `cd authbridge/authlib && go test -race ./...` passes.
+- [ ] `cd authbridge && go build ./...` and `cd authbridge/cmd/abctl && go build ./...` both succeed.
+- [ ] `make lint` passes.
+- [ ] `grep -rn "TODO(cost)" authbridge/` returns nothing.
+- [ ] `grep -rn "Pricer" authbridge/authlib/` returns nothing.
+- [ ] The four `cost_usd` / `source` / `daily_total_usd` / `daily_max_usd` JSON tags are unchanged, pinned by a test in `costevent` and another in `litellm_budgettrack`.
+- [ ] Every commit carries `Signed-off-by` and `Assisted-By`, and none carries `Co-Authored-By`.
+
+## Not in this phase
+
+Phases 1-7 of the spec, which get their own plan: the `authlib/pricing` package, `Deps`/`BuildWithDeps` injection, the `toolprune` and `litellm_budgettrack` rate-config migrations, dropping `parseFrameUsage`, `UnpricedBy`, the `abctl` provenance and coverage rendering, and `/model/info` discovery.
+
+Deliberately deferred detail: after this phase, a request is priced only when
+`litellm-budget-track` is in the pipeline. Traffic without it stays unpriced and
+is visible as the gap between `pricedRequests` and `requests` — which is the
+honest report, and what phase 5's resolver fallback closes.

--- a/authbridge/docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md
+++ b/authbridge/docs/superpowers/specs/2026-09-09-pricing-consolidation-design.md
@@ -1,0 +1,608 @@
+# Consolidated Model Pricing — Design
+
+**Date:** 2026-09-09
+**Status:** Converged design — ready for implementation plan.
+**Issue:** cortex #910 — "feature: consistent model cost across the board"
+**Repos touched:** `cortex/authbridge` only.
+
+> **Terminology.** *Rate* = USD per token for one tier of one model at one
+> endpoint. *Tier* = which kind of token (uncached input, cache write, cache
+> read, output). *Provenance* = where a rate came from, which travels with every
+> figure. *Coverage* = what fraction of requests in a window produced a cost at
+> all.
+
+## Problem
+
+Model cost is configured and computed in several places that do not agree.
+
+**Two plugins own independent rate tables** with incompatible shapes:
+
+| | `toolprune` | `litellm_budgettrack` |
+|---|---|---|
+| Rate knobs | 12 (`plugin.go:86-115`) | 4 (`plugin.go:55-63`) |
+| Per-model keys | yes, with globs | **no** — flat scalars only |
+| Per-million unit | yes | no |
+| Output rate | **no** | yes |
+| Built-in defaults | yes (`pricing.go:43-63`) | no |
+| Cache fallback | write→read→input per tier (`plugin.go:155-174`) | write→input, read→input (`plugin.go:68-82`) |
+
+Neither table alone can price a whole request: `toolprune` has no output rate
+(it prices removed *prompt* bytes), `litellm_budgettrack` has no model
+dimension at all.
+
+**Dollar arithmetic is duplicated across five sites**, three of them in the
+**client**:
+
+| Site | What it computes |
+|---|---|
+| `toolprune/metrics.go:214,219` | `$ saved`, `$ saved / request` |
+| `litellm_budgettrack/plugin.go:191` + ledger | daily spend, budget deny |
+| `cmd/abctl/tui/prune_saving.go:53-77` | saved tokens × the tier's rate |
+| `cmd/abctl/tui/cost_event.go:69-80` | tier-weighted prompt cost (`promptCost`) |
+| `cmd/abctl/tui/usage_render.go:332-333` | the `snap.Priced` footer |
+
+The client recomputes only because rates reach it exclusively as event payload
+(`toolprune/event.go:36-41`). Note the trend: `promptCost` is a *second*
+client-side tier-weighted implementation, added while this issue was open — the
+duplication is actively growing, not static.
+
+**Token extraction is duplicated, and the pricing path uses the un-shared copy.**
+`inference-parser` is the designated producer, filling `Extensions.Inference`
+via `parsercommon.TokenUsage.Fill`; `sessionbudget`, `toolprune`, `cpex` and
+`opa` all consume it. `litellm_budgettrack` instead runs its own
+`parseFrameUsage` / `usageJSON` / `frameUsage` (`plugin.go:353-430`) with its own
+cross-frame reconciliation. The two reconciliations are the same algorithm
+written twice — `mergeAnthropicPromptMaxSeen` (`inferenceparser/anthropic.go:393-406`)
+versus the max-per-bucket block in `OnResponseFrame` (`litellm_budgettrack/plugin.go:214-235`)
+— and they already differ in one rule: output is a **cumulative assign** in
+`inference-parser` (`anthropic.go:382`) and a **max-of-seen** in
+`litellm_budgettrack` (`plugin.go:232-234`). Identical on a monotonic stream,
+not the same rule. The budget plugin's copy also drops `Present` bits and
+`Reasoning`.
+
+**The aggregator seam is wired to nothing.** `usage.Pricer` and
+`Counts.CostMicros` exist (`usage.go:107-129`); no caller supplies a Pricer, so
+`/v1/usage` reports `priced:false` and `abctl` renders no cost. Two `TODO(cost)`
+blocks (`usage/usage.go:114`, `sessionapi/usage.go:46`) name this issue and
+propose *different* fixes — promote the rates to a shared package, versus have
+the plugin that knows the true cost report it. The design below does both,
+because they are complementary rather than alternatives.
+
+### What has already landed upstream
+
+Checked against `upstream/main` at `25e612f8`, because two of this issue's
+sub-problems are partly solved and the design must not re-propose them.
+
+**The per-request cost event exists.** `litellm_budgettrack` already publishes
+`costEvent{cost_usd, source, daily_total_usd, daily_max_usd}` via `emitCost`
+(`plugin.go:303-309`), from both the header path (`plugin.go:204`) and the
+terminal-frame path (`plugin.go:275`), with `source` ∈ {`gateway-header`,
+`usage-fallback`} (`plugin.go:88-89`). `abctl` decodes it
+(`cmd/abctl/tui/cost_event.go:41-54`) under a test that pins every field.
+
+Two consequences. First, `sessionapi/usage.go:55-61`'s claim that a real cost
+"would need the cost surfaced onto the session event […] today it stays inside
+the plugin" **is now stale** — it is on the event; the aggregator simply does not
+read it. Second, `source` already draws the authoritative/modelled distinction
+this design needs, so provenance must **extend** that field rather than rename
+it: `abctl`'s decode test pins the tags, and additive is safe where a rename is
+not.
+
+**A per-tier `ok` discipline is already house style.** `promptCost`
+(`cost_event.go:69-80`) returns `ok=false` when `RateSource == "none"`, under the
+comment that this avoids "a $0.00 that would read as a free prompt". The `Cost`
+invariant below is that rule generalised, not a new policy.
+
+### Two grounding facts that change the shape of the fix
+
+**1. The built-in table cannot express versions that price differently, and
+that is a live error, not a hypothetical.** `pricing.go:22-31` keys by family
+(`*claude-opus-*`) and states the tradeoff plainly: *"this assumes a family
+bills at one rate."* Against LiteLLM's public price map today,
+`claude-opus-4-1` is **$15/$75** per MTok while `claude-opus-4-5` and
+`claude-opus-5` are **$5/$25** — a **3× error** between two models that both
+match the same glob.
+
+**2. The "~4x understatement" that blocked wiring the Pricer is stale.**
+`usage.go:118-121` and `sessionapi/usage.go:50-53` assert the built-in
+gateway-measured table understates a direct-to-Anthropic deployment by roughly
+4×. Measured against current first-party list prices it is a uniform **0.76×**
+— a flat 24% discount:
+
+| Family | `toolprune` built-in | Current list | Ratio |
+|---|---|---|---|
+| opus | $3.80/MTok | $5.00 | 0.76 |
+| sonnet | $1.52 | $2.00 | 0.76 |
+| haiku | $0.76 | $1.00 | 0.76 |
+
+The 4× figure is a fossil from when the current opus was `claude-opus-4-1` at
+$15/MTok ($15 ÷ $3.80 ≈ 3.9). Opus list dropped to $5 with 4.5. The stated
+objection therefore no longer holds at the stated magnitude — but the fact that
+a hand-maintained table rotted silently for a whole model generation is itself
+the argument for sourcing rates from data rather than from measurement.
+
+## Goals / Non-goals
+
+**Goals**
+
+1. One owner of rates; one function that turns tokens into dollars.
+2. Rates keyed by **(endpoint, model, tier)** — because the same model costs
+   different amounts at different endpoints.
+3. Distinguish models whose prices differ, including within a family.
+4. Discover rates automatically where the endpoint publishes them; accept
+   manual rates where it does not.
+5. Prefer a real, authoritative per-request cost over a modelled one.
+6. Never present an incomplete dollar total as a complete one.
+7. `/v1/usage` and `abctl` stop being cost-blind.
+
+**Non-goals**
+
+- Deriving a gateway's negotiated discount by regression over observed
+  header costs. Discovery returns the gateway's effective rates directly, which
+  makes inference unnecessary.
+- Modelling every tier LiteLLM can express (flex / priority / ultrafast service
+  tiers). See *Tier scope*.
+- Billing, invoicing, or reconciliation against a provider's books. This is
+  observability and budget enforcement.
+- Changing `sessionbudget`, which is token-denominated by design and has no
+  rate config.
+
+## Design decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Where rates live | New `authlib/pricing` package + top-level `pricing:` config | Sibling of `mtls` / `spiffe` / `tls_bridge`; no new config concept |
+| Key | `(endpoint, model, tier)` + context threshold | The same model prices differently per endpoint; a global profile is per-deployment when the choice is per-request |
+| Rate sources | authoritative → configured → discovered → bundled → none | An observed cost beats a modelled one; an explicit operator rate beats a fetched one |
+| LiteLLM endpoints | Discover via `GET /model/info` | It publishes rates, resolves aliases, and honours operator overrides |
+| Endpoints with no pricing API | Manual config, shipped pre-populated | Anthropic publishes no rate card; its list prices are public, so the block ships filled in rather than blank |
+| Tiers | input, cache-write, cache-read, output + context thresholds | Matches what LiteLLM publishes and what long sessions actually hit |
+| Coverage reporting | Counters, not a boolean | A bool cannot fold across buckets and cannot express a partial window |
+| Token source | `Extensions.Inference` only | One parser; the pricing path stops using the un-shared copy |
+| Injection | `pricing.ResolverConsumer`, mirroring `spiffe.ProviderConsumer` | Established precedent (`registry.go:316-368`) rather than a new mechanism |
+
+## Verified external facts
+
+Recorded because the design depends on them and they are checkable.
+
+**Anthropic publishes no rate card.** `GET /v1/models` returns `id`,
+`display_name`, `created_at`, `max_input_tokens`, `max_tokens`, `capabilities` —
+no prices. The Usage & Cost Admin API (`/v1/organizations/cost_report`,
+`/v1/organizations/usage_report/messages`) returns the organisation's **actual
+historical spend**: Admin API key required (workspace keys rejected), daily
+granularity for cost, ~5 minute lag. Useful for reconciliation, unusable as a
+rate card, and blind to a LiteLLM→Bedrock path since it only knows spend booked
+at Anthropic.
+
+**LiteLLM publishes rates two ways.**
+
+1. *Static public map* — `model_prices_and_context_window.json` in
+   `BerriAI/litellm`: 2.3 MB, 3,853 models, no auth. Fields:
+   `input_cost_per_token`, `output_cost_per_token`,
+   `cache_creation_input_token_cost`, `cache_read_input_token_cost`, and
+   `cache_creation_input_token_cost_above_1hr`. The endpoint dimension is
+   encoded in the **key** — `claude-opus-5` $5.00, `us.anthropic.claude-opus-5`
+   $5.50, `us-gov.anthropic.claude-opus-5` $6.00,
+   `databricks/databricks-claude-opus-5` $5.00003.
+2. *Runtime `GET /model/info`* — `proxy_server.py:14712-14721`, also registered
+   at `/v1/model/info`. Auth is `Depends(user_api_key_auth)`, so **any valid
+   virtual key** works, not only the master key. Credentials are stripped from
+   the response (`remove_sensitive_info_from_deployment`, `proxy_server.py:14707`).
+   Per deployment it returns `model_name` (the **client-facing alias**),
+   `litellm_params.model` (the underlying provider model), and `model_info`
+   carrying the rates.
+
+**Discovery returns *effective* rates, not list.** `_get_proxy_model_info`
+(`proxy_server.py:14673-14709`) resolves in three passes — the operator's config
+`model_info`, then `litellm.get_model_info(litellm_params.model)`, then a retry
+with the provider prefix stripped — and merges with `if k not in model_info`
+(`proxy_server.py:14702-14704`), so **configured pricing wins over the map**. A
+gateway with a negotiated discount reports the discount. This read path does not
+require `store_model_in_db` (its own sample response shows `db_model: false`);
+that requirement applies to the model CRUD routes.
+
+**Why discovery is structurally necessary, not a convenience.** Both parsers
+record the model from the **request** body — `inferenceparser/anthropic.go:87`
+and `inferenceparser/plugin.go:104` both do `Model: req.Model`. That is the name
+the *client* sent, i.e. the gateway's alias, and only the gateway knows the
+alias→underlying-model mapping. The static map is keyed by LiteLLM's internal
+identifier, so an alias cannot be resolved against it from the client-visible
+name alone.
+
+**The endpoint dimension already exists on the wire.** `pctx.Host`
+(`pipeline/context.go:108`) at request time, and `SessionEvent.Host`
+(`pipeline/session.go:126-131`), whose doc already states the intent: *"for
+outbound events it's the target service, which is the useful case — a session
+with many outbound calls can be attributed to the tool / LLM / target each
+landed on."*
+
+## Tier scope
+
+LiteLLM's `ModelInfoBase` (`litellm/types/utils.py:232-269`) models far more
+tiers than authbridge does: `cache_creation_input_token_cost_above_1hr`,
+`input_cost_per_token_above_200k_tokens`,
+`cache_read_input_token_cost_above_200k_tokens` / `_above_272k` / `_above_512k`,
+plus flex / priority / ultrafast service-tier variants.
+
+**In scope:** the four base tiers, each optionally overridden above a context
+threshold. Long-context premiums are not exotic for 1M-context Opus running an
+agent — crossing 200k prompt tokens is what a long session *is*, and today's
+three flat tiers price that traffic at the base rate.
+
+**Out of scope:** service-tier variants (flex / priority / ultrafast) and the
+1-hour-TTL cache-write premium. Both are real, neither is on a Claude path we
+run today, and unpopulated tiers are untested tiers. Discovery ignores those
+fields; adding one later is a field on `Rates` plus a threshold row, not a
+reshape.
+
+## Architecture
+
+### New package `authlib/pricing/`
+
+Single owner of rates and of the arithmetic.
+
+```go
+// Tier names which kind of token is being priced.
+type Tier int
+const (TierInput Tier = iota; TierCacheWrite; TierCacheRead; TierOutput)
+
+// Rates is one (endpoint, model) pair's rates, in USD per token.
+// Thresholds override Base above a prompt-token count, highest match winning.
+type Rates struct {
+    Base       [4]float64
+    Thresholds []ContextThreshold // {AbovePromptTokens int; Rate [4]float64; Set [4]bool}
+    Set        [4]bool            // which tiers actually have a rate
+}
+
+// Provenance travels with every figure so no consumer has to guess.
+type Provenance int
+const (ProvNone Provenance = iota; ProvBundled; ProvDiscovered; ProvConfigured; ProvAuthoritative)
+
+type Resolver interface {
+    Resolve(endpoint, model string, promptTotal int) (Rates, Provenance)
+}
+
+// Cost is the ONE place tokens become dollars.
+func Cost(r Rates, u parsercommon.TokenUsage) (micros int64, ok bool)
+```
+
+**`Cost` invariant — a request is priced only if every tier that carried tokens
+had a rate.** Otherwise `ok` is false and the request counts as *unpriced*,
+never as under-priced. This is not new policy; it is `toolprune`'s existing rule
+promoted. `rateFor` (`toolprune/plugin.go:155-174`) already returns a bool for
+exactly this reason, documented there: a model configured with only
+`cache_read_cost_per_token`
+
+> *"used to resolve as 'priced' and then return 0 for a cache-write request —
+> pricing it at zero while still counting toward the priced denominator, so the
+> saving silently vanished with no `requests unpriced` row to show it had."*
+
+Integer micros (millionths of a dollar) because `Counts.CostMicros` is already
+that unit (`usage/usage.go:51-56`) and it keeps bucket addition exact.
+
+### Resolution order
+
+Per `(endpoint, model, tier)`, first hit wins:
+
+1. **`ProvAuthoritative`** — a real observed cost for this request
+   (`X-Litellm-Response-Cost`, or its `-Original` variant). Not a rate; a
+   settled figure. Bypasses `Cost` entirely.
+2. **`ProvConfigured`** — an explicit `pricing.endpoints[].models` entry. An
+   override is an override, so it outranks a fetched value.
+3. **`ProvDiscovered`** — a cached `GET /model/info` answer for this endpoint.
+4. **`ProvBundled`** — the shipped slice of the public map.
+5. **`ProvNone`** — no rate. The request is unpriced.
+
+Within a level, an **exact model key beats a glob**, and longer globs beat
+shorter ones — `toolprune`'s existing rule (`plugin.go:190-209`, `pricing.go:80-85`)
+promoted unchanged. Endpoint matching uses host globs with the port stripped,
+reusing the established idiom (`sparc/collect.go:148-156`).
+
+### Discovery
+
+Per-endpoint, opt-in, and failure-tolerant.
+
+- On `Init`, and every `refresh` interval, `GET {endpoint}/model/info` with the
+  configured key. Index `model_name` → `Rates` built from `model_info`.
+- A fetch failure or timeout **never fails a request**: the previous snapshot is
+  retained, and if there is none, resolution falls through to
+  `ProvBundled`/`ProvNone`. Same fail-soft posture as the config reloader, which
+  keeps a stale bundle rather than deleting it.
+- Both `model_name` and `litellm_params.model` are indexed, so traffic naming
+  either the alias or the underlying model resolves.
+- Status (last success, model count, last error) is exposed on the existing
+  diagnostic listener alongside `/reload/status`, so "why is my traffic
+  unpriced" is answerable without a log dive.
+
+### Injection
+
+Plugins take no construction arguments and build dependencies from local config
+inside `Configure` (`plugins/registry.go:15-20`). The documented exception is
+the framework SPIFFE provider, injected via `BuildWithSPIFFE` +
+`spiffe.ProviderConsumer` **before** `Configure` runs so config code can use it
+(`registry.go:316-368`), with `SPIFFEConsumerPlugins()` (`registry.go:96-107`)
+probing for consumers the binary forgot to provision.
+
+Pricing follows that pattern exactly: `pricing.ResolverConsumer` with
+`SetPricingResolver`, injected before `Configure`, nil-tolerant, with an
+equivalent consumer probe.
+
+**One in-passing cleanup.** A second injected service would give us
+`BuildWithSPIFFEAndPricing`, and a third would be worse. Introduce:
+
+```go
+type Deps struct {
+    SPIFFE  *spiffe.Provider
+    Pricing pricing.Resolver
+}
+func BuildWithDeps(entries []config.PluginEntry, d Deps, opts ...pipeline.Option) (*pipeline.Pipeline, error)
+```
+
+`Build` and `BuildWithSPIFFE` become thin wrappers, so no caller or test
+changes. This is the only refactor outside the feature's own surface and it
+exists to stop a combinatorial explosion the feature would otherwise start.
+
+The resolver is constructed once at binary composition and shared by the
+pipeline builder *and* the usage aggregator — the aggregator needs it too, and a
+per-plugin instance would mean N discovery pollers per sidecar.
+
+### Plugin changes
+
+**`toolprune`** — delete `pricing.go`'s `defaultPatterns` and its glob machinery,
+all 12 rate knobs, `modelRates`, `normalize`, `rateFor`, `set`, `ratesFor`, and
+the `rateSource` enum. Consume the resolver. It keeps publishing resolved rates
+on its event: the counterfactual genuinely needs them, because it prices tokens
+that were never sent and therefore never appear in any authoritative cost.
+
+Its `$ saved` metric keeps its existing caveats and its `requests unpriced` row
+(`metrics.go:215-234`), now fed by resolver provenance rather than a local enum.
+The `usedDefaultRates` note (`metrics.go:190-201`) becomes provenance-driven.
+Its "understates list pricing" wording stays accurate — at 0.76× the built-in
+table does understate list — but the accompanying source comment's claim that
+the figure is *"several times low"* for anyone paying vendor list must go: that
+was true against $15/MTok opus and is now a 24% gap, not a multiple.
+
+**`litellm_budgettrack`** — delete `parseFrameUsage`, `usageJSON`, `frameUsage`,
+the max-per-bucket reconciliation, and all four rate knobs. Read
+`Extensions.Inference`. Keep `max_budget`, keep header authority, keep the
+exactly-once settle guard (`plugin.go:240-252`) — a listener that dispatches
+`last=true` twice must still not double-charge.
+
+Its cost event stays; only `source` changes, additively. Today
+`usage-fallback` means "priced from the plugin's own rates" and collapses every
+modelled case into one label. It becomes the rate's provenance —
+`configured` / `discovered` / `bundled` — with `gateway-header` unchanged and
+`usage-fallback` retained as the value when provenance is unavailable, so
+`abctl`'s pinning decode test keeps passing and older consumers keep parsing.
+
+It declares `Requires: ["inference-parser"]` so a pipeline missing the parser
+fails at startup with a named error rather than silently pricing zero — exactly
+what `validateRelationships` (`registry.go:370-448`) exists for. This is the one
+change that can break a working deployment: anyone running
+`litellm-budget-track` without `inference-parser` goes from working to a startup
+error. That is deliberate — the alternative is a budget that silently never
+triggers — and it belongs in the release note.
+
+### Aggregator and wire format
+
+`foldInto` currently collapses four tiers into `e.Inference.TotalTokens` and
+hands that to a scalar `Pricer` (`usage/usage.go:405-412`), which structurally
+cannot price cache-read at 0.1× input. Replace with:
+
+1. If the event carries a `litellm-budget-track` cost event, use its `cost_usd`
+   and its `source` as provenance. This is a decode of data already on the wire
+   (`cost_event.go:41-54` proves it decodes cleanly) — the cheapest correct
+   answer available, and the one the stale TODO was waiting for.
+2. Else resolve `(e.Host, e.Inference.Model, promptTotal)` and call `Cost` with
+   the full `TokenUsage`.
+3. Else the request is unpriced.
+
+Step 1 alone closes both `TODO(cost)` blocks for any pipeline running
+`litellm-budget-track`, independently of everything else in this design. It is
+therefore sequenced first among the aggregator work.
+
+`Pricer` and `WithPricer` are deleted rather than re-signatured — no caller has
+ever supplied one, so there is nothing to migrate.
+
+**Coverage counters replace the `Priced` boolean.** `Snapshot.Priced`
+(`usage/snapshot.go:58-61`) means "a Pricer was configured", which is wrong in
+two ways once rates are per-endpoint. Mixed traffic is the normal case for a
+laptop hitting several endpoints: `true` would present a total that silently
+omits unpriced traffic, and `false` would let one stray endpoint erase cost
+display for everything. It also **cannot be folded** — `Counts.add` sums fields
+(`usage.go:63`) and the aggregator folds buckets to any requested `resolution`,
+so a per-snapshot bool cannot express "12 of 40 requests in this bucket were
+priced."
+
+```go
+type Counts struct {
+    Requests       int64
+    CostMicros     int64
+    PricedRequests int64 // NEW — requests that contributed a cost
+    ...
+}
+```
+
+Unpriced is `Requests - PricedRequests`, correct at every resolution. Plus a
+snapshot-level `UnpricedBy map[string]int64` keyed `endpoint|model`, capped and
+truncated the way `byMethod` already is via `addLabel` / `truncateLabel`, so an
+operator sees which pricing block is missing. `Priced` stays on the wire as a
+derived convenience (`PricedRequests > 0`); its meaning shifts from "a Pricer
+exists" to "something actually priced", which is strictly more truthful and not
+a shape change.
+
+This directly precedents on `toolprune`, which already reports coverage
+alongside its total under the comment *"An incomplete pricing table is a gap in
+the dollar total, so name it"* (`metrics.go:225`).
+
+### `abctl`
+
+`savedTokensAndCost` (`prune_saving.go:53-77`) and `promptCost`
+(`cost_event.go:69-80`) both stop computing dollars and render what the event
+carries. `promptCost`'s `ok=false`-on-`none` behaviour — show tokens, omit the
+`$` — is the model for the unpriced case everywhere.
+
+**One existing decision this reverses, deliberately.** `cost_event.go:25-27`
+decodes `Source` but pointedly does *not* render it, reasoning that the COST
+column shows modelled and gateway-stamped figures identically because "the
+request-side cost […] is modelled too. Marking one and not the other would be the
+inconsistency." That reasoning is sound *today*. Once request-side cost also
+carries provenance, the asymmetry it guards against no longer exists, so
+rendering provenance on both becomes the consistent choice. The reversal is
+conditional on that, and the phase that renders it must land after the phase that
+gives the request side provenance.
+
+The usage footer (`usage_render.go:330-333`) gains three states:
+
+| Coverage | Render |
+|---|---|
+| none | `COST unavailable` |
+| partial | `COST $1.8421 (42/57 priced)` |
+| full | `COST $1.8421` + provenance label |
+
+## Config
+
+```yaml
+pricing:
+  endpoints:
+    # A LiteLLM gateway: ask it what it charges.
+    - hosts: ["litellm-a.corp", "*.litellm.internal"]
+      discover:
+        key_ref: { env: LITELLM_KEY }   # or file:
+        refresh: 15m
+
+    # No pricing API: manual rates. Ships pre-populated from public data.
+    - hosts: ["api.anthropic.com"]
+      models:
+        "claude-opus-5":
+          input_cost_per_million: 5.00
+          cache_write_cost_per_million: 6.25
+          cache_read_cost_per_million: 0.50
+          output_cost_per_million: 25.00
+        "claude-opus-4-1":
+          input_cost_per_million: 15.00
+          cache_write_cost_per_million: 18.75
+          cache_read_cost_per_million: 1.50
+          output_cost_per_million: 75.00
+```
+
+- Rates accept `*_per_million` (the published unit) or `*_per_token`; setting
+  both for one tier is a config error, as `toolprune` already enforces
+  (`plugin.go:139-150`).
+- `above_prompt_tokens:` blocks nest under a model for context thresholds.
+- Absent `pricing:` means bundled-only resolution — never a hard failure.
+- Hot reload: `pricing:` is not on the reloader's refusal list (`mode`,
+  `listener`, `session` — `reloader.go:309-318`), so it reloads by pipeline
+  rebuild. The resolver is shared with the aggregator, which outlives a
+  rebuild, so it is swapped in place rather than reconstructed.
+
+### The bundled slice
+
+A generated Go file holding Anthropic-family entries extracted from the public
+map, with the upstream commit SHA recorded in a constant. A `make` target
+regenerates it. This replaces three hand-measured family globs with data that
+already distinguishes `claude-opus-4-1` from `claude-opus-5`, and turns "refresh
+the rates" from a measurement exercise into a scripted diff.
+
+## Testing & success criteria
+
+**Unit**
+
+- Resolution precedence table: every provenance level, exact-beats-glob,
+  longest-glob-wins, endpoint scoping, port stripping.
+- Context-threshold crossing, including a request exactly at the boundary.
+- `Cost` invariant: a tier carrying tokens with no rate yields `ok == false`,
+  not a partial sum. Direct regression cover for the `rateFor` hazard.
+- Coverage folding: `Counts.add` and `fold` keep `PricedRequests` consistent
+  when buckets merge at coarser resolution.
+
+**Integration**
+
+- A discovery fake serving a real-shaped `/model/info` payload: alias
+  resolution, config-override precedence, fetch failure retaining the previous
+  snapshot, and cold-start failure falling through to bundled.
+- **SSE equivalence test (the key regression guard).** A canned Anthropic
+  streaming body, including the `?beta=true` shape that defers cache counts to
+  `message_delta`, must price identically before and after
+  `litellm_budgettrack` drops its own parser. This is the riskiest change in the
+  set and the only one where a silent divergence would be invisible.
+- Golden test pinning the bundled slice to its recorded upstream commit, so the
+  table cannot rot silently the way the 4× comment did.
+- `/v1/usage` end to end: mixed priced and unpriced traffic reports a partial
+  total with correct counters and names the unpriced pairs.
+
+**Success criteria**
+
+1. Exactly one rate table, one `Cost` function, one token parser.
+2. `claude-opus-4-1` and `claude-opus-5` price 3× apart, from bundled data, with
+   no operator config.
+3. A laptop hitting two LiteLLM gateways and `api.anthropic.com` prices all
+   three correctly — discovery for the gateways, manual for Anthropic.
+4. `/v1/usage` and `abctl` show cost, labelled with provenance, and say so when
+   coverage is partial.
+5. `litellm_budgettrack`'s ledger and `/v1/usage` agree on the same request.
+
+## Implementation surface
+
+**New:** `authlib/pricing/` (rates, resolver, `Cost`, host matching, discovery
+client, generated bundled slice) · `pricing.ResolverConsumer` · `Deps` +
+`BuildWithDeps`.
+
+**Deleted:** `toolprune/pricing.go` defaults and glob machinery · 12 `toolprune`
+rate knobs · `toolprune`'s `modelRates` / `normalize` / `rateFor` / `set` /
+`ratesFor` / `rateSource` · `litellm_budgettrack`'s `parseFrameUsage` / `usageJSON` /
+`frameUsage` / reconciliation / 4 rate knobs · `usage.Pricer` / `WithPricer` ·
+client-side arithmetic in `prune_saving.go`.
+
+**Changed:** `config.Config` (+`Pricing`) · `usage.Counts` (+`PricedRequests`) ·
+`usage.Snapshot` (+`UnpricedBy`, `Priced` re-derived) · `usage.foldInto` ·
+`litellm_budgettrack`'s `costEvent.source` values (additive) · `toolprune` and
+`litellm_budgettrack` configure/price paths · `abctl` `prune_saving.go`,
+`cost_event.go`, `usage_render.go` · `plugin-catalog.md`,
+`tool-prune-plugin.md`, `litellm-budgettrack-plugin.md`,
+`laptop-token-savings.md` · the stale `TODO(cost)` blocks and the stale
+"several times low" comment.
+
+**Net:** ~17 rate knobs → one `pricing:` section · 3 hand-measured globs → a
+generated slice · 2 token parsers → 1 · 5 arithmetic sites → 1.
+
+## Phasing (for the implementation plan)
+
+0. **Aggregator consumes the existing cost event** — `foldInto` decodes
+   `litellm-budget-track`'s `costEvent`, populates `CostMicros` and the coverage
+   counters, deletes `Pricer` / `WithPricer`, closes both `TODO(cost)` blocks.
+   **Independently shippable and independently valuable**: it needs none of the
+   packages below, and it makes `/v1/usage` and `abctl` show real cost for any
+   pipeline already running `litellm-budget-track`. Sequenced first so the
+   longest-standing gap closes in the smallest diff.
+1. **`authlib/pricing` standalone** — types, resolution, `Cost`, host matching,
+   bundled slice + generator + golden test. No consumers. Fully unit-tested in
+   isolation.
+2. **Injection** — `Deps` / `BuildWithDeps`, `ResolverConsumer`, consumer probe.
+   Behaviour-neutral.
+3. **`toolprune` migration** — swap to the resolver, delete its table. Existing
+   `$ saved` tests are the oracle; the bundled slice changes some expected
+   figures, which the diff must state per model rather than bulk-update.
+4. **`litellm_budgettrack` migration** — SSE equivalence test written *first*,
+   then drop the parser and rate knobs, add `Requires`, refine `source` into
+   provenance.
+5. **Aggregator resolver fallback** — pricing for requests with no cost event
+   (no `litellm-budget-track` in the pipeline), plus `UnpricedBy`.
+6. **`abctl`** — render provenance on both sides and the three coverage states.
+   Must follow phase 3, which is what makes rendering provenance consistent
+   rather than asymmetric (see the `cost_event.go:25-27` note above).
+7. **Discovery** — the client, refresh loop, fail-soft, status endpoint. Last
+   because every prior phase is useful without it, and it is the only phase with
+   an outbound dependency and a credential.
+
+## Open questions
+
+None blocking. Two to settle during implementation:
+
+- `/model/info` versus `/model_group/info` as the discovery target. Both expose
+  the client-facing name; `/model_group/info` (`proxy_server.py:15006`) is
+  documented as the end-user surface. Phase 7 checks which is more stable across
+  LiteLLM versions and may index both.
+- Whether the bundled slice covers non-Anthropic families. Anthropic-only keeps
+  it small and matches current traffic; the generator makes widening a one-line
+  filter change.


### PR DESCRIPTION
## Summary

Phase 0 of consolidating model pricing. `litellm-budget-track` has been publishing a settled per-request dollar figure on the session event since *Cost emission on event stream*; the usage aggregator ignored it and offered an unused `Pricer` hook instead. So `/v1/usage` reported `priced:false` forever and `abctl` showed no cost, while the number it needed was already on the wire.

This reads that event, and adds a coverage counter so a partially-priced window says so instead of passing a partial total off as complete.

The design doc covers all 8 phases; this PR is phase 0 only, which is independently shippable and validates the wire assumptions the rest rests on.

Key changes:

- New `authlib/costevent`: the cost event's wire shape declared **once**. It was declared in the plugin, again in `abctl`, and the aggregator was about to make it three. Same four JSON tags, pinned by tests on both sides.
- `Counts.PricedRequests` — coverage as a *counter*, not a flag. Buckets are summed when a client asks for a coarser resolution, and a snapshot bool cannot express "12 of 40 requests here were priced". `requests - pricedRequests` is the gap, correct at every resolution.
- `foldInto` decodes the cost event, so `CostMicros` is populated for real.
- `Snapshot.Priced` now means "something was actually priced" rather than "a `Pricer` was installed" — which no caller ever did, so it was always false. `Pricer` and `WithPricer` are deleted.
- Retires the `TODO(cost)` blocks in `usage/usage.go` and `sessionapi/usage.go`. The latter's claim that the cost "stays inside the plugin" was already stale.

Unpriced traffic still contributes tokens but no dollars, and never renders as `$0.00` — a zero cost and an unknown cost are different answers. Modelled rates for traffic with no cost event arrive with the pricing resolver in a later phase.

## Testing

- `go test -race ./...` green in `authlib`; `abctl`, `authbridge-proxy` and `storage/redis` tests pass and all 8 workspace modules build.
- The three pre-existing `TestEmitCost_*` tests are the regression oracle for the struct move and pass unchanged — the only edits to them are identifier renames.
- Added a **composed-path test**: every other test builds the session event by hand, so nothing exercised plugin → `SnapshotPlugins` → `Store.Append` → `Record` across four order-sensitive packages. A listener that appended before snapshotting, or a key mismatch, would leave `/v1/usage` silently costless with every unit test still green. Covered in both directions, priced and unpriced.
- Verified that test is load-bearing by mutating `costevent.PluginName`: it fails the composed test and the name pin, while the `usage` unit tests stay green — they build the event with the same constant they read, so only the composed test can catch a key mismatch.

## Notes for reviewers

Two things found along the way, both pre-existing and **not** addressed here:

- `make lint` fails on `main` on pre-existing `ruff`/E501 errors in `demos/` and `sparc-service/`, and `ruff-format` rewrites ~10 unrelated Python files in the working tree as a side effect. I reverted that collateral and gated on scoped `pre-commit`, `go vet` (what CI runs for Go), and `golangci-lint --new-from-rev`. Probably worth its own issue.
- `toolprune`'s built-in rate table is keyed by family (`*claude-opus-*`), which misprices `claude-opus-4-1` ($15/MTok) against `claude-opus-5` ($5/MTok) by 3x today. Phase 3 territory; recorded in the design doc.

The design doc and phase-0 plan are included as the first two commits, so the reasoning travels with the code.

## Related issue(s)

Part of #910

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Usage reports now include actual per-request costs when available.
  - Usage summaries show pricing coverage, including how many requests were priced.
  - Unpriced requests are clearly distinguished from requests costing $0.00.
  - Partial pricing is displayed with a priced-request count.

- **Bug Fixes**
  - Cost totals and pricing status now remain accurate when usage is grouped across time buckets or folded into “other.”

- **Documentation**
  - Added documentation describing cost reporting, pricing coverage, and unavailable-cost behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->