### PR TITLE
chore: :goal_net: Surface deny invocations

### DIFF
--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -185,9 +185,23 @@ func (p *BudgetTrack) OnRequest(_ context.Context, pctx *pipeline.Context) pipel
 	p.mu.Lock()
 	p.resetIfNewDay()
 	spend := p.ledger.TotalSpend
+	calls := p.ledger.TotalCalls
 	p.mu.Unlock()
 
 	if spend >= p.cfg.MaxBudget {
+		// Record before returning — phase:"denied" events only surface when a
+		// plugin recorded first, so skipping this hides the "why was I cut off?"
+		// answer from the session API.
+		pctx.Record(pipeline.Invocation{
+			Action: pipeline.ActionDeny,
+			Reason: "budget.exceeded",
+			Details: map[string]string{
+				// -1 precision: shortest exact representation.
+				"daily_spent_usd": strconv.FormatFloat(spend, 'f', -1, 64),
+				"daily_max_usd":   strconv.FormatFloat(p.cfg.MaxBudget, 'f', -1, 64),
+				"total_calls":     strconv.Itoa(calls),
+			},
+		})
 		return pipeline.DenyStatus(429, "budget.exceeded",
 			fmt.Sprintf("Cortex ExceededTokenBudget: daily spend $%.4f exceeds budget $%.2f. Reset at midnight UTC.", spend, p.cfg.MaxBudget))
 	}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -196,9 +196,10 @@ func (p *BudgetTrack) OnRequest(_ context.Context, pctx *pipeline.Context) pipel
 			Action: pipeline.ActionDeny,
 			Reason: "budget.exceeded",
 			Details: map[string]string{
-				// -1 precision: shortest exact representation.
-				"daily_spent_usd": strconv.FormatFloat(spend, 'f', -1, 64),
-				"daily_max_usd":   strconv.FormatFloat(p.cfg.MaxBudget, 'f', -1, 64),
+				// Key + precision mirror the 429 wire message and
+				// costEvent.DailyTotalUSD — one ledger, one name.
+				"daily_total_usd": strconv.FormatFloat(spend, 'f', 4, 64),
+				"daily_max_usd":   strconv.FormatFloat(p.cfg.MaxBudget, 'f', 2, 64),
 				"total_calls":     strconv.Itoa(calls),
 			},
 		})

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -643,7 +643,12 @@ func TestOnRequestRecordsDenyInvocation(t *testing.T) {
 		ResponseHeaders: http.Header{responseCostHeader: {"0.002"}},
 	})
 
+	// Stamp Plugin+Phase like Pipeline.Run does — without it Record leaves
+	// Phase:"" and the listener's FilteredByPhase drops the invocation.
 	pctx := &pipeline.Context{}
+	pctx.SetCurrentPlugin("litellm-budget-track", pipeline.InvocationPhaseRequest)
+	defer pctx.ClearCurrentPlugin()
+
 	action := p.OnRequest(context.Background(), pctx)
 	if action.Type != pipeline.Reject {
 		t.Fatalf("OnRequest() over budget = %v, want Reject", action.Type)
@@ -657,6 +662,12 @@ func TestOnRequestRecordsDenyInvocation(t *testing.T) {
 		t.Fatalf("Inbound invocations = %d, want 1", len(inv))
 	}
 	got := inv[0]
+	if got.Plugin != "litellm-budget-track" {
+		t.Errorf("Plugin = %q, want litellm-budget-track", got.Plugin)
+	}
+	if got.Phase != pipeline.InvocationPhaseRequest {
+		t.Errorf("Phase = %q, want request (else listener FilteredByPhase drops it)", got.Phase)
+	}
 	if got.Action != pipeline.ActionDeny {
 		t.Errorf("Action = %q, want deny", got.Action)
 	}
@@ -664,12 +675,13 @@ func TestOnRequestRecordsDenyInvocation(t *testing.T) {
 		t.Errorf("Reason = %q, want budget.exceeded", got.Reason)
 	}
 	// Snapshot must match the ledger the plugin actually checked — not a
-	// stale zero from before the OnResponse above.
-	if got.Details["daily_spent_usd"] != "0.002" {
-		t.Errorf("Details[daily_spent_usd] = %q, want 0.002", got.Details["daily_spent_usd"])
+	// stale zero from before the OnResponse above. Values match the 429
+	// wire message's precision.
+	if got.Details["daily_total_usd"] != "0.0020" {
+		t.Errorf("Details[daily_total_usd] = %q, want 0.0020", got.Details["daily_total_usd"])
 	}
-	if got.Details["daily_max_usd"] != "0.001" {
-		t.Errorf("Details[daily_max_usd] = %q, want 0.001", got.Details["daily_max_usd"])
+	if got.Details["daily_max_usd"] != "0.00" {
+		t.Errorf("Details[daily_max_usd] = %q, want 0.00", got.Details["daily_max_usd"])
 	}
 	if got.Details["total_calls"] != "1" {
 		t.Errorf("Details[total_calls] = %q, want 1", got.Details["total_calls"])
@@ -681,6 +693,8 @@ func TestOnRequestRecordsDenyInvocation(t *testing.T) {
 func TestOnRequestUnderBudgetRecordsNothing(t *testing.T) {
 	p := configure(t, 5.00)
 	pctx := &pipeline.Context{}
+	pctx.SetCurrentPlugin("litellm-budget-track", pipeline.InvocationPhaseRequest)
+	defer pctx.ClearCurrentPlugin()
 	if action := p.OnRequest(context.Background(), pctx); action.Type != pipeline.Continue {
 		t.Fatalf("OnRequest() under budget = %v, want Continue", action.Type)
 	}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -632,3 +632,60 @@ func TestEmitCost_NoEmitWhenUnpriced(t *testing.T) {
 		})
 	}
 }
+
+// TestOnRequestRecordsDenyInvocation: the 429 path must record a deny
+// Invocation with the spend snapshot, or phase:"denied" never surfaces.
+func TestOnRequestRecordsDenyInvocation(t *testing.T) {
+	p := configure(t, 0.001)
+
+	// Push past the budget so the next OnRequest denies.
+	p.OnResponse(context.Background(), &pipeline.Context{
+		ResponseHeaders: http.Header{responseCostHeader: {"0.002"}},
+	})
+
+	pctx := &pipeline.Context{}
+	action := p.OnRequest(context.Background(), pctx)
+	if action.Type != pipeline.Reject {
+		t.Fatalf("OnRequest() over budget = %v, want Reject", action.Type)
+	}
+
+	if pctx.Extensions.Invocations == nil {
+		t.Fatal("no Invocations recorded on deny path")
+	}
+	inv := pctx.Extensions.Invocations.Inbound
+	if len(inv) != 1 {
+		t.Fatalf("Inbound invocations = %d, want 1", len(inv))
+	}
+	got := inv[0]
+	if got.Action != pipeline.ActionDeny {
+		t.Errorf("Action = %q, want deny", got.Action)
+	}
+	if got.Reason != "budget.exceeded" {
+		t.Errorf("Reason = %q, want budget.exceeded", got.Reason)
+	}
+	// Snapshot must match the ledger the plugin actually checked — not a
+	// stale zero from before the OnResponse above.
+	if got.Details["daily_spent_usd"] != "0.002" {
+		t.Errorf("Details[daily_spent_usd] = %q, want 0.002", got.Details["daily_spent_usd"])
+	}
+	if got.Details["daily_max_usd"] != "0.001" {
+		t.Errorf("Details[daily_max_usd] = %q, want 0.001", got.Details["daily_max_usd"])
+	}
+	if got.Details["total_calls"] != "1" {
+		t.Errorf("Details[total_calls] = %q, want 1", got.Details["total_calls"])
+	}
+}
+
+// TestOnRequestUnderBudgetRecordsNothing: allow-path stays clean; an
+// always-record plugin would clutter every timeline.
+func TestOnRequestUnderBudgetRecordsNothing(t *testing.T) {
+	p := configure(t, 5.00)
+	pctx := &pipeline.Context{}
+	if action := p.OnRequest(context.Background(), pctx); action.Type != pipeline.Continue {
+		t.Fatalf("OnRequest() under budget = %v, want Continue", action.Type)
+	}
+	if pctx.Extensions.Invocations != nil && len(pctx.Extensions.Invocations.Inbound) > 0 {
+		t.Errorf("under-budget OnRequest recorded %d invocations, want 0",
+			len(pctx.Extensions.Invocations.Inbound))
+	}
+}

--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -171,6 +171,18 @@ See [`plugin-reference.md#emitting-session-events`](./plugin-reference.md#emitti
 for how the listener promotes `pctx.Extensions.Custom` entries to
 `SessionEvent.Plugins`.
 
+### Deny events
+
+`OnRequest` rejects with HTTP 429 once the daily budget is exhausted,
+and surfaces the denial as a `phase: "denied"` session event carrying
+an `Invocation` with these `details`:
+
+| Key | Meaning |
+|-----|---------|
+| `daily_total_usd` | Ledger total at denial; same quantity as the cost event's `daily_total_usd`, formatted like the 429 wire body. |
+| `daily_max_usd` | Configured daily cap (`max_budget`). |
+| `total_calls` | Ledger call count at denial. |
+
 ## Build
 
 The plugin is included by default in `authbridge-proxy` builds. To exclude:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

The 429 budget-exceeded path denied the request but didn't record, so the cutoff never surfaced on the session timeline. The plugin now records a deny row on the session event before returning, no change to wire response

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

## Related issue(s)

Fixes #908 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budget-exceeded requests now record a denial event with spending totals, budget limits, and call counts before returning a 429 response.
  * Requests within the daily budget continue without recording a denial event.

* **Documentation**
  * Added guidance on denial events and the information included when a request is rejected.

* **Tests**
  * Added coverage for budget-exceeded and under-budget request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->