### PR TITLE
Feat: Install unreleased main builds with --ref=main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,20 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v -x --ignore=tests/e2e
 
+  # install.sh is a curl|sh entry point, so a regression there is a
+  # stranger's first experience of Cortex. shellcheck in
+  # security-scans.yaml catches syntax, not behaviour — the tag parser
+  # returning the OLDEST release shipped past it.
+  install-script:
+    name: install.sh tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Run install.sh tests
+        run: sh authbridge/install_test.sh
+
   # `go mod tidy -diff` on every authbridge module. GOWORK=off so
   # replace directives resolve as they do in build.yaml and
   # release-binaries.yaml.

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -59,7 +59,20 @@ jobs:
       || github.event_name == 'workflow_dispatch'
       || vars.MAIN_CHANNEL_ENABLED == 'true'
     permissions:
-      contents: write  # create the Release and upload assets (tag + main pushes)
+      # create/update the Release, upload assets, and move the rolling tag.
+      #
+      # This is reachable on every `main` push now, not only on tag pushes, so the blast
+      # radius of a compromised step in this job is larger than it was. Nothing here is
+      # known-wrong — the job builds only first-party code and every action is SHA-pinned
+      # — but the scope change deserves a look at the moment it starts mattering, which
+      # is when MAIN_CHANNEL_ENABLED flips rather than when this merges. It is listed as
+      # a pre-enable check in CONTRIBUTING for that reason.
+      #
+      # If that look wants a smaller surface, the shape is splitting build (contents:
+      # read) from publish (contents: write) and passing dist/ between them as an
+      # artifact. Not done here: it is a restructuring, not a fix, and the gate keeps
+      # this inert until someone decides.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -30,19 +30,30 @@ permissions:
 # checksums.txt from whichever finished last — which users meet as "checksum
 # verification failed", an alarming message for what is really a publish race.
 # Superseding is right for a rolling channel: only the newest tip matters.
+# event_name is in the group, not just the ref: github.ref is refs/heads/main for BOTH a
+# push to main and a workflow_dispatch (which defaults to the default branch), so a ref-
+# only group let someone clicking "Run workflow" cancel a merge build mid-upload.
 concurrency:
-  group: release-binaries-${{ github.ref }}
+  group: release-binaries-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   release-binaries:
     runs-on: ubuntu-latest
     # The developer channel is off until a release containing the newest_release()
-    # v-tag filter exists. Publishing a `main` release before that would make the
-    # DEFAULT curl|sh die, because the released copy of install.sh is what every
-    # one-liner bootstraps into. Set MAIN_CHANNEL_ENABLED=true in repo variables
-    # after cutting that release. workflow_dispatch stays ungated: it publishes
-    # nothing, it only uploads artifacts.
+    # v-tag filter exists. Set MAIN_CHANNEL_ENABLED=true in repo variables after
+    # cutting that release.
+    #
+    # Precisely what that protects, because an earlier version of this comment
+    # overstated it: the DEFAULT one-liner is safe as soon as main carries the filter,
+    # since it resolves a v-tag and re-execs the released copy, and that copy then hits
+    # `case "${SCRIPT_REF}" in v*)` and never calls newest_release at all. What needs a
+    # filtered release is anyone invoking a RELEASED copy as the parent — including the
+    # pinned one-liner this script prints in its own abctl-too-old message. An
+    # unfiltered parent resolves the rolling release as its version and installs
+    # unreleased binaries.
+    #
+    # workflow_dispatch stays ungated: it publishes nothing, it only uploads artifacts.
     if: >-
       github.ref_type == 'tag'
       || github.event_name == 'workflow_dispatch'
@@ -201,6 +212,12 @@ jobs:
               gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
                 -f sha="${GITHUB_SHA}" -F force=true >/dev/null
             fi
+            # --clobber replaces same-named assets but never deletes others, so if a
+            # proxy_variants entry is ever retired its *_main-latest_* archive lingers
+            # while checksums.txt stops listing it: downloadable but unverifiable. The
+            # installer is unaffected (it fetches two exact names and needs two checksum
+            # lines), so this is a note rather than a prune — delete stale assets by hand
+            # when retiring a variant.
             gh release upload "${TAG}" dist/*.tar.gz dist/checksums.txt --clobber
           else
             prerelease=""
@@ -209,7 +226,13 @@ jobs:
             case "${TAG}" in
               main-latest | *-rc* | *-alpha* | *-beta*) prerelease="--prerelease" ;;
             esac
+            # --target "${GITHUB_SHA}": without it the API defaults target_commitish to
+            # the repository's default branch at call time, not the commit that was
+            # built. Usually the same on a main push, but it is exactly the drift the
+            # PATCH above exists to prevent — and it made the FIRST publish create the
+            # tag at the wrong commit, so the two paths disagreed.
             gh release create "${TAG}" dist/*.tar.gz dist/checksums.txt \
+              --target "${GITHUB_SHA}" \
               --title "${TAG}" --notes "${notes}" ${prerelease}
           fi
 

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -23,6 +23,17 @@ on:
 permissions:
   contents: read
 
+# Scoped by ref, because main-latest is the first FIXED, reused release target this
+# repo has had: every v* tag is unique, so two runs never contended for the same
+# assets before. Two merges inside one build window would otherwise have both runs
+# uploading 17 files with --clobber, interleaving into a mixed asset set plus a
+# checksums.txt from whichever finished last — which users meet as "checksum
+# verification failed", an alarming message for what is really a publish race.
+# Superseding is right for a rolling channel: only the newest tip matters.
+concurrency:
+  group: release-binaries-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-binaries:
     runs-on: ubuntu-latest
@@ -40,10 +51,10 @@ jobs:
       contents: write  # create the Release and upload assets (tag + main pushes)
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: authbridge/cmd/authbridge-proxy/go.mod
 
@@ -136,10 +147,15 @@ jobs:
           ls -l dist
 
       - name: Publish to GitHub Release
-        # A main push publishes too, which is the whole point of the channel. The
-        # job-level gate already requires MAIN_CHANNEL_ENABLED for that path;
-        # repeating ref_type here keeps workflow_dispatch from ever publishing.
-        if: github.ref_type == 'tag' || github.event_name == 'push'
+        # A main push publishes too, which is the whole point of the channel; the
+        # job-level gate already requires MAIN_CHANNEL_ENABLED for that path.
+        #
+        # `event_name == 'push'` ALONE, deliberately. A tag push already satisfies it,
+        # so adding `ref_type == 'tag'` bought nothing except one bad case: dispatching
+        # this workflow against a tag ref gives ref_type=='tag' with
+        # event_name=='workflow_dispatch', which published and --clobbered that
+        # release's assets. The dry run is supposed to publish nothing.
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -175,6 +191,16 @@ jobs:
             add 'supported install, use the newest `v*` release instead.'
           fi
           if gh release view "${TAG}" >/dev/null 2>&1; then
+            # Uploading assets does not move the tag, so on a REUSED tag the release
+            # would keep pointing at its first-publish commit forever: the "Source
+            # code" archives and the commit shown on the release page would drift
+            # further from the binaries beside them on every merge. Renaming the tag to
+            # main-latest fixed ref ambiguity with the branch; it did nothing about
+            # freezing. Only for the rolling tag — a v* release must never be moved.
+            if [ "${TAG}" = "main-latest" ]; then
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" \
+                -f sha="${GITHUB_SHA}" -F force=true >/dev/null
+            fi
             gh release upload "${TAG}" dist/*.tar.gz dist/checksums.txt --clobber
           else
             prerelease=""

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -11,6 +11,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       tag:
@@ -24,8 +26,18 @@ permissions:
 jobs:
   release-binaries:
     runs-on: ubuntu-latest
+    # The developer channel is off until a release containing the newest_release()
+    # v-tag filter exists. Publishing a `main` release before that would make the
+    # DEFAULT curl|sh die, because the released copy of install.sh is what every
+    # one-liner bootstraps into. Set MAIN_CHANNEL_ENABLED=true in repo variables
+    # after cutting that release. workflow_dispatch stays ungated: it publishes
+    # nothing, it only uploads artifacts.
+    if: >-
+      github.ref_type == 'tag'
+      || github.event_name == 'workflow_dispatch'
+      || vars.MAIN_CHANNEL_ENABLED == 'true'
     permissions:
-      contents: write  # create the Release and upload assets (tag pushes only)
+      contents: write  # create the Release and upload assets (tag + main pushes)
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
@@ -42,11 +54,36 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME}"
             VERSION="${GITHUB_REF_NAME}"
+          elif [ "${GITHUB_REF_NAME}" = "main" ] && [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            # TAG names the rolling release and the assets, so the download URL is
+            # predictable. VERSION identifies the build, and the two must differ:
+            # abctl's serviceIsCurrent compares the stamp recorded in the installed
+            # launchd unit against the running binary to decide whether `service
+            # install` is a no-op. A constant stamp would report "Already current"
+            # while the old binary kept running — hiding upgrades on the one channel
+            # that changes every merge.
+            #
+            # "main-latest", not "main": a GitHub release needs a git tag, and a tag
+            # named `main` collides with the branch. Verified — `git rev-parse main`
+            # then resolves to the tag, every git command warns that the refname is
+            # ambiguous, and the tag freezes at the first publish while the branch
+            # moves on. Must match CHANNEL_TAG in authbridge/install.sh.
+            TAG="main-latest"
+            VERSION="main-$(printf '%s' "${GITHUB_SHA}" | cut -c1-7)"
           else
+            TAG="${INPUT_TAG:-dev}"
             VERSION="${INPUT_TAG:-dev}"
           fi
-          echo "Building version ${VERSION}"
+          echo "Building ${VERSION} for release ${TAG}"
+          # Hand both to later steps rather than re-deriving them there. The publish
+          # step used GITHUB_REF_NAME, which is "main" on a main push — it would have
+          # published to the wrong tag the moment the two stopped being equal.
+          {
+            echo "TAG=${TAG}"
+            echo "VERSION=${VERSION}"
+          } >> "${GITHUB_ENV}"
           mkdir -p dist
 
           # authbridge-proxy variants: "<suffix>:<build-tags>". Empty
@@ -64,7 +101,10 @@ jobs:
           build_proxy() {
             local variant="$1" tags="$2" os="$3" arch="$4"
             local suffix=""; [ -n "${variant}" ] && suffix="-${variant}"
-            local archive="dist/authbridge-proxy${suffix}_${VERSION}_${os}_${arch}.tar.gz"
+            # ${TAG}, not ${VERSION}: the filename has to match the download URL the
+            # installer builds from the release tag. They are the same string for a
+            # v* tag and differ only on the rolling channel release.
+            local archive="dist/authbridge-proxy${suffix}_${TAG}_${os}_${arch}.tar.gz"
             echo "==> authbridge-proxy${suffix} ${os}/${arch}"
             ( cd authbridge/cmd/authbridge-proxy && \
               GOWORK=off CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" \
@@ -85,7 +125,7 @@ jobs:
               go build -trimpath \
                 -ldflags "-s -w -X main.version=${VERSION}" \
                 -o "${GITHUB_WORKSPACE}/dist/abctl" . )
-            tar -C dist -czf "dist/abctl_${VERSION}_${os}_${arch}.tar.gz" abctl
+            tar -C dist -czf "dist/abctl_${TAG}_${os}_${arch}.tar.gz" abctl
             rm -f dist/abctl
 
             for entry in "${proxy_variants[@]}"; do
@@ -96,12 +136,16 @@ jobs:
           ls -l dist
 
       - name: Publish to GitHub Release
-        if: github.ref_type == 'tag'
+        # A main push publishes too, which is the whole point of the channel. The
+        # job-level gate already requires MAIN_CHANNEL_ENABLED for that path;
+        # repeating ref_type here keeps workflow_dispatch from ever publishing.
+        if: github.ref_type == 'tag' || github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
+          # TAG comes from the build step via GITHUB_ENV — one derivation, not two.
+          [ -n "${TAG:-}" ] || { echo "TAG not set by the build step" >&2; exit 1; }
           # Build release notes one line at a time so no single string
           # exceeds yamllint's 150-char cap. Single-quoted arguments keep
           # backticks literal (no shell expansion).
@@ -117,17 +161,37 @@ jobs:
           add ''
           add 'Verify downloads with `sha256sum -c checksums.txt`. On macOS, clear the'
           add 'Gatekeeper quarantine after extracting: `xattr -dr com.apple.quarantine ./abctl`.'
+          # The rolling release is not a release, and its notes should not read like
+          # one — someone landing on it from a search result needs to know that
+          # before they install it.
+          if [ "${TAG}" = "main-latest" ]; then
+            notes=""
+            add 'Unreleased build from the tip of `main`, rebuilt on every merge. Not a release.'
+            add ''
+            add 'Install with:'
+            add '    curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh | sh -s -- --ref=main'
+            add ''
+            add 'Each binary reports its own build (`abctl --version` -> `main-<sha>`). For a'
+            add 'supported install, use the newest `v*` release instead.'
+          fi
           if gh release view "${TAG}" >/dev/null 2>&1; then
             gh release upload "${TAG}" dist/*.tar.gz dist/checksums.txt --clobber
           else
             prerelease=""
-            case "${TAG}" in *-rc*|*-alpha*|*-beta*) prerelease="--prerelease" ;; esac
+            # `main` belongs here or the rolling release takes GitHub's "Latest"
+            # badge, displacing the newest real release.
+            case "${TAG}" in
+              main-latest | *-rc* | *-alpha* | *-beta*) prerelease="--prerelease" ;;
+            esac
             gh release create "${TAG}" dist/*.tar.gz dist/checksums.txt \
               --title "${TAG}" --notes "${notes}" ${prerelease}
           fi
 
       - name: Upload dry-run artifacts
-        if: github.ref_type != 'tag'
+        # workflow_dispatch only. `!= 'tag'` also matched a main push, which now
+        # publishes a real release — it would have uploaded a redundant artifact
+        # copy of every asset on every merge.
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
         with:
           name: release-binaries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,10 @@ Three things to know:
 The rolling release is tagged `main-latest`, not `main`. A GitHub release needs a git
 tag, and a tag named `main` would collide with the branch — `git rev-parse main` would
 then resolve to the tag rather than the branch, and every git command in the repo would
-warn that the name is ambiguous. Only the tag differs; `--ref=main` is what you type.
+warn that the name is ambiguous. `--ref=main` is the spelling to use, but `--ref=main-latest`
+does the same thing, since that is the title the Releases page shows. CI moves the tag to
+the published commit on every merge, so the release's "Source code" archives match the
+binaries beside them.
 
 ### Enabling the channel (one-time, maintainers)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,29 @@ does the same thing, since that is the title the Releases page shows. CI moves t
 the published commit on every merge, so the release's "Source code" archives match the
 binaries beside them.
 
+If you have `AUTHBRIDGE_VERSION`, `AUTHBRIDGE_REF`, or `AUTHBRIDGE_INSTALL_ONLY` exported
+in a shell profile, unset them. They are no longer read, and the installer now refuses to
+run rather than quietly ignoring them — so a stale export fails the **default** one-liner
+even though you passed no flags. The error names the flag that replaced it and echoes your
+value back, so the fix is copy-pasteable.
+
 ### Enabling the channel (one-time, maintainers)
 
 Merge, **cut a release**, then set the repo variable `MAIN_CHANNEL_ENABLED=true`
 (Settings → Secrets and variables → Actions → Variables). The next push to `main`
 publishes the rolling release.
+
+Two things to check deliberately before flipping it, because both become live at that
+moment and are inert until then:
+
+- **`release-binaries.yaml` holds `contents: write` on every `main` push**, not just on
+  tag pushes. It builds only first-party code with SHA-pinned actions, but that is a
+  wider blast radius than before. If you want it narrower, split build (`contents: read`)
+  from publish (`contents: write`) and pass `dist/` between them as an artifact.
+- **The job moves the `main-latest` tag** on each publish. That is the one destructive
+  operation in the workflow. It is guarded to the rolling tag, and `install_test.sh`
+  asserts no `${TAG}` comparison in the workflow names anything other than
+  `CHANNEL_TAG`, so a `v*` release cannot become movable by a rename going unnoticed.
 
 The middle step is load-bearing, though not for the reason it first appears. The default
 one-liner is safe as soon as `main` carries the `newest_release()` v-tag filter: it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,13 @@ curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/ins
   | sh -s -- --claude-code --ref=main
 ```
 
-`--ref=X` means "install X" — both the installer script and the binaries. Every push
-to `main` rebuilds a rolling pre-release, so this tracks the tip.
+`--ref=X` means "install X" — both the installer script and the binaries — for any X
+that has published binaries: `main` and any `vX.Y.Z` release. Every push to `main`
+rebuilds a rolling pre-release, so `--ref=main` tracks the tip.
+
+`--ref=` also accepts a branch or a commit, but no binaries are published for those, so
+you get that ref's *script* with the newest *release's* binaries. The installer warns
+when that happens rather than leaving you to infer it.
 
 Each binary reports its own build: `abctl --version` → `main-a1b2c3d`. Quote that,
 not "main", in a bug report — the channel moves under you.
@@ -74,12 +79,19 @@ binaries beside them.
 
 ### Enabling the channel (one-time, maintainers)
 
-The rolling release must not exist before a cut release contains the
-`newest_release()` v-tag filter — the released copy of `install.sh` is what every
-`curl | sh` bootstraps into, and an unfiltered copy dies when it sees a non-version
-tag at the top of the release list. So: merge, cut a release, then set the repo
-variable `MAIN_CHANNEL_ENABLED=true` (Settings → Secrets and variables → Actions →
-Variables). The next push to `main` publishes it.
+Merge, **cut a release**, then set the repo variable `MAIN_CHANNEL_ENABLED=true`
+(Settings → Secrets and variables → Actions → Variables). The next push to `main`
+publishes the rolling release.
+
+The middle step is load-bearing, though not for the reason it first appears. The default
+one-liner is safe as soon as `main` carries the `newest_release()` v-tag filter: it
+resolves a `v` tag, re-execs that released copy, and the copy then matches
+`case "${SCRIPT_REF}" in v*)` and never calls `newest_release` at all. What needs a
+*filtered release* is anyone running a **released** copy as the parent — including the
+pinned one-liner this installer prints in its own "abctl is too old" message. An
+unfiltered parent resolves the rolling release as its version and installs unreleased
+binaries. Cutting a release first stops that window growing; it cannot fix copies already
+published.
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,47 @@ pre-commit install
 cd authbridge/proxy-init && make docker-build-init
 ```
 
+## Installing an unreleased build
+
+A fix merged to `main` is installable immediately, without waiting for a release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
+  | sh -s -- --claude-code --ref=main
+```
+
+`--ref=X` means "install X" — both the installer script and the binaries. Every push
+to `main` rebuilds a rolling pre-release, so this tracks the tip.
+
+Each binary reports its own build: `abctl --version` → `main-a1b2c3d`. Quote that,
+not "main", in a bug report — the channel moves under you.
+
+Three things to know:
+
+- **Every `--ref=main` run replaces and restarts the service.** The installed build
+  never matches the requested `main`, so the installer always re-downloads and
+  `service install` always reinstalls. That cuts any running Claude Code session,
+  because `HTTPS_PROXY` is fixed in each session's environment at startup.
+- **`checksums.txt` rolls with the assets.** The installer fetches assets and
+  checksums in the same run, so verification is sound. Downloading them hours apart
+  will mismatch.
+- **The plain one-liner takes you back.** Running it without `--ref` reinstalls the
+  newest release and reinstalls the service, so there is no stuck state to clean up.
+
+The rolling release is tagged `main-latest`, not `main`. A GitHub release needs a git
+tag, and a tag named `main` would collide with the branch — `git rev-parse main` would
+then resolve to the tag rather than the branch, and every git command in the repo would
+warn that the name is ambiguous. Only the tag differs; `--ref=main` is what you type.
+
+### Enabling the channel (one-time, maintainers)
+
+The rolling release must not exist before a cut release contains the
+`newest_release()` v-tag filter — the released copy of `install.sh` is what every
+`curl | sh` bootstraps into, and an unfiltered copy dies when it sees a non-version
+tag at the top of the release list. So: merge, cut a release, then set the repo
+variable `MAIN_CHANNEL_ENABLED=true` (Settings → Secrets and variables → Actions →
+Variables). The next push to `main` publishes it.
+
 ## Issues
 
 Prioritization for pull requests is given to those that address and resolve existing GitHub issues. Utilize the available issue labels to identify meaningful and relevant issues to work on.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Your agent's calls stream into `abctl`. Cortex only reads them; nothing is rewri
 `~/.cortex/ca/ca.crt`.
 
 The install URL is on `main`, but the script re-runs the copy from the newest
-**release**, so `curl | sh` does not execute unreleased code. `--ref` overrides that.
+**release**, so `curl | sh` does not execute unreleased code. `--ref` overrides that for
+both halves — script and binaries: `--ref=vX.Y.Z` pins a release, and `--ref=main`
+installs the unreleased tip
+([CONTRIBUTING.md](./CONTRIBUTING.md#installing-an-unreleased-build)).
 
 ## What else Cortex does
 

--- a/authbridge/docs/superpowers/plans/2026-09-09-main-channel.md
+++ b/authbridge/docs/superpowers/plans/2026-09-09-main-channel.md
@@ -1,0 +1,817 @@
+# Main Channel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a developer install unreleased `main` binaries with `--ref=main`, without changing the default one-liner's command or behaviour.
+
+**Architecture:** One rolling GitHub pre-release tagged `main`, assets overwritten on every push to main by the existing `release-binaries.yaml`. `install.sh` gains a filter so the default path ignores that release, and `--ref=X` becomes consistent — script *and* binaries from X, for any X. Three vestigial env vars are removed in the same change, so the selection surface shrinks.
+
+**Tech Stack:** POSIX `sh` (`authbridge/install.sh`), GitHub Actions, `gh` CLI, `curl`, `shellcheck`.
+
+**Spec:** `authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md`
+
+## Global Constraints
+
+- **POSIX `sh` only** in `install.sh`. `set -eu`, never `pipefail` (a bashism; the documented entry point is `curl … | sh`).
+- **No new dependencies.** The script may use only `curl`, `tar`, `tr`, `grep`, `cut`, `awk`, `sed`, and a checksum tool. Not `jq`. Not `gh`.
+- **`shellcheck --severity=error` must pass**, and `shellcheck -s sh` must pass, on every commit touching `install.sh`. CI runs the former.
+- **Work in the worktree** `.worktrees/main-channel` on branch `feat/main-channel`. Never in the shared top-level checkout (root `CLAUDE.md`, "AI Assistant Instructions").
+- **Commit trailer:** `Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>`. Never `Co-Authored-By`. All commits use `git commit -s` (DCO required).
+- **`AUTHBRIDGE_SCRIPT_REF` must keep working** — it is the bootstrap's recursion guard. Removing it causes infinite re-exec.
+- **`AUTHBRIDGE_SKIP_DOWNLOAD` must keep working** — the install tests and all manual installer testing depend on it.
+- **Do not enable the channel.** `MAIN_CHANNEL_ENABLED` is set in repo settings *after* a release containing the guard is cut. No task flips it.
+
+---
+
+### Task 1: First committed test harness for `install.sh`
+
+`install.sh` has no tests today; `security-scans.yaml` runs `shellcheck --severity=error` and `ci.yaml` does not reference it. Every later task in this plan asserts behaviour, so the harness comes first.
+
+**Files:**
+- Create: `authbridge/install_test.sh`
+- Modify: `.github/workflows/ci.yaml`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `authbridge/install_test.sh`, runnable as `sh authbridge/install_test.sh` from the repo root. Exits 0 on success, 1 on any failure, and prints one line per case. Later tasks add cases to it and rely on these helpers existing:
+  - `fixture <name> <<'EOF' … EOF` — writes a fixture file into the test tempdir, returns its path via `$FIXTURE`
+  - `with_newest_release <fixture-path>` — sources `newest_release` from `install.sh` with `curl` stubbed to print that fixture, echoes the resolved tag, returns the function's exit status
+  - `check <label> <expected> <actual>` — records pass/fail
+  - `check_fails <label> <exit-status>` — records pass when status is non-zero
+
+- [ ] **Step 1: Write the harness with one failing case**
+
+The first case asserts today's behaviour so the harness is proven before it is trusted. Create `authbridge/install_test.sh`:
+
+```sh
+#!/bin/sh
+# Tests for authbridge/install.sh.
+#
+# install.sh is a curl|sh entry point, so its failure modes are other people's
+# first experience of Cortex. Until this file existed the only automated check was
+# `shellcheck --severity=error`, which is why the tag-parser bug (returning the
+# OLDEST release from compact JSON) shipped in #902 without a test.
+#
+# Approach: source a single function out of install.sh with `curl` replaced by one
+# that prints a fixture. No network, no GitHub, no downloads. Plain POSIX sh
+# because the repo has no bats or shunit2 and a framework is not worth it for a
+# handful of functions.
+#
+# Run: sh authbridge/install_test.sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INSTALL_SH="${SCRIPT_DIR}/install.sh"
+[ -f "${INSTALL_SH}" ] || { printf 'cannot find %s\n' "${INSTALL_SH}" >&2; exit 1; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+PASS=0
+FAIL=0
+
+check() { # label expected actual
+	if [ "$2" = "$3" ]; then
+		PASS=$((PASS + 1))
+		printf '  ok   %s\n' "$1"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL %s\n       expected %s\n       actual   %s\n' "$1" "$2" "$3"
+	fi
+}
+
+check_fails() { # label status
+	if [ "$2" != "0" ]; then
+		PASS=$((PASS + 1))
+		printf '  ok   %s (exit %s)\n' "$1" "$2"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL %s: expected non-zero exit, got 0\n' "$1"
+	fi
+}
+
+fixture() { # name; body on stdin. Sets $FIXTURE to the path.
+	FIXTURE="${TMP}/$1"
+	cat >"${FIXTURE}"
+}
+
+# with_newest_release runs install.sh's newest_release() against a fixture.
+#
+# The function is extracted by line range rather than sourcing install.sh, because
+# sourcing would run the whole installer. `curl` is replaced by a function so the
+# extracted code is unmodified — testing what ships, not a copy of it.
+with_newest_release() { # fixture-path
+	_f=$1
+	{
+		printf 'REPO=rossoctl/cortex\n'
+		printf 'warn() { printf "warning: %%s\\n" "$*" >&2; }\n'
+		printf 'curl() { cat "%s"; }\n' "${_f}"
+		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
+		printf 'newest_release\n'
+	} >"${TMP}/probe.sh"
+	sh "${TMP}/probe.sh" 2>/dev/null
+}
+
+printf 'install.sh tests\n'
+
+# --- newest_release: the shape it is documented to handle ---
+
+fixture pretty.json <<'EOF'
+[
+  {
+    "tag_name": "v0.7.0-alpha.7",
+    "name": "v0.7.0-alpha.7"
+  },
+  {
+    "tag_name": "v0.3.1"
+  }
+]
+EOF
+check "pretty JSON resolves the newest tag" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+fixture compact.json <<'EOF'
+[{"tag_name":"v0.7.0-alpha.7"},{"tag_name":"v0.7.0-alpha.6"},{"tag_name":"v0.3.1"}]
+EOF
+check "compact JSON resolves the newest tag, not the oldest" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]
+```
+
+- [ ] **Step 2: Run it and verify both cases pass**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: two `ok` lines, `2 passed, 0 failed`, exit 0. These assert current behaviour, so they must pass against unmodified `install.sh`. If either fails, the harness is wrong — fix the harness, not `install.sh`.
+
+- [ ] **Step 3: Prove the harness can fail**
+
+Temporarily change the `compact.json` expectation from `v0.7.0-alpha.7` to `v0.3.1`, run again, and confirm you get `FAIL` and exit 1. Then change it back and re-run to confirm green. A harness never observed failing is not evidence.
+
+- [ ] **Step 4: Wire it into CI**
+
+In `.github/workflows/ci.yaml`, add a job alongside the existing ones:
+
+```yaml
+  install-script:
+    name: install.sh tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run install.sh tests
+        run: sh authbridge/install_test.sh
+```
+
+Match the checkout action version already pinned elsewhere in that file — read it and copy, do not assume `v4`.
+
+- [ ] **Step 5: Verify shellcheck accepts the new file**
+
+Run: `shellcheck --severity=error authbridge/install_test.sh && shellcheck -s sh authbridge/install_test.sh`
+
+Expected: no output. `security-scans.yaml` shellchecks shell scripts in the repo, so a new one must pass or CI fails on an unrelated job.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add authbridge/install_test.sh .github/workflows/ci.yaml
+git commit -s -m "$(printf 'test: First committed tests for install.sh\n\ninstall.sh is a curl|sh entry point, so its failure modes are other people first\nexperience of Cortex — and until now the only automated check was shellcheck\n--severity=error. That is why #902 fixed the tag parser returning the OLDEST\nrelease from compact JSON with no test.\n\nPlain POSIX sh: the repo has no bats or shunit2, and a framework is not worth it\nfor a handful of functions. newest_release() is extracted by line range and run\nwith curl replaced by a fixture-printing stub, so the code under test is the code\nthat ships rather than a copy.\n\nWired into ci.yaml so it cannot rot.\n\nAssisted-By: Claude (Anthropic AI) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 2: Filter `newest_release()` so the channel cannot hijack the default
+
+This is the guard the whole design rests on. Without it, publishing a release tagged `main` makes the default `curl | sh` warn and then die for every new user.
+
+**Files:**
+- Modify: `authbridge/install.sh` (the `newest_release()` function)
+- Test: `authbridge/install_test.sh`
+
+**Interfaces:**
+- Consumes: `with_newest_release`, `fixture`, `check`, `check_fails` from Task 1.
+- Produces: `newest_release()` returns the newest `tag_name` matching `v[0-9]*` from the first 10 releases, or non-zero if none matches. Task 3 relies on it still printing a bare tag on stdout and returning non-zero on failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `authbridge/install_test.sh`, before the final `printf '\n%s passed…'` summary block:
+
+```sh
+# --- newest_release: the main channel must not hijack the default ---
+#
+# The rolling `main` release sorts first until the next tagged release, because the
+# API sorts by created_at and created_at is fixed at creation. Unfiltered, the
+# v[0-9]* shape check then rejects it and the whole default install dies.
+
+fixture main_first.json <<'EOF'
+[
+  {
+    "tag_name": "main",
+    "prerelease": true
+  },
+  {
+    "tag_name": "v0.7.0-alpha.7"
+  }
+]
+EOF
+check "a main release sorting first is skipped" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+fixture main_first_compact.json <<'EOF'
+[{"tag_name":"main"},{"tag_name":"v0.7.0-alpha.7"},{"tag_name":"v0.3.1"}]
+EOF
+check "main skipped in compact JSON too" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+fixture only_non_v.json <<'EOF'
+[{"tag_name":"main"},{"tag_name":"nightly"}]
+EOF
+set +e
+_out=$(with_newest_release "${FIXTURE}"); _st=$?
+set -e
+check_fails "a page with no v-tag returns non-zero rather than guessing" "${_st}"
+check "and prints nothing on stdout" "" "${_out}"
+
+# --- newest_release: hostile inputs still fail closed ---
+
+fixture ratelimit.json <<'EOF'
+{"message":"API rate limit exceeded","documentation_url":"https://x"}
+EOF
+set +e
+_out=$(with_newest_release "${FIXTURE}"); _st=$?
+set -e
+check_fails "rate-limit body fails" "${_st}"
+
+fixture html.json <<'EOF'
+<html><body>502 Bad Gateway</body></html>
+EOF
+set +e
+_st=0; _out=$(with_newest_release "${FIXTURE}") || _st=$?
+set -e
+check_fails "an HTML error page fails" "${_st}"
+
+fixture empty.json </dev/null
+set +e
+_st=0; _out=$(with_newest_release "${FIXTURE}") || _st=$?
+set -e
+check_fails "an empty body fails" "${_st}"
+```
+
+- [ ] **Step 2: Run and verify the new cases fail**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: the two `main` skip cases FAIL. Unfiltered, `newest_release` sees `main` first, the shape check rejects it, and the function returns non-zero — so the assertion of `v0.7.0-alpha.7` fails. The hostile-input cases should already pass; they are regression cover for behaviour Task 2 must not break.
+
+- [ ] **Step 3: Implement the filter**
+
+In `authbridge/install.sh`, replace the `_tag=$(…)` assignment and the `case` block inside `newest_release()` with:
+
+```sh
+	# ?per_page=10 and a v-tag filter, not ?per_page=1: the rolling `main` release of
+	# the developer channel sorts first until the next tagged release (the API sorts
+	# by created_at, which is fixed at creation). Taking the first entry blindly
+	# would hand `main` to someone who never asked for it — and then the shape check
+	# below would reject it and kill the install outright. Ten is headroom, not a
+	# calculation: there is one rolling release, so two would do.
+	_tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=10" 2>/dev/null \
+		| tr ',{}' '\n' \
+		| grep '^[[:space:]]*"tag_name"[[:space:]]*:' \
+		| cut -d'"' -f4 \
+		| grep -m1 '^v[0-9]')
+	case "${_tag}" in
+		v[0-9]*) ;;
+		*) return 1 ;;
+	esac
+	printf '%s\n' "${_tag}"
+```
+
+Two deliberate changes beyond the page size. `grep -m1` moves from the key match to the *value* filter, so it selects the first `v`-shaped tag rather than the first tag. And the `warn` on an unexpected tag is dropped: with the filter, "no `v` tag in ten releases" is the only way to reach the failure, and warning `main` at someone who never mentioned it is noise. The caller already dies with an actionable message.
+
+- [ ] **Step 4: Run the tests and verify all pass**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: all cases `ok`, `0 failed`, exit 0. Both `main`-skip cases now resolve `v0.7.0-alpha.7`; the hostile inputs still fail closed.
+
+- [ ] **Step 5: Verify against the live API**
+
+Run:
+```bash
+curl -fsSL "https://api.github.com/repos/rossoctl/cortex/releases?per_page=10" \
+  | tr ',{}' '\n' | grep '^[[:space:]]*"tag_name"[[:space:]]*:' \
+  | cut -d'"' -f4 | grep -m1 '^v[0-9]'
+```
+Expected: the newest `v*` tag (`v0.7.0-alpha.7` or later). Fixtures prove the logic; this proves the shape assumption about the real API still holds.
+
+- [ ] **Step 6: shellcheck and commit**
+
+```bash
+shellcheck --severity=error authbridge/install.sh && shellcheck -s sh authbridge/install.sh
+git add authbridge/install.sh authbridge/install_test.sh
+git commit -s -m "$(printf 'fix: Ignore non-release tags when resolving the newest release\n\nnewest_release() took the first entry of ?per_page=1 and required it to look like\nv<digit>. That is about to break: the developer channel publishes a rolling\npre-release tagged `main`, and it sorts first until the next tagged release,\nbecause the API sorts by created_at and created_at is fixed at creation.\n\nUnfiltered, the default curl|sh would then warn "could not resolve the newest\nrelease; continuing with the copy from main", fall through to main script, fail to\nresolve a version, and die — for every new user, on the documented one-liner.\n\nNow fetches 10 and takes the first tag matching v[0-9]*, so the channel is\ninvisible to the default path. Ten is headroom, not a calculation.\n\nThe unexpected-tag warning is gone: with the filter, the only way to fail is "no\nv-tag in ten releases", and warning `main` at someone who never asked for it is\nnoise. The caller already dies with actionable advice.\n\nLands before anything publishes a main release, and must be in a cut release\nbefore the channel is enabled — the released copy is what every curl|sh\nbootstraps into.\n\nAssisted-By: Claude (Anthropic AI) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 3: Make `--ref=X` select binaries as well as the script
+
+**Files:**
+- Modify: `authbridge/install.sh` (the `# --- resolve the release tag ---` block)
+- Test: `authbridge/install_test.sh`
+
+**Interfaces:**
+- Consumes: `newest_release()` from Task 2; `fixture`/`check` from Task 1.
+- Produces: a `resolve_version` shell function extracted for testability, signature `resolve_version <script_ref>`, echoing the version to install. Task 4 does not depend on it; Task 5 documents it.
+
+- [ ] **Step 1: Write the failing test**
+
+The current code inlines version resolution, which cannot be tested without running the installer. Extract it into a function first, then test the function. Append to `authbridge/install_test.sh` before the summary:
+
+```sh
+# --- resolve_version: --ref=X selects binaries too ---
+#
+# --ref was inconsistent: `--ref=v0.7.0-alpha.4` set script AND binaries, while
+# `--ref=main` set only the script, because there was no main release to download
+# from. One rule now covers both.
+
+with_resolve_version() { # script_ref fixture-path
+	_ref=$1; _f=$2
+	{
+		printf 'REPO=rossoctl/cortex\n'
+		printf 'warn() { printf "warning: %%s\\n" "$*" >&2; }\n'
+		printf 'die() { printf "error: %%s\\n" "$*" >&2; exit 1; }\n'
+		printf 'info() { :; }\n'
+		printf 'curl() { cat "%s"; }\n' "${_f}"
+		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
+		sed -n '/^resolve_version()/,/^}/p' "${INSTALL_SH}"
+		printf 'resolve_version "%s"\n' "${_ref}"
+	} >"${TMP}/rv.sh"
+	sh "${TMP}/rv.sh" 2>/dev/null
+}
+
+fixture rv_releases.json <<'EOF'
+[{"tag_name":"main"},{"tag_name":"v0.7.0-alpha.7"}]
+EOF
+check "--ref=main installs main binaries" "main" "$(with_resolve_version main "${FIXTURE}")"
+check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
+check "no ref resolves the newest v-tag" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
+
+# stdout must be the version and nothing else. info() writes to stdout
+# (install.sh:81), so an un-redirected progress line inside resolve_version would be
+# captured into $version and corrupt every download URL — a one-line mistake that
+# breaks every install and no other test would catch.
+_out=$(with_resolve_version "" "${FIXTURE}")
+check "stdout carries no progress text" "1" "$(printf '%s\n' "${_out}" | wc -l | tr -d ' ')"
+```
+
+- [ ] **Step 2: Run and verify it fails**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: the three `resolve_version` cases FAIL — `sed -n '/^resolve_version()/…'` matches nothing, so the probe script calls an undefined function and produces empty output.
+
+- [ ] **Step 3: Extract and extend the resolution**
+
+In `authbridge/install.sh`, replace the whole `# --- resolve the release tag ---` block with a function definition plus its call. Place the function next to `newest_release()` (above first use, since `sh` executes top to bottom):
+
+```sh
+# resolve_version prints the release tag whose binaries should be installed, given
+# the ref this script came from.
+#
+# One rule: --ref=X installs X. That was not true before — `--ref=v0.7.0-alpha.4`
+# set script and binaries, while `--ref=main` set only the script, because there
+# was no `main` release to download from. Now that the developer channel publishes
+# one, the special case disappears rather than growing a second flag.
+resolve_version() { # script_ref
+	case "$1" in
+		v*|main) printf '%s\n' "$1" ;;
+		*)
+			# >&2 deliberately: this function's stdout IS the resolved version, and
+			# info() writes to stdout (install.sh:81). Without the redirect the
+			# progress line lands inside `version` and corrupts every download URL.
+			info "Resolving newest release..." >&2
+			newest_release || return 1
+			;;
+	esac
+}
+```
+
+Then at the original location:
+
+```sh
+# --- resolve the release tag ---
+version=$(resolve_version "${SCRIPT_REF}") \
+	|| die "could not resolve the newest release (pass --ref=vX.Y.Z to pin one)"
+```
+
+- [ ] **Step 4: Run the tests and verify all pass**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: all cases `ok`, exit 0.
+
+- [ ] **Step 5: Verify the real paths still work**
+
+```bash
+shellcheck --severity=error authbridge/install.sh && shellcheck -s sh authbridge/install.sh
+sh -n authbridge/install.sh
+# default path, real network, into a throwaway HOME on shifted ports
+rm -rf /tmp/t1 && mkdir -p /tmp/t1/.local/bin /tmp/t1/.claude
+printf '{}\n' > /tmp/t1/.claude/settings.json
+sed -e 's|"${BIN_DIR}/abctl" service install --yes --proxy "${BIN_DIR}/authbridge-proxy"|true|' \
+    -e 's/^DEMO_\(FORWARD\|SESSION\|STATS\|HEALTH\)_PORT=4760/DEMO_\1_PORT=4779/' \
+    authbridge/install.sh > /tmp/t1/inst.sh
+HOME=/tmp/t1 sh /tmp/t1/inst.sh --ref=main --install-only --yes </dev/null 2>&1 | tail -4
+```
+
+Expected: it resolves and reports `v0.7.0-alpha.7` (no `main` release exists yet, so `--ref=main` will fail the *download*, not the resolution). Confirm the failure is `download failed: abctl_main_darwin_arm64.tar.gz` — that is the correct error before the channel exists, and it proves resolution now yields `main`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add authbridge/install.sh authbridge/install_test.sh
+git commit -s -m "$(printf 'fix: Make --ref=X select binaries as well as the script\n\n--ref was inconsistent: --ref=v0.7.0-alpha.4 set script AND binaries, while\n--ref=main set only the script, because there was no main release to download\nfrom. Whether one flag set one half or both depended on whether the value looked\nlike a tag.\n\nNow that the developer channel publishes a rolling `main` release, one rule covers\nboth: --ref=X installs X. The special case disappears rather than growing a second\nflag — an earlier draft added --main, and two flags differing by punctuation but\nnot by meaning is worse than the inconsistency it papered over.\n\nResolution moves into resolve_version() so it can be tested without running the\ninstaller; it was inline before and effectively untestable.\n\nAssisted-By: Claude (Anthropic AI) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 4: Remove three vestigial env vars
+
+All five `AUTHBRIDGE_*` vars were audited in the spec: none is referenced anywhere outside `install.sh` — no CI, docs, demos, or Makefiles. Three go.
+
+**Files:**
+- Modify: `authbridge/install.sh` (header comment, `usage()`, arg parsing, read sites, three messages)
+- Test: `authbridge/install_test.sh`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks beyond the harness helpers.
+- Produces: no new interfaces. `AUTHBRIDGE_SKIP_DOWNLOAD` and `AUTHBRIDGE_SCRIPT_REF` continue to work.
+
+- [ ] **Step 1: Write the failing test**
+
+The likely regression is not the removal — it is leaving a message that still recommends a removed var. Assert against that. Append before the summary:
+
+```sh
+# --- removed knobs leave no stale advice ---
+#
+# The failure mode is not "the var still works" — it is a message telling someone
+# to set a var the script no longer reads. Three sites advised AUTHBRIDGE_VERSION.
+
+for _v in AUTHBRIDGE_VERSION AUTHBRIDGE_REF AUTHBRIDGE_INSTALL_ONLY; do
+	_hits=$(grep -c "${_v}" "${INSTALL_SH}" || true)
+	check "${_v} is gone from install.sh entirely" "0" "${_hits}"
+done
+
+for _v in AUTHBRIDGE_SKIP_DOWNLOAD AUTHBRIDGE_SCRIPT_REF; do
+	_hits=$(grep -c "${_v}" "${INSTALL_SH}" || true)
+	check_fails "${_v} is still present" "${_hits}"
+done
+```
+
+`check_fails` is reused here for "non-zero count" — the same predicate, and clearer than adding a near-identical helper.
+
+- [ ] **Step 2: Run and verify it fails**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: the three "is gone" cases FAIL with non-zero counts (`AUTHBRIDGE_VERSION` around 5, `AUTHBRIDGE_REF` 3, `AUTHBRIDGE_INSTALL_ONLY` 3). The two "still present" cases pass.
+
+- [ ] **Step 3: Remove them**
+
+Four edits in `authbridge/install.sh`:
+
+1. **Header comment** — delete these four lines from the `# Environment:` block, keeping the `AUTHBRIDGE_SKIP_DOWNLOAD` pair, and retitle the block to mark it internal:
+
+```
+#   AUTHBRIDGE_REF=REF          same as --ref
+#   AUTHBRIDGE_VERSION=vX.Y.Z   install binaries from a specific release
+#                               (default: the release this script came from)
+#   AUTHBRIDGE_INSTALL_ONLY=1   same as --install-only
+```
+
+Replace the block header `# Environment:` with:
+
+```
+# Environment (maintainer testing only — not part of the documented interface):
+```
+
+2. **`usage()`** — delete the whole `Environment:` section, all six lines:
+
+```
+Environment:
+  AUTHBRIDGE_VERSION=vX.Y.Z   install a specific release tag (default: newest)
+  AUTHBRIDGE_INSTALL_ONLY=1   same as --install-only
+  AUTHBRIDGE_SKIP_DOWNLOAD=1  use the binaries already in ~/.local/bin instead of
+                              downloading (re-run setup offline)
+```
+
+`AUTHBRIDGE_SKIP_DOWNLOAD` keeps working but stops being advertised: it is a testing hook, not a way to install.
+
+3. **Arg parsing** — `--ref=*` currently assigns to the env var. Make it a plain local:
+
+```sh
+		--ref=*) WANT_REF="${arg#*=}" ;;
+```
+
+Initialise `WANT_REF=""` beside the other defaults (`MODE=local`, `WIRE_CLAUDE_CODE=""`, `ASSUME_YES=""`), and change the bootstrap's read from `want_ref="${AUTHBRIDGE_REF:-}"` to `want_ref="${WANT_REF:-}"`.
+
+Delete the `AUTHBRIDGE_INSTALL_ONLY` fallback block entirely:
+
+```sh
+# Env form kept working; the flag wins if both are given.
+if [ "${AUTHBRIDGE_INSTALL_ONLY:-}" = "1" ] && [ "$MODE" = "local" ]; then
+	MODE=install-only
+fi
+```
+
+4. **Three messages** — rewrite each to name `--ref` instead:
+
+- The `resolve_version` caller from Task 3 already says `pass --ref=vX.Y.Z to pin one`. Confirm no `AUTHBRIDGE_VERSION` remains there.
+- In the abctl-lacks-`service` guard, `AUTHBRIDGE_VERSION=<newer tag>` becomes `--ref=<newer tag>`.
+- In that guard's non-tag branch, `or point AUTHBRIDGE_VERSION at a release that has it.` becomes `or pass --ref=<a release that has it>.`
+
+- [ ] **Step 4: Run the tests and verify all pass**
+
+Run: `sh authbridge/install_test.sh`
+
+Expected: all `ok`, exit 0.
+
+- [ ] **Step 5: Verify the surviving paths and the help text**
+
+```bash
+shellcheck --severity=error authbridge/install.sh && shellcheck -s sh authbridge/install.sh
+sh authbridge/install.sh --help | sed -n '1,40p'   # no Environment section
+# SKIP_DOWNLOAD must still work — every manual installer test uses it
+rm -rf /tmp/t2 && mkdir -p /tmp/t2/.local/bin /tmp/t2/.claude
+printf '{}\n' > /tmp/t2/.claude/settings.json
+cp ~/.local/bin/abctl ~/.local/bin/authbridge-proxy /tmp/t2/.local/bin/ 2>/dev/null || true
+sed -e 's|"${BIN_DIR}/abctl" service install --yes --proxy "${BIN_DIR}/authbridge-proxy"|true|' \
+    -e 's/^DEMO_\(FORWARD\|SESSION\|STATS\|HEALTH\)_PORT=4760/DEMO_\1_PORT=4778/' \
+    authbridge/install.sh > /tmp/t2/inst.sh
+HOME=/tmp/t2 AUTHBRIDGE_SKIP_DOWNLOAD=1 sh /tmp/t2/inst.sh --ref=main --install-only --yes </dev/null 2>&1 | tail -3
+```
+
+Expected: `--help` shows no `Environment:` section; the `SKIP_DOWNLOAD` run reports using the existing binaries rather than downloading.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add authbridge/install.sh authbridge/install_test.sh
+git commit -s -m "$(printf 'refactor: Remove three vestigial installer env vars\n\nAll five AUTHBRIDGE_* vars were audited: none is referenced anywhere outside\ninstall.sh — no CI, docs, demos or Makefiles.\n\nAUTHBRIDGE_REF and AUTHBRIDGE_INSTALL_ONLY are pure aliases for flags that exist,\nleft over from when piping to sh made flags awkward to pass, which `sh -s --\n--flag` solves. AUTHBRIDGE_VERSION is redundant now that --ref=X selects binaries\ntoo.\n\nAUTHBRIDGE_SKIP_DOWNLOAD stays because it does something no flag does and the\ninstall tests depend on it, but it drops out of usage(): it is a testing hook, not\na way to install. AUTHBRIDGE_SCRIPT_REF stays untouched — it is the bootstrap\nrecursion guard, and removing it causes infinite re-exec.\n\nThree messages advised AUTHBRIDGE_VERSION and now name --ref. A script\nrecommending a knob it no longer honours would be worse than the clutter removed,\nso the tests assert the strings are gone rather than merely that the vars are\nunread.\n\nBREAKING for anyone scripting the three removed vars. Zero in-repo references,\nalpha-stage, teammate-sized audience.\n\nAssisted-By: Claude (Anthropic AI) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 5: Publish the rolling `main` release from CI
+
+**Files:**
+- Modify: `.github/workflows/release-binaries.yaml`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks at runtime, but the guard from Task 2 **must be in a cut release** before `MAIN_CHANNEL_ENABLED` is set (see Task 6).
+- Produces: for a push to `main` with the variable set, a pre-release tagged `main` whose assets are named `abctl_main_<os>_<arch>.tar.gz` / `authbridge-proxy[-variant]_main_<os>_<arch>.tar.gz`, each binary stamped `main-<short-sha>`.
+
+- [ ] **Step 1: Add the trigger, gated**
+
+In `.github/workflows/release-binaries.yaml`, add the branch trigger beside the existing tag trigger:
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+```
+
+Then gate the job so an unset variable is a no-op. On the existing job, add:
+
+```yaml
+    # The developer channel is off until a release containing the newest_release()
+    # v-tag filter exists. Publishing a `main` release before that would make the
+    # DEFAULT curl|sh die, because the released copy of install.sh is what every
+    # one-liner bootstraps into. Set MAIN_CHANNEL_ENABLED=true in repo variables
+    # after cutting that release.
+    if: github.ref_type == 'tag' || vars.MAIN_CHANNEL_ENABLED == 'true'
+```
+
+- [ ] **Step 2: Split TAG from VERSION**
+
+Replace the version-derivation block (currently `if [ "${GITHUB_REF_TYPE}" = "tag" ]; then VERSION="${GITHUB_REF_NAME}" … fi`) with:
+
+```sh
+            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+              TAG="${GITHUB_REF_NAME}"
+              VERSION="${GITHUB_REF_NAME}"
+            elif [ "${GITHUB_REF_NAME}" = "main" ]; then
+              # TAG names the rolling release and the assets, so the download URL is
+              # predictable. VERSION identifies the build, and the two must differ:
+              # abctl's serviceIsCurrent compares the stamp recorded in the installed
+              # launchd unit against the running binary to decide whether `service
+              # install` is a no-op. A constant stamp would report "Already current"
+              # while the old binary kept running — hiding upgrades on the one channel
+              # that changes every merge.
+              TAG="main"
+              VERSION="main-$(printf '%s' "${GITHUB_SHA}" | cut -c1-7)"
+            else
+              TAG="${INPUT_TAG:-dev}"
+              VERSION="${INPUT_TAG:-dev}"
+            fi
+            echo "Building ${VERSION} for release ${TAG}"
+```
+
+Add `GITHUB_SHA: ${{ github.sha }}` to that step's `env:` block if it is not already exposed. Then replace every `${VERSION}` used in an **asset filename** with `${TAG}`, and leave `${VERSION}` in the two `-ldflags` invocations. The filename sites are `dist/authbridge-proxy${suffix}_${VERSION}_${os}_${arch}.tar.gz` and `dist/abctl_${VERSION}_${os}_${arch}.tar.gz`; every later reference to those archives must use the same variable.
+
+- [ ] **Step 3: Mark it a prerelease and give it notes**
+
+In the `gh release create` arm, add `main` to the prerelease case and give the rolling release its own notes. The existing case is `case "${TAG}" in *-rc*|*-alpha*|*-beta*) prerelease="--prerelease" ;; esac` — change it to:
+
+```sh
+              case "${TAG}" in
+                main | *-rc* | *-alpha* | *-beta*) prerelease="--prerelease" ;;
+              esac
+```
+
+Without `main` in that list the rolling release would be created without `--prerelease` and would take GitHub's "Latest" badge, displacing `v0.3.1`.
+
+For the notes, when `TAG` is `main`, replace the release-notes body with:
+
+```
+Unreleased build from the tip of `main`, rebuilt on every merge. Not a release.
+
+Install with:
+    curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh | sh -s -- --ref=main
+
+Each binary reports its own build (`abctl --version` → `main-<sha>`). For a
+supported install, use the newest `v*` release instead.
+```
+
+- [ ] **Step 4: Validate the workflow file**
+
+```bash
+python3 -c "import yaml,io; yaml.safe_load(io.open('.github/workflows/release-binaries.yaml')); print('YAML parses')"
+```
+
+Expected: `YAML parses`. Then re-read the diff and confirm by eye: every asset filename uses `${TAG}`, both `-ldflags` use `${VERSION}`, and no `${VERSION}` remains in a `tar`, `gh release`, or `checksums` path. A mismatch here produces assets the installer cannot find — a 404 for every user of the channel.
+
+- [ ] **Step 5: Dry-run the build without publishing**
+
+Use the existing `workflow_dispatch` path, which builds and uploads artifacts without creating a release:
+
+```bash
+gh workflow run release-binaries.yaml -f tag=dev-mainchannel-check
+gh run watch "$(gh run list --workflow=release-binaries.yaml --limit 1 --json databaseId -q '.[0].databaseId')"
+```
+
+Expected: success, and the run's artifacts contain 16 archives named `_dev-mainchannel-check_`. This exercises the split code path without touching the release namespace. Confirm no release was created: `gh release view dev-mainchannel-check` must fail with "release not found".
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/release-binaries.yaml
+git commit -s -m "$(printf 'feat: Publish a rolling main release for the developer channel\n\nPushes to main now build the same 16 archives a tag does and overwrite the assets\non a single pre-release tagged `main`, so a merged fix is installable with\n--ref=main minutes later instead of waiting for someone to cut a tag.\n\nNo new publishing logic: the existing `gh release view || create` branch already\nis rolling behaviour. The trigger is extended rather than a second workflow added,\nbecause a duplicated 16-archive matrix would drift — this repo has already paid\nfor two implementations of one thing twice (install.sh stop_previous_cortex vs\nabctl adoption, and the migration two parallel pin lists).\n\nTAG and VERSION now differ, deliberately. TAG names the release and the assets so\nthe download URL is predictable; VERSION stamps main-<sha> into the binary. abctl\nserviceIsCurrent compares the stamp in the installed unit against the running\nbinary, so a constant stamp would report "Already current" while the old binary\nkept running — hiding upgrades on the one channel that changes every merge.\n\n`main` joins the prerelease case, or the rolling release would take GitHub Latest\nbadge from v0.3.1.\n\nGated on MAIN_CHANNEL_ENABLED, unset. The guard in newest_release() must ship in\na cut release first: the released copy of install.sh is what every curl|sh\nbootstraps into, so a main release existing before then would kill the default\ninstall.\n\nAssisted-By: Claude (Anthropic AI) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 6: Document the channel and the enable procedure
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: the behaviour built in Tasks 2, 3, 5.
+- Produces: no code.
+
+- [ ] **Step 1: Document the channel in CONTRIBUTING.md**
+
+Add a section. Read the file first and match its heading depth and tone; place it near other developer-workflow content, not at the end by default.
+
+```markdown
+## Installing an unreleased build
+
+A fix merged to `main` is installable immediately, without waiting for a release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
+  | sh -s -- --claude-code --ref=main
+```
+
+`--ref=X` means "install X" — both the installer script and the binaries. Every push
+to `main` rebuilds a rolling pre-release tagged `main`, so this tracks the tip.
+
+Each binary reports its own build: `abctl --version` → `main-a1b2c3d`. Quote that,
+not "main", in a bug report — the channel moves under you.
+
+Three things to know:
+
+- **Every `--ref=main` run replaces and restarts the service.** The installed build
+  never matches the requested `main`, so the installer always re-downloads and
+  `service install` always reinstalls. That cuts any running Claude Code session,
+  because `HTTPS_PROXY` is fixed in each session's environment at startup.
+- **`checksums.txt` rolls with the assets.** The installer fetches assets and
+  checksums in the same run, so verification is sound. Downloading them hours apart
+  will mismatch.
+- **The plain one-liner takes you back.** Running it without `--ref` reinstalls the
+  newest release and reinstalls the service, so there is no stuck state to clean up.
+
+### Enabling the channel (one-time, maintainers)
+
+The rolling release must not exist before a cut release contains the
+`newest_release()` v-tag filter — the released copy of `install.sh` is what every
+`curl | sh` bootstraps into, and an unfiltered copy dies when it sees a `main` tag.
+So: merge, cut a release, then set the repo variable `MAIN_CHANNEL_ENABLED=true`
+(Settings → Secrets and variables → Actions → Variables). The next push to `main`
+publishes it.
+```
+
+- [ ] **Step 2: Fix the README's `--ref` sentence**
+
+The quickstart currently ends with a sentence saying the script re-runs the copy from the newest release and that "`--ref` overrides". That now understates `--ref`. Locate it and change the final clause to name both halves — for example `--ref=vX.Y.Z pins a release, and --ref=main installs the unreleased tip (see CONTRIBUTING.md)`.
+
+Do **not** add the `--ref=main` command itself to the quickstart. The audience there is new users; the channel belongs in CONTRIBUTING.md.
+
+- [ ] **Step 3: Verify links and rendering**
+
+```bash
+# every relative link in the touched files resolves
+for f in CONTRIBUTING.md README.md; do
+  grep -o '](\.\{0,2\}/\?[^)]*\.md[^)]*)' "$f" | sed 's/^](//;s/)$//' | while read -r l; do
+    t="${l%%#*}"; [ -e "$t" ] && echo "ok: $f -> $l" || echo "BROKEN: $f -> $l"
+  done
+done
+pre-commit run --files CONTRIBUTING.md README.md
+```
+
+Expected: no `BROKEN` lines; pre-commit passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CONTRIBUTING.md README.md
+git commit -s -m "$(printf 'docs: Document the developer channel and how to enable it\n\nA fix merged to main is now installable with --ref=main. Documented in\nCONTRIBUTING.md rather than the README quickstart on purpose: the audience there\nis new users, and putting an unreleased channel beside the getting-started command\nwould place them one flag from untested code — which is what the release-bootstrap\nexists to prevent.\n\nRecords the three things that surprise people: every --ref=main run restarts the\nservice and cuts live Claude Code sessions; checksums roll with the assets, so\ndownloading them hours apart mismatches; and the plain one-liner takes you back to\nreleases with no stuck state.\n\nAlso records the enable procedure, because the ordering is load-bearing and easy\nto get wrong: the v-tag filter must be in a CUT RELEASE before the rolling `main`\nrelease exists, since the released copy of install.sh is what every curl|sh\nbootstraps into.\n\nREADME `--ref` sentence corrected — it said "--ref overrides", which understated a\nflag that now selects binaries too.\n\nAssisted-By: Claude (Anthropic AI) <noreply@anthropic.com>')"
+```
+
+---
+
+### Task 7: End-to-end verification and PR
+
+**Files:** none modified — this task verifies and opens the PR.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6.
+- Produces: a PR against `main`.
+
+- [ ] **Step 1: Full local check**
+
+```bash
+sh authbridge/install_test.sh
+shellcheck --severity=error authbridge/install.sh authbridge/install_test.sh
+shellcheck -s sh authbridge/install.sh authbridge/install_test.sh
+sh -n authbridge/install.sh
+python3 -c "import yaml,io; yaml.safe_load(io.open('.github/workflows/release-binaries.yaml')); yaml.safe_load(io.open('.github/workflows/ci.yaml')); print('workflows parse')"
+pre-commit run --files authbridge/install.sh authbridge/install_test.sh CONTRIBUTING.md README.md .github/workflows/release-binaries.yaml .github/workflows/ci.yaml
+```
+
+Expected: tests pass, shellcheck silent, workflows parse, pre-commit clean.
+
+- [ ] **Step 2: Prove the default install is unaffected, on real network**
+
+```bash
+rm -rf /tmp/e2e-default && mkdir -p /tmp/e2e-default/.local/bin /tmp/e2e-default/.claude
+printf '{}\n' > /tmp/e2e-default/.claude/settings.json
+sed -e 's|"${BIN_DIR}/abctl" service install --yes --proxy "${BIN_DIR}/authbridge-proxy"|true|' \
+    -e 's/^DEMO_\(FORWARD\|SESSION\|STATS\|HEALTH\)_PORT=4760/DEMO_\1_PORT=4777/' \
+    authbridge/install.sh > /tmp/e2e-default/inst.sh
+HOME=/tmp/e2e-default sh /tmp/e2e-default/inst.sh --ref=main --install-only --yes </dev/null 2>&1 | tail -3
+HOME=/tmp/e2e-default sh /tmp/e2e-default/inst.sh --install-only --yes </dev/null 2>&1 | tail -3
+/tmp/e2e-default/.local/bin/abctl --version
+```
+
+Expected: the second run downloads and installs the newest `v*` release, and `abctl --version` reports that tag. The first run fails at download (`abctl_main_…tar.gz`) because no `main` release exists yet — that is the correct pre-enable state and confirms resolution reaches `main`.
+
+- [ ] **Step 3: Do not enable the channel**
+
+Confirm `MAIN_CHANNEL_ENABLED` is unset:
+
+```bash
+gh variable list 2>/dev/null | grep -c MAIN_CHANNEL_ENABLED
+```
+
+Expected: `0`. If it is set, unset it — enabling belongs after a release is cut (Task 6, Step 1).
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/main-channel
+```
+
+Then open a PR titled `Feat: Developer channel — install unreleased main binaries`, with a body covering: the problem (a merged fix was not installable, with the sandbox report as the concrete case); the three verified findings (artifacts 401 anonymously, an unfiltered `main` release kills the default install, the TAG/VERSION split is required by `serviceIsCurrent`); the surface *shrinking* by three env vars; the enable sequencing; and that `install.sh` gained its first tests. End with the `Assisted-By` trailer.
+
+- [ ] **Step 5: Confirm CI is green**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all checks pass, including the new `install.sh tests` job. The `Release binaries` workflow must **not** run for this PR — it triggers on tag pushes and on `main` pushes, not on pull requests. If it appears, the trigger is wrong.

--- a/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
+++ b/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
@@ -1,0 +1,231 @@
+# Main Channel — installing unreleased binaries — Design
+
+**Date:** 2026-09-09
+**Status:** Converged design — ready for implementation plan.
+**Repos touched:** `cortex` only (`.github/workflows/release-binaries.yaml`, `authbridge/install.sh`, `CONTRIBUTING.md`)
+
+> **Naming:** "channel" here means only *where binaries come from* — a tagged
+> release, or the tip of `main`. It is not a subscription, an update daemon, or a
+> promotion pipeline. There are exactly two channels and no mechanism for adding a
+> third.
+
+## Problem
+
+A fix merged to `main` is not installable until someone cuts a tag. That gap is not
+theoretical: a colleague hit a sandbox failure on `v0.7.0-alpha.7`, the fix merged the
+next day as #897, and the only ways to get it to him were "wait for a release" or
+"clone the repo and build with Go". Neither is reasonable for confirming a fix he
+reported.
+
+`--ref=main` already exists but does not solve it: it swaps **the script only**, and
+the fix he needed (`launchdUsable`) is compiled into `abctl`. No workflow publishes
+binaries from `main` — `release-binaries.yaml` triggers on `v*` tags, `ci.yaml` uploads
+no artifacts, and `build.yaml` produces container images rather than the standalone
+binaries the installer downloads.
+
+CI artifacts are not a substitute. `actions/.../artifacts/<id>/zip` returns **HTTP 401
+anonymously** (verified), so `curl | sh` cannot fetch them without a token.
+
+## Goals / Non-goals
+
+**Goals**
+
+- A developer can install unreleased `main` binaries with one extra flag.
+- The default one-liner is unchanged, in command *and* behaviour.
+- Which `main` build is installed is identifiable after the fact.
+- Switching between channels works in both directions with no manual cleanup.
+
+**Non-goals**
+
+- A public bleeding-edge channel. Audience is teammates and contributors; this is
+  documented in `CONTRIBUTING.md`, deliberately **not** in the README quickstart.
+  Putting it beside the getting-started command would place new users one flag from
+  untested code, which is what the release-bootstrap exists to prevent.
+- Container images from `main`. `build.yaml` already publishes those on main pushes;
+  this design covers standalone binaries only.
+- Promotion, channel subscriptions, or automatic updates.
+- Reproducibility of a `main` install. The channel is rolling by construction.
+
+## What breaks without care
+
+Publishing a release tagged `main` breaks **the default install for every new user**,
+and quietly. Traced through the current script:
+
+1. the bootstrap calls `newest_release()`, which fetches `releases?per_page=1`;
+2. the rolling `main` release sorts first;
+3. the tag-shape guard requires `v[0-9]*`, so `main` fails it and the function returns 1;
+4. `want_ref` is empty, so the script warns *"could not resolve the newest release;
+   continuing with the copy from main"* and sets `SCRIPT_REF=main`;
+5. version resolution then calls `newest_release()` again, fails again, and dies with
+   *"could not resolve the newest release"*.
+
+A second break: `gh release create` only passes `--prerelease` for tags matching
+`*-rc*|*-alpha*|*-beta*`. `main` matches none, so the rolling release would be created
+**without** the prerelease flag and would take GitHub's "Latest" badge, displacing
+`v0.3.1`.
+
+Both are consequences of publishing to the same release namespace the installer reads.
+Neither guard below is optional.
+
+## Design decisions
+
+| # | Decision | Choice |
+| --- | --- | --- |
+| D1 | Publishing mechanism | **One rolling pre-release** tagged `main`, assets overwritten on each push. Reuses the existing `releases/download/<tag>` URL shape, so the installer's download path is unchanged. |
+| D2 | Trigger | **Every push to `main`.** A merged fix is installable minutes later, which is the case that motivated this. |
+| D3 | Opt-in surface | **A dedicated `--main` flag**, not an overload of `--ref`. |
+| D4 | Build identity | Asset names use the tag (`main`); the binary is stamped `main-<short-sha>`. The two deliberately disagree. |
+| D5 | Default resolution | `newest_release()` filters to `v[0-9]*`, ignoring the channel entirely. |
+| D6 | Workflow home | **Extend `release-binaries.yaml`** rather than add a second workflow. |
+
+**On D3.** `--ref=main` today means *script from main, binaries from the newest
+release* — the way to test an `install.sh` change without also changing the binaries
+underneath it. Overloading it to switch both would make that combination unreachable.
+A dedicated flag also appears in `usage()`, where a magic `--ref` value would not.
+
+**On D4.** This asymmetry is required, not stylistic. `serviceIsCurrent` compares the
+`AbctlVersion` stamp recorded in the installed unit against the running `abctl`'s
+version to decide whether `service install` is a no-op. If every `main` build stamped
+`main`, an upgrade would compare equal and `service install` would report *"Already
+current"* while the old binary kept running — the idempotency work would actively hide
+upgrades on precisely the channel that changes most.
+
+**On D6.** A second workflow means a second copy of a 16-archive build matrix. Two
+implementations of one thing have already cost this repo twice: `install.sh`'s
+`stop_previous_cortex` duplicating `abctl`'s adoption logic, and the migration's two
+parallel lists of pins. Drift in a duplicated matrix would mean the channel builds
+differently from releases — the exact failure a developer using it could not diagnose.
+
+## Architecture
+
+### Workflow (`release-binaries.yaml`)
+
+Add `push: branches: [main]` alongside the existing `tags: ['v*']`. Split the single
+`VERSION` variable in the build step into two:
+
+```
+TAG      = main                 # release target and asset names  (stable URL)
+VERSION  = main-<short-sha>     # -ldflags -X main.version        (unique per build)
+```
+
+For a tag push both keep today's value (`TAG = VERSION = $GITHUB_REF_NAME`), so the
+release path is byte-identical to now.
+
+Publishing needs no new logic. The existing branch already implements rolling
+behaviour:
+
+```sh
+if gh release view "${TAG}" >/dev/null 2>&1; then
+  gh release upload "${TAG}" dist/*.tar.gz dist/checksums.txt --clobber
+else
+  ...
+fi
+```
+
+Two edits to the `create` arm: add `main` to the prerelease case so the badge stays on
+`v0.3.1`, and give the rolling release notes that say it is an unreleased build from
+`main` and point at the newest `v*` tag — for the human who browses the releases page
+and sees `main` at the top.
+
+### Installer (`authbridge/install.sh`)
+
+**The guard (D5).** `newest_release()` fetches `?per_page=10` rather than
+`?per_page=1` and returns the first `tag_name` matching `v[0-9]*`. Ten is headroom, not
+a calculation: there is exactly one rolling `main` release, so two would do — the extra
+costs nothing and absorbs any future non-`v` tag. The existing shape check stays as the
+last line of defence, and an all-non-`v` page still returns non-zero rather than
+guessing.
+
+**The flag (D3).** `--main` sets the default for both halves; the more specific knob
+overrides its own half:
+
+| Invocation | script | binaries |
+| --- | --- | --- |
+| *(no flags)* | newest `v*` release | same release |
+| `--main` | main | main |
+| `--ref=main` | main | newest `v*` release (unchanged) |
+| `--main --ref=v0.7.0-alpha.7` | that release | main |
+| `--main` + `AUTHBRIDGE_VERSION=v0.7.0-alpha.7` | main | that release |
+
+No precedence surprises and no error paths: each knob keeps one meaning.
+
+**Reporting.** With `--main`, the installer prints that it is installing unreleased
+code, and reports the build it actually got by asking the binary (`installed_version
+abctl` → `main-a1b2c3d`) rather than echoing the channel name. "I am on main" is not a
+usable bug report; "I am on `main-a1b2c3d`" is.
+
+## Consequences accepted
+
+- **Every `--main` run reinstalls and restarts.** The installed binary reports
+  `main-<sha>`, which never equals `main`, so the skip-if-already-at-this-version check
+  always downloads; the differing stamp then makes `serviceIsCurrent` false. Correct for
+  a rolling channel, but each run cuts live Claude Code sessions. The existing
+  connection-count warning covers it.
+- **`checksums.txt` rolls with the assets.** `install.sh` fetches assets and checksums
+  in the same run, so verification stays sound. A human who downloads them hours apart
+  gets a mismatch. Documented, not fixed.
+- **The releases page gains a rolling `main` entry** that sorts first. Mitigated by the
+  prerelease flag (badge unaffected) and the release notes.
+- **CI cost roughly doubles per merge to `main`**: a 16-archive cross-compile alongside
+  the container images `build.yaml` already builds. Accepted for the freshness.
+
+## Sequencing (this is what makes "nothing breaks" true)
+
+The order is forced, because the guard must be in the **released** script before a
+`main` release exists — the released copy is what every `curl | sh` bootstraps into.
+
+1. Land the `newest_release()` filter alone.
+2. Cut a release containing it.
+3. Only then add the workflow trigger and the `--main` flag.
+
+Steps 1–2 are independently valuable: the filter also hardens against any future
+non-`v` tag. There is no window in which a `main` release exists and the released
+installer cannot cope.
+
+## Testing & success criteria
+
+Fixture-driven. `newest_release()` is exercised by sourcing the function and replacing
+`curl` with one that prints a fixture — the technique used ad hoc while diagnosing the
+tag-parser bug.
+
+**This harness does not exist yet, and that is scope.** `install.sh` currently has
+**no committed tests**: `security-scans.yaml` runs `shellcheck --severity=error` over it
+and `ci.yaml` does not reference it at all. The tag-parser fix (#902) shipped with no
+test for exactly this reason. So this design adds the first one — a plain POSIX `sh`
+script, since the repo has no `bats` or `shunit2` and adding a framework is not worth it
+for a handful of functions. It must be runnable locally and wired into CI, or it will
+rot.
+
+Committing that harness is independently valuable and is a prerequisite for the guard
+being verifiable rather than merely written.
+
+- **Guard:** a fixture where a `main` release sorts first still resolves
+  `v0.7.0-alpha.7`. Also with `main` first *and* several `v*` entries following.
+- **Guard, hostile:** rate-limit JSON, an HTML error page, empty, and a non-`v` tag all
+  still fail non-zero rather than returning a wrong tag.
+- **Default install unchanged:** no flags installs the newest `v*` release.
+- **Pinning unchanged:** `--ref=v0.7.0-alpha.7` and `AUTHBRIDGE_VERSION=...` behave as
+  today.
+- **`--ref=main` unchanged:** main's script, newest release's binaries.
+- **`--main`:** installs a binary whose `--version` matches `main-<sha>`, and the
+  install output names that build.
+- **Channel switching, both directions:** release → main downloads main; main → release
+  downloads the release *and* reinstalls the service (the unit's stamp differs, so
+  `serviceIsCurrent` must be false). This is the property that makes the channel safe to
+  hand to someone: the plain one-liner always returns them to releases.
+- **Workflow:** a tag push still produces assets named `_<tag>_` stamped with the tag; a
+  main push produces assets named `_main_` stamped `main-<sha>`; the rolling release is
+  flagged prerelease.
+
+Success: a developer runs the one-liner with `--main`, gets a merged-but-unreleased fix,
+and the default one-liner is provably unaffected.
+
+## Implementation surface (summary)
+
+| File | Change |
+| --- | --- |
+| `authbridge/install.sh` | `newest_release()` filter; `--main` flag + `usage()` entry; version resolution arm; install-time reporting |
+| `.github/workflows/release-binaries.yaml` | `push: branches: [main]`; `TAG`/`VERSION` split; `main` added to the prerelease case; rolling-release notes |
+| `CONTRIBUTING.md` | document the channel, the rolling-checksum caveat, and that the plain one-liner returns you to releases |
+| `authbridge/install_test.sh` *(new)* | first committed tests for `install.sh` — fixture-driven `newest_release()` cases |
+| `.github/workflows/ci.yaml` | run the new harness, so it cannot rot |

--- a/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
+++ b/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
@@ -99,10 +99,19 @@ consequences —
   installer. Confirming it would have required creating the colliding tag on a
   real repo.
 
-Only the tag changes. `--ref=main` remains what a developer types;
-`resolve_version` maps it to `CHANNEL_TAG` (`install.sh`), and the CI workflow
-must use the same string. The test suite reads the constant out of `install.sh`
-rather than restating it, so a rename cannot leave a stale expectation passing.
+`--ref=main` remains what a developer types; `resolve_version` maps it to
+`CHANNEL_TAG` (`install.sh`), and the CI workflow must use the same string. The
+test suite reads the constant out of `install.sh` rather than restating it, so a
+rename cannot leave a stale expectation passing.
+
+Two things review added on top of the rename. `--ref=main-latest` must behave
+identically to `--ref=main`, because `main-latest` is a real tag and it is the
+title the Releases page shows — a developer who saw it there will type it.
+And renaming addressed ref *ambiguity* only: the tag still froze at its
+first-publish commit, because uploading assets never moves it, so the release's
+source archives drifted from the binaries beside them. CI now moves the rolling
+tag before uploading. Neither is optional for the channel to behave as
+"`--ref=X` installs X".
 
 **On D3.** `--ref` is inconsistent *today*: `--ref=v0.7.0-alpha.4` sets both halves
 (`v*) version="${SCRIPT_REF}"`), while `--ref=main` sets only the script because there is

--- a/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
+++ b/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
@@ -2,93 +2,97 @@
 
 **Date:** 2026-09-09
 **Status:** Converged design — ready for implementation plan.
-**Repos touched:** `cortex` only (`.github/workflows/release-binaries.yaml`, `authbridge/install.sh`, `CONTRIBUTING.md`)
+**Repos touched:** `cortex` only (`.github/workflows/release-binaries.yaml`, `authbridge/install.sh`, `CONTRIBUTING.md`, `README.md`)
 
-> **Naming:** "channel" here means only *where binaries come from* — a tagged
-> release, or the tip of `main`. It is not a subscription, an update daemon, or a
-> promotion pipeline. There are exactly two channels and no mechanism for adding a
-> third.
+> **"Channel" means only where binaries come from** — a tagged release, or the tip of
+> `main`. Not a subscription, an update daemon, or a promotion pipeline. There are two
+> channels and no mechanism for a third.
 
 ## Problem
 
-A fix merged to `main` is not installable until someone cuts a tag. That gap is not
-theoretical: a colleague hit a sandbox failure on `v0.7.0-alpha.7`, the fix merged the
-next day as #897, and the only ways to get it to him were "wait for a release" or
-"clone the repo and build with Go". Neither is reasonable for confirming a fix he
-reported.
+A fix merged to `main` is not installable until someone cuts a tag. Not theoretical: a
+colleague hit a sandbox failure on `v0.7.0-alpha.7`, the fix merged the next day as
+#897, and the only ways to get it to him were "wait for a release" or "clone the repo
+and build with Go" — neither reasonable for confirming a bug he reported.
 
-`--ref=main` already exists but does not solve it: it swaps **the script only**, and
-the fix he needed (`launchdUsable`) is compiled into `abctl`. No workflow publishes
-binaries from `main` — `release-binaries.yaml` triggers on `v*` tags, `ci.yaml` uploads
-no artifacts, and `build.yaml` produces container images rather than the standalone
+`--ref=main` already exists but does not solve it: it swaps **the script only**, and the
+fix he needed (`launchdUsable`) is compiled into `abctl`. No workflow publishes binaries
+from `main` — `release-binaries.yaml` triggers on `v*` tags, `ci.yaml` uploads no
+artifacts, and `build.yaml` produces container images rather than the standalone
 binaries the installer downloads.
 
-CI artifacts are not a substitute. `actions/.../artifacts/<id>/zip` returns **HTTP 401
+CI artifacts are not a substitute: `actions/.../artifacts/<id>/zip` returns **HTTP 401
 anonymously** (verified), so `curl | sh` cannot fetch them without a token.
 
 ## Goals / Non-goals
 
 **Goals**
 
-- A developer can install unreleased `main` binaries with one extra flag.
+- A developer installs unreleased `main` binaries with `--ref=main`.
 - The default one-liner is unchanged, in command *and* behaviour.
 - Which `main` build is installed is identifiable after the fact.
-- Switching between channels works in both directions with no manual cleanup.
+- Switching channels works both directions with no manual cleanup.
+- **The selection surface gets smaller, not larger.**
 
 **Non-goals**
 
-- A public bleeding-edge channel. Audience is teammates and contributors; this is
-  documented in `CONTRIBUTING.md`, deliberately **not** in the README quickstart.
-  Putting it beside the getting-started command would place new users one flag from
-  untested code, which is what the release-bootstrap exists to prevent.
-- Container images from `main`. `build.yaml` already publishes those on main pushes;
-  this design covers standalone binaries only.
-- Promotion, channel subscriptions, or automatic updates.
+- A public bleeding-edge channel. Audience is teammates and contributors; documented in
+  `CONTRIBUTING.md`, deliberately **not** in the README quickstart. Putting it beside the
+  getting-started command would place new users one flag from untested code, which is
+  what the release-bootstrap exists to prevent.
+- Container images from `main` — `build.yaml` already publishes those on main pushes.
+- Promotion, subscriptions, or automatic updates.
 - Reproducibility of a `main` install. The channel is rolling by construction.
 
 ## What breaks without care
 
-Publishing a release tagged `main` breaks **the default install for every new user**,
-and quietly. Traced through the current script:
+Publishing a release tagged `main` breaks **the default install for every new user**, and
+quietly. Traced through the current script:
 
 1. the bootstrap calls `newest_release()`, which fetches `releases?per_page=1`;
 2. the rolling `main` release sorts first;
 3. the tag-shape guard requires `v[0-9]*`, so `main` fails it and the function returns 1;
 4. `want_ref` is empty, so the script warns *"could not resolve the newest release;
    continuing with the copy from main"* and sets `SCRIPT_REF=main`;
-5. version resolution then calls `newest_release()` again, fails again, and dies with
+5. version resolution calls `newest_release()` again, fails again, and dies with
    *"could not resolve the newest release"*.
 
-A second break: `gh release create` only passes `--prerelease` for tags matching
+Second break: `gh release create` passes `--prerelease` only for tags matching
 `*-rc*|*-alpha*|*-beta*`. `main` matches none, so the rolling release would be created
-**without** the prerelease flag and would take GitHub's "Latest" badge, displacing
-`v0.3.1`.
+**without** it and would take GitHub's "Latest" badge, displacing `v0.3.1`.
 
-Both are consequences of publishing to the same release namespace the installer reads.
-Neither guard below is optional.
+Both follow from publishing into the same release namespace the installer reads. Neither
+guard below is optional.
 
 ## Design decisions
 
 | # | Decision | Choice |
 | --- | --- | --- |
-| D1 | Publishing mechanism | **One rolling pre-release** tagged `main`, assets overwritten on each push. Reuses the existing `releases/download/<tag>` URL shape, so the installer's download path is unchanged. |
-| D2 | Trigger | **Every push to `main`.** A merged fix is installable minutes later, which is the case that motivated this. |
-| D3 | Opt-in surface | **A dedicated `--main` flag**, not an overload of `--ref`. |
+| D1 | Publishing mechanism | **One rolling pre-release** tagged `main`, assets overwritten each push. Reuses the existing `releases/download/<tag>` URL shape, so the download path is unchanged. |
+| D2 | Trigger | **Every push to `main`.** A merged fix is installable minutes later — the motivating case. |
+| D3 | Selection | **One selector: `--ref=X` means "install X"** — script *and* binaries — for every X, including `main`. No new flag. |
 | D4 | Build identity | Asset names use the tag (`main`); the binary is stamped `main-<short-sha>`. The two deliberately disagree. |
-| D5 | Default resolution | `newest_release()` filters to `v[0-9]*`, ignoring the channel entirely. |
+| D5 | Default resolution | `newest_release()` fetches `?per_page=10` and returns the first tag matching `v[0-9]*`, ignoring the channel entirely. |
 | D6 | Workflow home | **Extend `release-binaries.yaml`** rather than add a second workflow. |
+| D7 | Knob cleanup | Remove `AUTHBRIDGE_REF`, `AUTHBRIDGE_INSTALL_ONLY`, `AUTHBRIDGE_VERSION`. Keep `AUTHBRIDGE_SKIP_DOWNLOAD` (undocumented, maintainer) and `AUTHBRIDGE_SCRIPT_REF` (internal). |
+| D8 | First publish | Gated on repo variable `MAIN_CHANNEL_ENABLED`, unset by default — this is what lets everything ship in one PR safely (see Sequencing). |
 
-**On D3.** `--ref=main` today means *script from main, binaries from the newest
-release* — the way to test an `install.sh` change without also changing the binaries
-underneath it. Overloading it to switch both would make that combination unreachable.
-A dedicated flag also appears in `usage()`, where a magic `--ref` value would not.
+**On D3.** `--ref` is inconsistent *today*: `--ref=v0.7.0-alpha.4` sets both halves
+(`v*) version="${SCRIPT_REF}"`), while `--ref=main` sets only the script because there is
+no `main` release to download from. Once one exists, one rule covers both. This design
+therefore adds no selector — it makes an existing one consistent.
 
-**On D4.** This asymmetry is required, not stylistic. `serviceIsCurrent` compares the
-`AbctlVersion` stamp recorded in the installed unit against the running `abctl`'s
-version to decide whether `service install` is a no-op. If every `main` build stamped
-`main`, an upgrade would compare equal and `service install` would report *"Already
-current"* while the old binary kept running — the idempotency work would actively hide
-upgrades on precisely the channel that changes most.
+An earlier draft added a `--main` flag to preserve "main's script with released
+binaries". That capability is maintainer-only (testing an installer change without
+moving the binaries under it), and two flags differing by punctuation but not by meaning
+is worse than losing it. It remains reachable via `AUTHBRIDGE_SKIP_DOWNLOAD` with a
+locally built pair, which is how installer changes were actually tested.
+
+**On D4.** Required, not stylistic. `serviceIsCurrent` compares the `AbctlVersion` stamp
+in the installed unit against the running `abctl` to decide whether `service install` is
+a no-op. If every `main` build stamped `main`, an upgrade would compare equal and
+`service install` would report *"Already current"* while the old binary kept running —
+the idempotency work would hide upgrades on the one channel that changes most.
 
 **On D6.** A second workflow means a second copy of a 16-archive build matrix. Two
 implementations of one thing have already cost this repo twice: `install.sh`'s
@@ -96,12 +100,21 @@ implementations of one thing have already cost this repo twice: `install.sh`'s
 parallel lists of pins. Drift in a duplicated matrix would mean the channel builds
 differently from releases — the exact failure a developer using it could not diagnose.
 
+**On D7.** All five were audited: **none is referenced anywhere outside `install.sh`** —
+no CI, docs, demos, or Makefiles. `AUTHBRIDGE_REF` and `AUTHBRIDGE_INSTALL_ONLY` are pure
+aliases for flags that exist, dating from when piping to `sh` made flags awkward, which
+`sh -s -- --flag` solves. `AUTHBRIDGE_VERSION` is redundant once D3 lands.
+`AUTHBRIDGE_SKIP_DOWNLOAD` does something no flag does and stays, demoted to a header
+comment. `AUTHBRIDGE_SCRIPT_REF` is the bootstrap's recursion guard — removing it causes
+infinite re-exec — and is already undocumented.
+
 ## Architecture
 
 ### Workflow (`release-binaries.yaml`)
 
-Add `push: branches: [main]` alongside the existing `tags: ['v*']`. Split the single
-`VERSION` variable in the build step into two:
+Add `push: branches: [main]` alongside the existing `tags: ['v*']`, with the main path
+gated `if: vars.MAIN_CHANNEL_ENABLED == 'true'` (D8). Split the single `VERSION` variable
+in the build step:
 
 ```
 TAG      = main                 # release target and asset names  (stable URL)
@@ -111,8 +124,7 @@ VERSION  = main-<short-sha>     # -ldflags -X main.version        (unique per bu
 For a tag push both keep today's value (`TAG = VERSION = $GITHUB_REF_NAME`), so the
 release path is byte-identical to now.
 
-Publishing needs no new logic. The existing branch already implements rolling
-behaviour:
+Publishing needs no new logic — the existing branch already is rolling behaviour:
 
 ```sh
 if gh release view "${TAG}" >/dev/null 2>&1; then
@@ -123,64 +135,78 @@ fi
 ```
 
 Two edits to the `create` arm: add `main` to the prerelease case so the badge stays on
-`v0.3.1`, and give the rolling release notes that say it is an unreleased build from
-`main` and point at the newest `v*` tag — for the human who browses the releases page
-and sees `main` at the top.
+`v0.3.1`, and give the rolling release notes saying it is an unreleased build from `main`
+and pointing at the newest `v*` tag — for the human who browses releases and sees `main`
+on top.
 
 ### Installer (`authbridge/install.sh`)
 
-**The guard (D5).** `newest_release()` fetches `?per_page=10` rather than
-`?per_page=1` and returns the first `tag_name` matching `v[0-9]*`. Ten is headroom, not
-a calculation: there is exactly one rolling `main` release, so two would do — the extra
-costs nothing and absorbs any future non-`v` tag. The existing shape check stays as the
-last line of defence, and an all-non-`v` page still returns non-zero rather than
-guessing.
+**The guard (D5).** `newest_release()` fetches `?per_page=10` and returns the first
+`tag_name` matching `v[0-9]*`. Ten is headroom, not a calculation: there is exactly one
+rolling `main` release, so two would do — the extra costs nothing and absorbs any future
+non-`v` tag. The existing shape check stays as the last line of defence, and an
+all-non-`v` page still returns non-zero rather than guessing.
 
-**The flag (D3).** `--main` sets the default for both halves; the more specific knob
-overrides its own half:
+**One selector (D3).** Version resolution gains one arm so any ref, not just a `v*` tag,
+sources both halves:
 
-| Invocation | script | binaries |
-| --- | --- | --- |
-| *(no flags)* | newest `v*` release | same release |
-| `--main` | main | main |
-| `--ref=main` | main | newest `v*` release (unchanged) |
-| `--main --ref=v0.7.0-alpha.7` | that release | main |
-| `--main` + `AUTHBRIDGE_VERSION=v0.7.0-alpha.7` | main | that release |
+```sh
+case "${SCRIPT_REF}" in
+    v*|main) version="${SCRIPT_REF}" ;;
+    *)       version=$(newest_release) ;;
+esac
+```
 
-No precedence surprises and no error paths: each knob keeps one meaning.
+**Cleanup (D7).** Delete the three env vars from the header comment and `usage()`, and
+drop their read sites. Three messages currently advise `AUTHBRIDGE_VERSION` and must be
+rewritten to `--ref=vX.Y.Z`, or the script ends up recommending a knob it no longer
+honours — worse than the clutter it replaced:
 
-**Reporting.** With `--main`, the installer prints that it is installing unreleased
-code, and reports the build it actually got by asking the binary (`installed_version
-abctl` → `main-a1b2c3d`) rather than echoing the channel name. "I am on main" is not a
-usable bug report; "I am on `main-a1b2c3d`" is.
+- `install.sh:373` — *"could not resolve the newest release (set AUTHBRIDGE_VERSION=…)"*
+- `install.sh:591` — the abctl-lacks-`service` guard
+- `install.sh:596` — the same guard's non-tag branch
+
+**Reporting.** With `--ref=main` the installer says it is installing unreleased code, and
+reports the build it got by asking the binary (`installed_version abctl` →
+`main-a1b2c3d`) rather than echoing the channel name. "I am on main" is not a usable bug
+report; "I am on `main-a1b2c3d`" is.
 
 ## Consequences accepted
 
-- **Every `--main` run reinstalls and restarts.** The installed binary reports
-  `main-<sha>`, which never equals `main`, so the skip-if-already-at-this-version check
-  always downloads; the differing stamp then makes `serviceIsCurrent` false. Correct for
-  a rolling channel, but each run cuts live Claude Code sessions. The existing
+- **Every `--ref=main` run reinstalls and restarts.** The installed binary reports
+  `main-<sha>`, never equal to `main`, so the skip-if-already-at-this-version check always
+  downloads; the differing stamp then makes `serviceIsCurrent` false. Correct for a
+  rolling channel, but each run cuts live Claude Code sessions. The existing
   connection-count warning covers it.
-- **`checksums.txt` rolls with the assets.** `install.sh` fetches assets and checksums
-  in the same run, so verification stays sound. A human who downloads them hours apart
-  gets a mismatch. Documented, not fixed.
-- **The releases page gains a rolling `main` entry** that sorts first. Mitigated by the
-  prerelease flag (badge unaffected) and the release notes.
-- **CI cost roughly doubles per merge to `main`**: a 16-archive cross-compile alongside
+- **Removing three env vars is a breaking change** for anyone scripting them. Zero
+  references in-repo, alpha-stage, teammate-sized audience — acceptable, and recorded
+  rather than hidden.
+- **`checksums.txt` rolls with the assets.** `install.sh` fetches assets and checksums in
+  the same run, so verification stays sound. A human downloading them hours apart gets a
+  mismatch. Documented, not fixed.
+- **The releases page gains a rolling `main` entry.** It sorts first only until the next
+  tagged release, since `created_at` is fixed at creation. Badge unaffected via the
+  prerelease flag.
+- **CI cost roughly doubles per merge to `main`** — a 16-archive cross-compile alongside
   the container images `build.yaml` already builds. Accepted for the freshness.
 
-## Sequencing (this is what makes "nothing breaks" true)
+## Sequencing
 
-The order is forced, because the guard must be in the **released** script before a
-`main` release exists — the released copy is what every `curl | sh` bootstraps into.
+The constraint is about **releases, not PRs**: the guard must be in the *released* script
+before a `main` release exists, because the released copy is what every `curl | sh`
+bootstraps into. Merging the workflow trigger and the guard together would otherwise fire
+the first main build while the released script (`v0.7.0-alpha.7`) still lacks the guard.
 
-1. Land the `newest_release()` filter alone.
-2. Cut a release containing it.
-3. Only then add the workflow trigger and the `--main` flag.
+`MAIN_CHANNEL_ENABLED` (D8) resolves this without splitting the PR:
 
-Steps 1–2 are independently valuable: the filter also hardens against any future
-non-`v` tag. There is no window in which a `main` release exists and the released
-installer cannot cope.
+1. Merge the PR — guard, selector, cleanup, and workflow all land. The main job is
+   skipped because the variable is unset, so **no `main` release is created**.
+2. Cut a release from that merge. The released script now contains the guard.
+3. Set `MAIN_CHANNEL_ENABLED=true` in repo settings. The next push to `main` publishes the
+   channel.
+
+There is no window in which a `main` release exists and the released installer cannot
+cope. Step 3 is a settings toggle, not a code change, so nothing waits on a second PR.
 
 ## Testing & success criteria
 
@@ -188,44 +214,45 @@ Fixture-driven. `newest_release()` is exercised by sourcing the function and rep
 `curl` with one that prints a fixture — the technique used ad hoc while diagnosing the
 tag-parser bug.
 
-**This harness does not exist yet, and that is scope.** `install.sh` currently has
-**no committed tests**: `security-scans.yaml` runs `shellcheck --severity=error` over it
-and `ci.yaml` does not reference it at all. The tag-parser fix (#902) shipped with no
-test for exactly this reason. So this design adds the first one — a plain POSIX `sh`
-script, since the repo has no `bats` or `shunit2` and adding a framework is not worth it
-for a handful of functions. It must be runnable locally and wired into CI, or it will
-rot.
+**This harness does not exist yet, and that is scope.** `install.sh` has **no committed
+tests**: `security-scans.yaml` runs `shellcheck --severity=error` over it and `ci.yaml`
+does not reference it at all. The tag-parser fix (#902) shipped untested for exactly that
+reason. So this design adds the first one — a plain POSIX `sh` script, since the repo has
+no `bats` or `shunit2` and a framework is not worth it for a handful of functions — wired
+into CI so it cannot rot.
 
-Committing that harness is independently valuable and is a prerequisite for the guard
-being verifiable rather than merely written.
+Cases:
 
 - **Guard:** a fixture where a `main` release sorts first still resolves
-  `v0.7.0-alpha.7`. Also with `main` first *and* several `v*` entries following.
-- **Guard, hostile:** rate-limit JSON, an HTML error page, empty, and a non-`v` tag all
-  still fail non-zero rather than returning a wrong tag.
+  `v0.7.0-alpha.7`; likewise with `main` first and several `v*` following.
+- **Guard, hostile:** rate-limit JSON, an HTML error page, empty, and an all-non-`v` page
+  each return non-zero rather than a wrong tag.
 - **Default install unchanged:** no flags installs the newest `v*` release.
-- **Pinning unchanged:** `--ref=v0.7.0-alpha.7` and `AUTHBRIDGE_VERSION=...` behave as
-  today.
-- **`--ref=main` unchanged:** main's script, newest release's binaries.
-- **`--main`:** installs a binary whose `--version` matches `main-<sha>`, and the
-  install output names that build.
+- **Selector:** `--ref=v0.7.0-alpha.7` sources both halves from it; `--ref=main` sources
+  both from main and installs a binary whose `--version` is `main-<sha>`.
+- **Removed vars:** setting `AUTHBRIDGE_VERSION`, `AUTHBRIDGE_REF`, or
+  `AUTHBRIDGE_INSTALL_ONLY` has no effect — and no message anywhere still recommends them
+  (grep assertion, since a stale suggestion is the likely regression).
+- **`AUTHBRIDGE_SKIP_DOWNLOAD` still works**, since installer testing depends on it.
 - **Channel switching, both directions:** release → main downloads main; main → release
   downloads the release *and* reinstalls the service (the unit's stamp differs, so
-  `serviceIsCurrent` must be false). This is the property that makes the channel safe to
-  hand to someone: the plain one-liner always returns them to releases.
-- **Workflow:** a tag push still produces assets named `_<tag>_` stamped with the tag; a
-  main push produces assets named `_main_` stamped `main-<sha>`; the rolling release is
-  flagged prerelease.
+  `serviceIsCurrent` must be false). This is what makes the channel safe to hand to
+  someone: the plain one-liner always returns them to releases.
+- **Workflow:** a tag push produces assets named `_<tag>_` stamped with the tag; a main
+  push produces `_main_` stamped `main-<sha>`, flagged prerelease; with
+  `MAIN_CHANNEL_ENABLED` unset the main job is skipped.
 
-Success: a developer runs the one-liner with `--main`, gets a merged-but-unreleased fix,
-and the default one-liner is provably unaffected.
+Success: a developer runs the one-liner with `--ref=main`, gets a merged-but-unreleased
+fix, and the default one-liner is provably unaffected — with a smaller documented surface
+than before.
 
 ## Implementation surface (summary)
 
 | File | Change |
 | --- | --- |
-| `authbridge/install.sh` | `newest_release()` filter; `--main` flag + `usage()` entry; version resolution arm; install-time reporting |
-| `.github/workflows/release-binaries.yaml` | `push: branches: [main]`; `TAG`/`VERSION` split; `main` added to the prerelease case; rolling-release notes |
+| `authbridge/install.sh` | `newest_release()` `?per_page=10` + `v[0-9]*` filter; `main` added to the version-resolution arm; remove three env vars from docs, `usage()` and read sites; rewrite three messages that advise `AUTHBRIDGE_VERSION`; demote `AUTHBRIDGE_SKIP_DOWNLOAD` to a comment; install-time build reporting |
+| `.github/workflows/release-binaries.yaml` | `push: branches: [main]` gated on `vars.MAIN_CHANNEL_ENABLED`; `TAG`/`VERSION` split; `main` added to the prerelease case; rolling-release notes |
+| `authbridge/install_test.sh` *(new)* | first committed tests for `install.sh` — fixture-driven `newest_release()` and selector cases |
+| `.github/workflows/ci.yaml` | run the new harness so it cannot rot |
 | `CONTRIBUTING.md` | document the channel, the rolling-checksum caveat, and that the plain one-liner returns you to releases |
-| `authbridge/install_test.sh` *(new)* | first committed tests for `install.sh` — fixture-driven `newest_release()` cases |
-| `.github/workflows/ci.yaml` | run the new harness, so it cannot rot |
+| `README.md` | one sentence: `--ref` now selects script *and* binaries |

--- a/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
+++ b/authbridge/docs/superpowers/specs/2026-09-09-main-channel-design.md
@@ -68,14 +68,41 @@ guard below is optional.
 
 | # | Decision | Choice |
 | --- | --- | --- |
-| D1 | Publishing mechanism | **One rolling pre-release** tagged `main`, assets overwritten each push. Reuses the existing `releases/download/<tag>` URL shape, so the download path is unchanged. |
+| D1 | Publishing mechanism | **One rolling pre-release** tagged `main-latest`, assets overwritten each push. Reuses the existing `releases/download/<tag>` URL shape, so the download path is unchanged. **Amended during implementation — see D9.** |
 | D2 | Trigger | **Every push to `main`.** A merged fix is installable minutes later — the motivating case. |
 | D3 | Selection | **One selector: `--ref=X` means "install X"** — script *and* binaries — for every X, including `main`. No new flag. |
-| D4 | Build identity | Asset names use the tag (`main`); the binary is stamped `main-<short-sha>`. The two deliberately disagree. |
+| D4 | Build identity | Asset names use the release tag (`main-latest`); the binary is stamped `main-<short-sha>`. The two deliberately disagree. |
 | D5 | Default resolution | `newest_release()` fetches `?per_page=10` and returns the first tag matching `v[0-9]*`, ignoring the channel entirely. |
 | D6 | Workflow home | **Extend `release-binaries.yaml`** rather than add a second workflow. |
 | D7 | Knob cleanup | Remove `AUTHBRIDGE_REF`, `AUTHBRIDGE_INSTALL_ONLY`, `AUTHBRIDGE_VERSION`. Keep `AUTHBRIDGE_SKIP_DOWNLOAD` (undocumented, maintainer) and `AUTHBRIDGE_SCRIPT_REF` (internal). |
 | D8 | First publish | Gated on repo variable `MAIN_CHANNEL_ENABLED`, unset by default — this is what lets everything ship in one PR safely (see Sequencing). |
+| D9 | Channel tag name | **`main-latest`, not `main`** — a release needs a git tag, and a tag named `main` collides with the branch. Added during implementation; supersedes D1's original name. |
+
+**On D9 (added during implementation).** D1 originally named the rolling tag
+`main`. That does not work: a GitHub release requires a git tag, so it would have
+created a tag named `main` beside the branch of the same name. Verified
+consequences —
+
+- `git rev-parse main` resolves to the **tag**, not the branch: git's ref
+  precedence puts `refs/tags/` first. Anything treating `main` as a revision
+  silently reads the wrong commit, including the worktree bootstrap in the root
+  `CLAUDE.md`.
+- every git command against the repo prints `warning: refname 'main' is
+  ambiguous` — permanently, for every contributor.
+- the tag would freeze at the first publish. `gh release upload --clobber`
+  replaces assets and never moves the tag, so it drifts further from the branch
+  on every merge.
+- unverified but plausible: the bootstrap fetches
+  `raw.githubusercontent.com/<repo>/main/authbridge/install.sh`. If GitHub
+  resolves that tag-first the way git does, `--ref=main` would fetch a frozen
+  script forever — the channel would appear to work and silently serve a stale
+  installer. Confirming it would have required creating the colliding tag on a
+  real repo.
+
+Only the tag changes. `--ref=main` remains what a developer types;
+`resolve_version` maps it to `CHANNEL_TAG` (`install.sh`), and the CI workflow
+must use the same string. The test suite reads the constant out of `install.sh`
+rather than restating it, so a rename cannot leave a stale expectation passing.
 
 **On D3.** `--ref` is inconsistent *today*: `--ref=v0.7.0-alpha.4` sets both halves
 (`v*) version="${SCRIPT_REF}"`), while `--ref=main` sets only the script because there is

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -206,6 +206,27 @@ newest_release() {
 	printf '%s\n' "${_tag}"
 }
 
+# resolve_version prints the release tag whose binaries should be installed, given
+# the ref this script came from.
+#
+# One rule: --ref=X installs X. That was not true before — `--ref=v0.7.0-alpha.4`
+# set script and binaries, while `--ref=main` set only the script, because there
+# was no `main` release to download from. Now that the developer channel publishes
+# one, the special case disappears rather than growing a second flag.
+resolve_version() { # script_ref
+	case "$1" in
+		v*|main) printf '%s\n' "$1" ;;
+		*)
+			# >&2 deliberately: this function's stdout IS the resolved version, and
+			# info() writes to stdout (see its definition above). Without the
+			# redirect the progress line lands inside `version` and corrupts every
+			# download URL.
+			info "Resolving newest release..." >&2
+			newest_release || return 1
+			;;
+	esac
+}
+
 # ere_escape quotes the ERE metacharacters in a literal so it matches exactly.
 # Archive names contain dots, and an unescaped "." matches any character: the
 # pattern for abctl_v0.7.0-alpha.3_..tar.gz also accepted
@@ -374,19 +395,10 @@ if [ "${AUTHBRIDGE_SKIP_DOWNLOAD:-}" = "1" ]; then
 else
 
 # --- resolve the release tag ---
-version="${AUTHBRIDGE_VERSION:-}"
-if [ -z "$version" ]; then
-	# Default the binaries to the same release this script came from, so the
-	# script and the binaries it installs are one tested set rather than two
-	# independently-moving things.
-	case "${SCRIPT_REF}" in
-		v*) version="${SCRIPT_REF}" ;;
-		*)
-			info "Resolving newest release..."
-			version=$(newest_release) || die "could not resolve the newest release (set AUTHBRIDGE_VERSION=vX.Y.Z)"
-			;;
-	esac
-fi
+# The binaries default to the same ref this script came from, so the script and the
+# binaries it installs are one tested set rather than two independently-moving things.
+version=$(resolve_version "${SCRIPT_REF}") \
+	|| die "could not resolve the newest release (pass --ref=vX.Y.Z to pin one)"
 
 # --- download + verify ---
 tmp=$(mktemp -d)

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -33,19 +33,17 @@
 # --demo -> --local alias is different: that flag really did ship.)
 #
 # Flags rather than env vars: written `VAR=1 curl ... | sh` the variable reaches
-# curl, not sh, so the script runs without it. `sh -s -- --flag` has no such
-# failure mode. The env vars below still work.
+# curl, not sh, so the script runs without it — the failure mode is silent, and
+# `sh -s -- --flag` does not have it. That is why the env aliases for --ref and
+# --install-only were removed rather than kept as a second spelling: they were the
+# form most likely to be typed and least likely to work.
 #
 # By default this script re-runs the copy from the newest RELEASE rather than
 # executing whatever is currently on main — main is unstable by definition, and a
 # `curl | sh` should not be the first thing to run a change nobody has released.
 # --ref=main opts back in; --ref=vX.Y.Z pins.
 #
-# Environment:
-#   AUTHBRIDGE_REF=REF          same as --ref
-#   AUTHBRIDGE_VERSION=vX.Y.Z   install binaries from a specific release
-#                               (default: the release this script came from)
-#   AUTHBRIDGE_INSTALL_ONLY=1   same as --install-only
+# Environment (maintainer testing only — not part of the documented interface):
 #   AUTHBRIDGE_SKIP_DOWNLOAD=1  use the already-installed binaries in ~/.local/bin
 #                               instead of downloading (re-run setup offline)
 # set -eu, not -euo pipefail: this is POSIX sh (the documented entry point is
@@ -104,17 +102,10 @@ Options:
                    it runs as plain `claude` with no environment variables
   --local          the default, spelled out
   --yes, -y        do not prompt; answer yes to configuring Claude Code
-  --ref=REF        take THIS SCRIPT from a git ref instead of the newest release
-                   (e.g. --ref=main for unreleased changes, --ref=v0.7.0-alpha.4
-                   to pin). Binaries come from the same release unless
-                   AUTHBRIDGE_VERSION says otherwise.
+  --ref=REF        install from a git ref instead of the newest release — both
+                   this script and the binaries (e.g. --ref=main for unreleased
+                   changes, --ref=v0.7.0-alpha.4 to pin)
   -h, --help       this text
-
-Environment:
-  AUTHBRIDGE_VERSION=vX.Y.Z   install a specific release tag (default: newest)
-  AUTHBRIDGE_INSTALL_ONLY=1   same as --install-only
-  AUTHBRIDGE_SKIP_DOWNLOAD=1  use the binaries already in ~/.local/bin instead of
-                              downloading (re-run setup offline)
 
 After installing, to cut Claude Code's token cost:
   abctl tools scan --write ~/.cortex/config.yaml
@@ -125,12 +116,13 @@ USAGE
 MODE=local
 WIRE_CLAUDE_CODE=""
 ASSUME_YES=""
+WANT_REF=""
 for arg in "$@"; do
 	case "$arg" in
 		--install-only) MODE=install-only ;;
 		--claude-code) WIRE_CLAUDE_CODE=1 ;;
 		--yes | -y) ASSUME_YES=1 ;;
-		--ref=*) AUTHBRIDGE_REF="${arg#*=}" ;;
+		--ref=*) WANT_REF="${arg#*=}" ;;
 		# --local is the default; accepted so writing it out explicitly works, and
 		# so it mirrors the proxy flag of the same name.
 		--local) MODE=local ;;
@@ -141,11 +133,6 @@ for arg in "$@"; do
 		*) die "unknown option: $arg (try --claude-code, --install-only, --local, --ref=REF, --yes, or no argument)" ;;
 	esac
 done
-# Env form kept working; the flag wins if both are given.
-if [ "${AUTHBRIDGE_INSTALL_ONLY:-}" = "1" ] && [ "$MODE" = "local" ]; then
-	MODE=install-only
-fi
-
 command -v curl >/dev/null 2>&1 || die "curl is required"
 command -v tar  >/dev/null 2>&1 || die "tar is required"
 
@@ -248,7 +235,7 @@ ere_escape() {
 # the child sees it set and does not bootstrap again.
 SCRIPT_REF="${AUTHBRIDGE_SCRIPT_REF:-}"
 if [ -z "${SCRIPT_REF}" ]; then
-	want_ref="${AUTHBRIDGE_REF:-}"
+	want_ref="${WANT_REF:-}"
 	if [ -z "${want_ref}" ]; then
 		want_ref="$(newest_release)" || true
 	fi
@@ -613,12 +600,12 @@ if ! "${BIN_DIR}/abctl" service status >/dev/null 2>&1 &&
   in order to start Cortex. Either use the installer that shipped with it:
     curl -fsSL https://raw.githubusercontent.com/${REPO}/${version}/authbridge/install.sh | sh
   or install newer binaries with this script:
-    AUTHBRIDGE_VERSION=<newer tag>"
+    --ref=<newer tag>"
 			;;
 		*)
 			die "the abctl in ${BIN_DIR} has no 'service' command, which this installer
   needs in order to start Cortex. Install a newer one — drop
-  AUTHBRIDGE_SKIP_DOWNLOAD, or point AUTHBRIDGE_VERSION at a release that has it."
+  AUTHBRIDGE_SKIP_DOWNLOAD, or pass --ref=<a release that has it>."
 			;;
 	esac
 fi

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -149,11 +149,11 @@ fi
 command -v curl >/dev/null 2>&1 || die "curl is required"
 command -v tar  >/dev/null 2>&1 || die "tar is required"
 
-# newest_release prints the newest release tag, prereleases included.
+# newest_release prints the newest VERSION release tag, prereleases included.
 # `releases/latest` excludes prereleases and this project ships them, so list
-# releases (newest first) and take the first tag_name.
+# releases (newest first) and take the first tag that looks like a version.
 newest_release() {
-	# Three steps, each doing one thing that cannot silently go wrong:
+	# Four steps, each doing one thing that cannot silently go wrong:
 	#
 	#   tr ',{}' '\n'   put every JSON field on its own line, so nothing greedy can
 	#                   run past the field it was aimed at. Without this the old
@@ -161,34 +161,47 @@ newest_release() {
 	#                   against a COMPACT response the whole array is one line, the
 	#                   greedy .* runs to the LAST tag_name, and it returns the OLDEST
 	#                   release. Verified — it yields v0.3.1 from compact JSON.
-	#   grep -m1 ...    match tag_name only where it is a KEY (anchored, colon after).
+	#   grep '"tag_name":'
+	#                   match tag_name only where it is a KEY (anchored, colon after).
 	#                   An unanchored match is hijacked by any release whose name or
 	#                   body contains the text "tag_name", and release bodies are ours
-	#                   to author.
+	#                   to author. Every tag, not just the first — the -m1 belongs on
+	#                   the value filter below, so that what gets picked is the first
+	#                   VERSION tag rather than merely the first tag.
 	#   cut -d'"' -f4   take the value by position, not by pattern.
+	#   grep -m1 '^v[0-9]'
+	#                   the developer channel's rolling `main` release sorts first
+	#                   until the next tagged release (the API sorts by created_at,
+	#                   which is fixed at creation). Taking the first entry blindly
+	#                   would hand `main` to someone who never asked for it, and the
+	#                   shape check below would then reject it and kill the install
+	#                   outright. Skipping non-version tags keeps the channel
+	#                   invisible to the default path.
 	#
-	# Then check the shape: a tag looks like v<digit>... Anything else means the API
-	# returned something we did not expect — an error page, a rate-limit body, a schema
-	# change — and the right move is to say so, not to build a download URL out of it.
-	# This is the difference that matters: a surprise becomes an error instead of a
-	# wrong answer.
+	# ?per_page=10 for the same reason: one page has to contain a version tag even
+	# with rolling releases ahead of it. Ten is headroom, not a calculation — there is
+	# one rolling release, so two would do.
+	#
+	# The shape check is now a backstop rather than the filter. Reaching it with a
+	# non-version tag is impossible; reaching it EMPTY is not, and means no version tag
+	# in ten releases — an error page, a rate-limit body, a schema change. Fail rather
+	# than build a download URL out of it. No warning here: the only reachable failure
+	# is "nothing matched", and naming `main` at someone who never mentioned it is
+	# noise. The caller already dies with actionable advice.
 	#
 	# Not jq (not installed everywhere) and not gh (a far larger dependency than a
 	# curl|sh installer should require; this script needs curl, tar and a checksum tool).
 	# Not /releases/latest either: it excludes prereleases, and this project ships them,
 	# so it names a tag from January. Listing releases asks what we actually mean — the
 	# newest release, whatever its flags.
-	_tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1" 2>/dev/null \
+	_tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=10" 2>/dev/null \
 		| tr ',{}' '\n' \
-		| grep -m1 '^[[:space:]]*"tag_name"[[:space:]]*:' \
-		| cut -d'"' -f4)
+		| grep '^[[:space:]]*"tag_name"[[:space:]]*:' \
+		| cut -d'"' -f4 \
+		| grep -m1 '^v[0-9]')
 	case "${_tag}" in
 		v[0-9]*) ;;
-		'') return 1 ;;
-		*)
-			warn "the release API returned an unexpected tag: ${_tag}"
-			return 1
-			;;
+		*) return 1 ;;
 	esac
 	printf '%s\n' "${_tag}"
 }

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -142,6 +142,16 @@ for arg in "$@"; do
 		*) die "unknown option: $arg (try --claude-code, --install-only, --local, --ref=REF, --yes, or no argument)" ;;
 	esac
 done
+# Removed knobs die rather than being ignored. Left set in someone's shell,
+# AUTHBRIDGE_INSTALL_ONLY=1 would silently do a FULL install and AUTHBRIDGE_VERSION
+# would silently install the newest release instead of the pin. Both are wrong answers,
+# and this script's whole standard is that a surprise becomes an error instead. Each
+# message names the flag that replaced it, echoing the value back so the fix is
+# copy-pasteable.
+[ -z "${AUTHBRIDGE_INSTALL_ONLY:-}" ] || die "AUTHBRIDGE_INSTALL_ONLY is no longer read. Pass --install-only instead."
+[ -z "${AUTHBRIDGE_VERSION:-}" ] || die "AUTHBRIDGE_VERSION is no longer read. Pass --ref=${AUTHBRIDGE_VERSION} instead."
+[ -z "${AUTHBRIDGE_REF:-}" ] || die "AUTHBRIDGE_REF is no longer read. Pass --ref=${AUTHBRIDGE_REF} instead."
+
 command -v curl >/dev/null 2>&1 || die "curl is required"
 command -v tar  >/dev/null 2>&1 || die "tar is required"
 
@@ -202,14 +212,16 @@ newest_release() {
 	printf '%s\n' "${_tag}"
 }
 
-# resolve_version prints the release tag whose binaries should be installed, given
-# the ref this script came from.
+# resolve_version prints the release tag whose binaries should be installed, given the
+# ref the USER asked to install (VERSION_REF). Not the ref this script came from —
+# conflating those two is what let the default one-liner reach the channel, so the
+# distinction is worth keeping visible in the name.
 #
 # One rule: --ref=X installs X. That was not true before — `--ref=v0.7.0-alpha.4`
 # set script and binaries, while `--ref=main` set only the script, because there
 # was no `main` release to download from. Now that the developer channel publishes
 # one, the special case disappears rather than growing a second flag.
-resolve_version() { # script_ref
+resolve_version() { # version_ref
 	# Takes VERSION_REF, not SCRIPT_REF. Empty means "nobody named anything
 	# installable" — resolve the newest release, and fail loudly if that is not
 	# possible. It must never mean "fall back to the channel": rate limiting alone
@@ -223,6 +235,13 @@ resolve_version() { # script_ref
 		main | "${CHANNEL_TAG}") printf '%s\n' "${CHANNEL_TAG}" ;;
 		v*) printf '%s\n' "$1" ;;
 		*)
+			# A ref that is neither channel nor release tag: a branch, or a SHA. No
+			# binaries are published for those, so the newest release is the only
+			# option — but say so. Silent, this is byte-identical to the plain
+			# one-liner, and someone testing a feature branch gets that branch's
+			# SCRIPT against release BINARIES with nothing to attribute it to. Same
+			# principle the 404 fallback states: name the surprise.
+			[ -z "$1" ] || warn "no binaries are published for ${1}; using this script from ${1} with binaries from the newest release"
 			# >&2 deliberately: this function's stdout IS the resolved version, and
 			# info() writes to stdout (see its definition above). Without the
 			# redirect the progress line lands inside `version` and corrupts every

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -210,20 +210,17 @@ newest_release() {
 # was no `main` release to download from. Now that the developer channel publishes
 # one, the special case disappears rather than growing a second flag.
 resolve_version() { # script_ref
-	# Only an EXPLICIT --ref=main selects channel binaries. The bootstrap also sets
-	# SCRIPT_REF=main when it falls back to this copy — API unreachable, or the release
-	# it wanted has no install.sh. That means "run main's script", not "install main's
-	# binaries", and conflating the two hands an unreleased build to someone who asked
-	# for a release. Rate limiting makes that path reachable, not theoretical.
+	# Takes VERSION_REF, not SCRIPT_REF. Empty means "nobody named anything
+	# installable" — resolve the newest release, and fail loudly if that is not
+	# possible. It must never mean "fall back to the channel": rate limiting alone
+	# would then hand unreleased builds to people who ran the plain one-liner.
 	#
-	# The assets live on CHANNEL_TAG, not on a tag called `main` — see its definition
-	# for why. The ref someone types, the tag the assets hang off, and the binary's own
-	# stamp are three different strings, deliberately.
-	if [ "$1" = "main" ] && [ "${CHANNEL_REQUESTED:-}" = "1" ]; then
-		printf '%s\n' "${CHANNEL_TAG}"
-		return 0
-	fi
+	# Both channel spellings land on CHANNEL_TAG. The assets live there rather than on
+	# a tag called `main` — see its definition for why — so the ref someone types, the
+	# tag the assets hang off, and the binary's own stamp are three different strings,
+	# deliberately.
 	case "$1" in
+		main | "${CHANNEL_TAG}") printf '%s\n' "${CHANNEL_TAG}" ;;
 		v*) printf '%s\n' "$1" ;;
 		*)
 			# >&2 deliberately: this function's stdout IS the resolved version, and
@@ -256,6 +253,12 @@ ere_escape() {
 # SCRIPT_REF names the ref this copy came from and doubles as the recursion guard:
 # the child sees it set and does not bootstrap again.
 SCRIPT_REF="${AUTHBRIDGE_SCRIPT_REF:-}"
+# VERSION_REF answers "what did the user ask to INSTALL". SCRIPT_REF answers a
+# different question — "which copy of this script is running" — and the two diverge on
+# every fallback below. Reading one for the other is how the default one-liner ended up
+# able to install channel binaries: three separate situations all set SCRIPT_REF=main,
+# and only one of them was a request for unreleased builds.
+VERSION_REF="${SCRIPT_REF}"
 if [ -z "${SCRIPT_REF}" ]; then
 	want_ref="${WANT_REF:-}"
 	if [ -z "${want_ref}" ]; then
@@ -264,16 +267,19 @@ if [ -z "${SCRIPT_REF}" ]; then
 	if [ -z "${want_ref}" ]; then
 		# Could not ask: offline, rate-limited, 5xx. Fall back to THIS copy of the
 		# script, but deliberately NOT to channel binaries. Whoever ran the plain
-		# one-liner asked for a release, so CHANNEL_REQUESTED stays unset and version
-		# resolution below still hunts for the newest v-tag — failing loudly if it
-		# cannot find one, which beats silently installing an unreleased build.
+		# one-liner asked for a release, so VERSION_REF is cleared and resolution below
+		# still hunts for the newest v-tag — failing loudly if it cannot find one,
+		# which beats silently installing an unreleased build.
 		warn "could not resolve the newest release; continuing with the copy from main"
 		SCRIPT_REF="main"
-	elif [ "${want_ref}" = "main" ]; then
-		# Explicitly asked for main: this copy already is main, and channel binaries
-		# are what was requested. This is the ONLY branch that sets CHANNEL_REQUESTED.
+		VERSION_REF=""
+	elif [ "${want_ref}" = "main" ] || [ "${want_ref}" = "${CHANNEL_TAG}" ]; then
+		# Explicitly asked for the channel, by either name. `main` is the documented
+		# spelling; CHANNEL_TAG is what the Releases page shows, so someone who saw the
+		# title there will type that instead and must get the same thing. This copy
+		# already is main, so there is nothing to re-exec.
 		SCRIPT_REF="main"
-		CHANNEL_REQUESTED=1
+		VERSION_REF="main"
 	else
 		# Rebuild the argument list without --ref: it is meta, consumed here, and a
 		# released script from before --ref existed rejects it as an unknown option.
@@ -319,11 +325,13 @@ if [ -z "${SCRIPT_REF}" ]; then
 			# A release from before this script existed under that name. Falling
 			# back beats refusing to install, but name the copy that is running so
 			# a surprise is attributable.
-			# Same reasoning as the unreachable-API fallback above: running main's
-			# SCRIPT is the fallback, installing main's BINARIES is not.
-			# CHANNEL_REQUESTED stays unset.
+			#
+			# VERSION_REF keeps the pin: running main's SCRIPT is the fallback,
+			# changing which BINARIES get installed is not. `--ref=X installs X`
+			# has to survive this branch or the flag means nothing here.
 			warn "${want_ref} has no authbridge/install.sh (HTTP 404); continuing with the copy from main"
 			SCRIPT_REF="main"
+			VERSION_REF="${want_ref}"
 		else
 			# Blocked, offline, rate-limited, proxied, 5xx. We cannot tell whether a
 			# released installer exists, so do not quietly run main instead.
@@ -416,7 +424,7 @@ else
 # --- resolve the release tag ---
 # The binaries default to the same ref this script came from, so the script and the
 # binaries it installs are one tested set rather than two independently-moving things.
-version=$(resolve_version "${SCRIPT_REF}") \
+version=$(resolve_version "${VERSION_REF}") \
 	|| die "could not resolve the newest release (pass --ref=vX.Y.Z to pin one)"
 
 # --- download + verify ---

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -52,6 +52,15 @@
 set -eu
 
 REPO="rossoctl/cortex"
+# CHANNEL_TAG is the release the developer channel's assets hang off. Deliberately
+# NOT "main": a GitHub release needs a git tag, and a tag named `main` would collide
+# with the branch. Verified consequences of that collision — `git rev-parse main`
+# resolves to the TAG, not the branch, and every git command warns "refname 'main' is
+# ambiguous". The tag would also freeze at the first publish (uploading assets does
+# not move it) while the branch moved on, so anything resolving `main` as a revision
+# would silently read a stale commit. `--ref=main` is still what people type; only
+# the tag underneath differs.
+CHANNEL_TAG="main-latest"
 BIN_DIR="${HOME}/.local/bin"
 # Every file Cortex writes for this user lives here: config, CA, keys, logs,
 # pidfiles. One directory to inspect, back up, or delete.
@@ -202,7 +211,11 @@ newest_release() {
 # one, the special case disappears rather than growing a second flag.
 resolve_version() { # script_ref
 	case "$1" in
-		v*|main) printf '%s\n' "$1" ;;
+		# The channel's assets live on CHANNEL_TAG, not on a tag called `main` —
+		# see its definition for why. The ref someone types and the tag the assets
+		# hang off are allowed to differ; the binary stamp differs from both.
+		main) printf '%s\n' "${CHANNEL_TAG}" ;;
+		v*) printf '%s\n' "$1" ;;
 		*)
 			# >&2 deliberately: this function's stdout IS the resolved version, and
 			# info() writes to stdout (see its definition above). Without the

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -210,11 +210,20 @@ newest_release() {
 # was no `main` release to download from. Now that the developer channel publishes
 # one, the special case disappears rather than growing a second flag.
 resolve_version() { # script_ref
+	# Only an EXPLICIT --ref=main selects channel binaries. The bootstrap also sets
+	# SCRIPT_REF=main when it falls back to this copy — API unreachable, or the release
+	# it wanted has no install.sh. That means "run main's script", not "install main's
+	# binaries", and conflating the two hands an unreleased build to someone who asked
+	# for a release. Rate limiting makes that path reachable, not theoretical.
+	#
+	# The assets live on CHANNEL_TAG, not on a tag called `main` — see its definition
+	# for why. The ref someone types, the tag the assets hang off, and the binary's own
+	# stamp are three different strings, deliberately.
+	if [ "$1" = "main" ] && [ "${CHANNEL_REQUESTED:-}" = "1" ]; then
+		printf '%s\n' "${CHANNEL_TAG}"
+		return 0
+	fi
 	case "$1" in
-		# The channel's assets live on CHANNEL_TAG, not on a tag called `main` —
-		# see its definition for why. The ref someone types and the tag the assets
-		# hang off are allowed to differ; the binary stamp differs from both.
-		main) printf '%s\n' "${CHANNEL_TAG}" ;;
 		v*) printf '%s\n' "$1" ;;
 		*)
 			# >&2 deliberately: this function's stdout IS the resolved version, and
@@ -253,11 +262,18 @@ if [ -z "${SCRIPT_REF}" ]; then
 		want_ref="$(newest_release)" || true
 	fi
 	if [ -z "${want_ref}" ]; then
+		# Could not ask: offline, rate-limited, 5xx. Fall back to THIS copy of the
+		# script, but deliberately NOT to channel binaries. Whoever ran the plain
+		# one-liner asked for a release, so CHANNEL_REQUESTED stays unset and version
+		# resolution below still hunts for the newest v-tag — failing loudly if it
+		# cannot find one, which beats silently installing an unreleased build.
 		warn "could not resolve the newest release; continuing with the copy from main"
 		SCRIPT_REF="main"
 	elif [ "${want_ref}" = "main" ]; then
-		# Explicitly asked for main: this copy already is main.
+		# Explicitly asked for main: this copy already is main, and channel binaries
+		# are what was requested. This is the ONLY branch that sets CHANNEL_REQUESTED.
 		SCRIPT_REF="main"
+		CHANNEL_REQUESTED=1
 	else
 		# Rebuild the argument list without --ref: it is meta, consumed here, and a
 		# released script from before --ref existed rejects it as an unknown option.
@@ -303,6 +319,9 @@ if [ -z "${SCRIPT_REF}" ]; then
 			# A release from before this script existed under that name. Falling
 			# back beats refusing to install, but name the copy that is running so
 			# a surprise is attributable.
+			# Same reasoning as the unreachable-API fallback above: running main's
+			# SCRIPT is the fallback, installing main's BINARIES is not.
+			# CHANNEL_REQUESTED stays unset.
 			warn "${want_ref} has no authbridge/install.sh (HTTP 404); continuing with the copy from main"
 			SCRIPT_REF="main"
 		else

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -194,5 +194,20 @@ set -e
 check "stdout carries no progress text" "1" "$(printf '%s\n' "${_out}" | wc -l | tr -d ' ')"
 check "stdout is exactly the version" "v0.7.0-alpha.7" "${_out}"
 
+# --- removed knobs leave no stale advice ---
+#
+# The failure mode is not "the var still works" — it is a message telling someone
+# to set a var the script no longer reads. Three sites advised AUTHBRIDGE_VERSION.
+
+for _v in AUTHBRIDGE_VERSION AUTHBRIDGE_REF AUTHBRIDGE_INSTALL_ONLY; do
+	_hits=$(grep -c "${_v}" "${INSTALL_SH}" || true)
+	check "${_v} is gone from install.sh entirely" "0" "${_hits}"
+done
+
+for _v in AUTHBRIDGE_SKIP_DOWNLOAD AUTHBRIDGE_SCRIPT_REF; do
+	_hits=$(grep -c "${_v}" "${INSTALL_SH}" || true)
+	check_fails "${_v} is still present" "${_hits}"
+done
+
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -340,5 +340,32 @@ check "--ref=v0.5.0 with a transport failure refuses to run main" \
 check "--ref=v0.5.0 with a 200 script re-execs into it" \
 	"REEXECED" "$(with_bootstrap v0.5.0 200 v0.7.0-alpha.7)"
 
+# --- the channel tag is one string, in two files ---
+#
+# install.sh owns CHANNEL_TAG and every test above reads it out of the script rather than
+# restating it, so a rename cannot leave a stale expectation passing. That discipline
+# stopped at the workflow boundary: CI had its own bare literal with a comment asking a
+# human to keep them equal. Rename CHANNEL_TAG and every test here would still pass while
+# the channel broke in the only way users see — the installer requesting main-next_*
+# assets from a release publishing main-latest_*, i.e. a 404 on download.
+#
+# The workflow is also where the one destructive operation lives: the tag move is guarded
+# by that same literal, so a drift makes a v* release movable.
+WORKFLOW="${SCRIPT_DIR}/../.github/workflows/release-binaries.yaml"
+if [ -f "${WORKFLOW}" ]; then
+	check "CI publishes the tag install.sh asks for" "1" \
+		"$(grep -c "TAG=\"${CHANNEL_TAG}\"" "${WORKFLOW}" || true)"
+	# Every `[ "${TAG}" = ... ]` in the workflow must name CHANNEL_TAG. Counting matches
+	# would be brittle — there are legitimately two today, the release-notes switch and
+	# the tag-move guard — so assert the absence of any comparison against a DIFFERENT
+	# literal instead. That is the invariant: no branch keyed on a stale channel name.
+	check "no TAG comparison names a different tag" "0" \
+		"$(grep -oE '\[ "\$\{TAG\}" = "[^"]*" \]' "${WORKFLOW}" | grep -cv "\"${CHANNEL_TAG}\"" || true)"
+	check "at least one TAG comparison names CHANNEL_TAG" "1" \
+		"$(grep -oE '\[ "\$\{TAG\}" = "[^"]*" \]' "${WORKFLOW}" | grep -c "\"${CHANNEL_TAG}\"" | awk '$1>0{print 1; exit} {print 0}')"
+else
+	check "release-binaries.yaml is where expected" "found" "missing at ${WORKFLOW}"
+fi
+
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -149,5 +149,50 @@ _st=0; _out=$(with_newest_release "${FIXTURE}") || _st=$?
 set -e
 check_fails "an empty body fails" "${_st}"
 
+# --- resolve_version: --ref=X selects binaries too ---
+#
+# --ref was inconsistent: `--ref=v0.7.0-alpha.4` set script AND binaries, while
+# `--ref=main` set only the script, because there was no main release to download
+# from. One rule now covers both.
+
+with_resolve_version() { # script_ref fixture-path
+	_ref=$1; _f=$2
+	{
+		printf 'REPO=rossoctl/cortex\n'
+		printf 'warn() { printf "warning: %%s\\n" "$*" >&2; }\n'
+		printf 'die() { printf "error: %%s\\n" "$*" >&2; exit 1; }\n'
+		# info() is stubbed to match install.sh's definition EXACTLY — stdout, not
+		# stderr. Stubbing it silent (`info() { :; }`) would leave the
+		# "stdout carries no progress text" case below unable to fail, which is the
+		# one thing it exists to catch.
+		printf 'info() { printf "%%s\\n" "$*"; }\n'
+		printf 'curl() { cat "%s"; }\n' "${_f}"
+		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
+		sed -n '/^resolve_version()/,/^}/p' "${INSTALL_SH}"
+		printf 'resolve_version "%s"\n' "${_ref}"
+	} >"${TMP}/rv.sh"
+	sh "${TMP}/rv.sh" 2>/dev/null
+}
+
+fixture rv_releases.json <<'EOF'
+[{"tag_name":"main"},{"tag_name":"v0.7.0-alpha.7"}]
+EOF
+check "--ref=main installs main binaries" "main" "$(with_resolve_version main "${FIXTURE}")"
+check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
+check "no ref resolves the newest v-tag" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
+
+# stdout must be the version and nothing else. info() writes to stdout
+# (install.sh:81), so an un-redirected progress line inside resolve_version would be
+# captured into $version and corrupt every download URL — a one-line mistake that
+# breaks every install and no other test would catch.
+# set +e around the capture: under `set -e` a bare assignment from a failing command
+# substitution aborts the whole suite, so a regression that broke resolve_version
+# would kill the run at this line instead of reporting a FAIL and carrying on.
+set +e
+_out=$(with_resolve_version "" "${FIXTURE}")
+set -e
+check "stdout carries no progress text" "1" "$(printf '%s\n' "${_out}" | wc -l | tr -d ' ')"
+check "stdout is exactly the version" "v0.7.0-alpha.7" "${_out}"
+
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Tests for authbridge/install.sh.
+#
+# install.sh is a curl|sh entry point, so its failure modes are other people's
+# first experience of Cortex. Until this file existed the only automated check was
+# `shellcheck --severity=error`, which is why the tag-parser bug (returning the
+# OLDEST release from compact JSON) shipped in #902 without a test.
+#
+# Approach: source a single function out of install.sh with `curl` replaced by one
+# that prints a fixture. No network, no GitHub, no downloads. Plain POSIX sh
+# because the repo has no bats or shunit2 and a framework is not worth it for a
+# handful of functions.
+#
+# Run: sh authbridge/install_test.sh
+set -eu
+
+# shellcheck disable=SC1007 # `CDPATH= cd` is deliberate, not a typo: it empties
+# CDPATH for this one command. The documented invocation is `sh
+# authbridge/install_test.sh`, so $0 is RELATIVE — with a CDPATH set, `cd` can
+# resolve it against a CDPATH entry and land somewhere else entirely.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INSTALL_SH="${SCRIPT_DIR}/install.sh"
+[ -f "${INSTALL_SH}" ] || { printf 'cannot find %s\n' "${INSTALL_SH}" >&2; exit 1; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "${TMP}"' EXIT
+
+PASS=0
+FAIL=0
+
+check() { # label expected actual
+	if [ "$2" = "$3" ]; then
+		PASS=$((PASS + 1))
+		printf '  ok   %s\n' "$1"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL %s\n       expected %s\n       actual   %s\n' "$1" "$2" "$3"
+	fi
+}
+
+check_fails() { # label status
+	if [ "$2" != "0" ]; then
+		PASS=$((PASS + 1))
+		printf '  ok   %s (exit %s)\n' "$1" "$2"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL %s: expected non-zero exit, got 0\n' "$1"
+	fi
+}
+
+fixture() { # name; body on stdin. Sets $FIXTURE to the path.
+	FIXTURE="${TMP}/$1"
+	cat >"${FIXTURE}"
+}
+
+# with_newest_release runs install.sh's newest_release() against a fixture.
+#
+# The function is extracted by line range rather than sourcing install.sh, because
+# sourcing would run the whole installer. `curl` is replaced by a function so the
+# extracted code is unmodified — testing what ships, not a copy of it.
+with_newest_release() { # fixture-path
+	_f=$1
+	{
+		printf 'REPO=rossoctl/cortex\n'
+		printf 'warn() { printf "warning: %%s\\n" "$*" >&2; }\n'
+		printf 'curl() { cat "%s"; }\n' "${_f}"
+		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
+		printf 'newest_release\n'
+	} >"${TMP}/probe.sh"
+	sh "${TMP}/probe.sh" 2>/dev/null
+}
+
+printf 'install.sh tests\n'
+
+# --- newest_release: the shape it is documented to handle ---
+
+fixture pretty.json <<'EOF'
+[
+  {
+    "tag_name": "v0.7.0-alpha.7",
+    "name": "v0.7.0-alpha.7"
+  },
+  {
+    "tag_name": "v0.3.1"
+  }
+]
+EOF
+check "pretty JSON resolves the newest tag" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+fixture compact.json <<'EOF'
+[{"tag_name":"v0.7.0-alpha.7"},{"tag_name":"v0.7.0-alpha.6"},{"tag_name":"v0.3.1"}]
+EOF
+check "compact JSON resolves the newest tag, not the oldest" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" = "0" ]

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -155,8 +155,8 @@ check_fails "an empty body fails" "${_st}"
 # `--ref=main` set only the script, because there was no main release to download
 # from. One rule now covers both.
 
-with_resolve_version() { # script_ref fixture-path
-	_ref=$1; _f=$2
+with_resolve_version() { # script_ref fixture-path [channel_requested]
+	_ref=$1; _f=$2; _req=${3:-}
 	{
 		printf 'REPO=rossoctl/cortex\n'
 		# CHANNEL_TAG is read out of install.sh, not restated here, so this probe
@@ -172,6 +172,7 @@ with_resolve_version() { # script_ref fixture-path
 		printf 'curl() { cat "%s"; }\n' "${_f}"
 		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
 		sed -n '/^resolve_version()/,/^}/p' "${INSTALL_SH}"
+		printf 'CHANNEL_REQUESTED=%s\n' "${_req}"
 		printf 'resolve_version "%s"\n' "${_ref}"
 	} >"${TMP}/rv.sh"
 	sh "${TMP}/rv.sh" 2>/dev/null
@@ -186,7 +187,15 @@ EOF
 # hardcode it, or renaming the channel silently passes a stale test.
 CHANNEL_TAG=$(sed -n 's/^CHANNEL_TAG="\(.*\)"$/\1/p' "${INSTALL_SH}")
 check "install.sh defines a non-colliding CHANNEL_TAG" "1" "$(printf '%s' "${CHANNEL_TAG}" | grep -c '^main-' || true)"
-check "--ref=main installs the channel tag" "${CHANNEL_TAG}" "$(with_resolve_version main "${FIXTURE}")"
+check "--ref=main installs the channel tag" "${CHANNEL_TAG}" "$(with_resolve_version main "${FIXTURE}" 1)"
+
+# The bootstrap sets SCRIPT_REF=main for TWO other reasons: the release API was
+# unreachable, and the wanted release has no install.sh. Both mean "run main's script";
+# neither means "install main's binaries". Without this distinction a rate-limited user
+# who ran the plain one-liner silently received an unreleased build — and rate limiting
+# is reachable, not theoretical. Guarding on the literal "main" alone is what caused it,
+# so the test pins the fallback, not just the happy path.
+check "fallback to main's script still installs a RELEASE" "v0.7.0-alpha.7" "$(with_resolve_version main "${FIXTURE}")"
 check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
 check "no ref resolves the newest v-tag" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
 

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -159,6 +159,9 @@ with_resolve_version() { # script_ref fixture-path
 	_ref=$1; _f=$2
 	{
 		printf 'REPO=rossoctl/cortex\n'
+		# CHANNEL_TAG is read out of install.sh, not restated here, so this probe
+		# cannot disagree with the script about what the channel is called.
+		sed -n '/^CHANNEL_TAG=/p' "${INSTALL_SH}"
 		printf 'warn() { printf "warning: %%s\\n" "$*" >&2; }\n'
 		printf 'die() { printf "error: %%s\\n" "$*" >&2; exit 1; }\n'
 		# info() is stubbed to match install.sh's definition EXACTLY — stdout, not
@@ -177,7 +180,13 @@ with_resolve_version() { # script_ref fixture-path
 fixture rv_releases.json <<'EOF'
 [{"tag_name":"main"},{"tag_name":"v0.7.0-alpha.7"}]
 EOF
-check "--ref=main installs main binaries" "main" "$(with_resolve_version main "${FIXTURE}")"
+# --ref=main resolves to the channel tag, not the literal string "main": a
+# release tagged `main` would collide with the branch. See CHANNEL_TAG in
+# install.sh. The harness must pick the constant up from the script rather than
+# hardcode it, or renaming the channel silently passes a stale test.
+CHANNEL_TAG=$(sed -n 's/^CHANNEL_TAG="\(.*\)"$/\1/p' "${INSTALL_SH}")
+check "install.sh defines a non-colliding CHANNEL_TAG" "1" "$(printf '%s' "${CHANNEL_TAG}" | grep -c '^main-' || true)"
+check "--ref=main installs the channel tag" "${CHANNEL_TAG}" "$(with_resolve_version main "${FIXTURE}")"
 check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
 check "no ref resolves the newest v-tag" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
 

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -174,7 +174,18 @@ with_resolve_version() { # version_ref fixture-path
 		sed -n '/^resolve_version()/,/^}/p' "${INSTALL_SH}"
 		printf 'resolve_version "%s"\n' "${_ref}"
 	} >"${TMP}/rv.sh"
-	sh "${TMP}/rv.sh" 2>/dev/null
+	# stderr goes to a file rather than being discarded or leaked: two cases below assert
+	# on the warnings it carries, and letting it reach the terminal would scatter
+	# "Resolving newest release..." through the suite's own output.
+	sh "${TMP}/rv.sh" 2>"${TMP}/rv.err"
+}
+
+# with_resolve_version_stderr is the same probe, returning stderr instead of stdout —
+# the warnings are the behaviour under test here, and they must not reach stdout because
+# stdout IS the resolved version.
+with_resolve_version_stderr() { # version_ref fixture-path
+	with_resolve_version "$1" "$2" >/dev/null
+	cat "${TMP}/rv.err"
 }
 
 fixture rv_releases.json <<'EOF'
@@ -192,14 +203,21 @@ check "--ref=main installs the channel tag" "${CHANNEL_TAG}" "$(with_resolve_ver
 # page, so it is what someone types after seeing it there.
 check "--ref=CHANNEL_TAG resolves the same" "${CHANNEL_TAG}" "$(with_resolve_version "${CHANNEL_TAG}" "${FIXTURE}")"
 
+check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
+
 # An empty VERSION_REF means "nobody named anything installable" and must resolve the
 # newest RELEASE. It must never fall through to the channel: that is what the bootstrap
-# passes when the API was unreachable, and the whole point is that a rate-limited plain
+# passes when the API was unreachable, and the point is that a rate-limited plain
 # one-liner does not silently receive an unreleased build. Asserted here at the function
 # level and again against the real bootstrap block further down.
 check "empty version ref resolves a RELEASE, never the channel" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
-check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
-check "no ref resolves the newest v-tag" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
+
+# A branch or a SHA has no published binaries, so the newest release is the only option
+# — but it must SAY so, or it is indistinguishable from the plain one-liner and someone
+# testing a branch gets a mixed set with nothing to attribute it to.
+_st=0; _err=$(with_resolve_version_stderr feat/my-branch "${FIXTURE}") || _st=$?
+check "a branch ref warns that binaries come from a release" "1" "$(printf '%s\n' "${_err}" | grep -c 'no binaries are published for feat/my-branch')"
+check "an empty ref warns nothing" "0" "$(printf '%s\n' "$(with_resolve_version_stderr "" "${FIXTURE}")" | grep -c 'no binaries are published')"
 
 # stdout must be the version and nothing else. info() writes to stdout
 # (install.sh:81), so an un-redirected progress line inside resolve_version would be
@@ -219,9 +237,18 @@ check "stdout is exactly the version" "v0.7.0-alpha.7" "${_out}"
 # The failure mode is not "the var still works" — it is a message telling someone
 # to set a var the script no longer reads. Three sites advised AUTHBRIDGE_VERSION.
 
+# Each removed var is now mentioned on exactly ONE line, and that line rejects it. The
+# earlier "zero occurrences" assertion was the wrong shape: ignoring a var someone still
+# has set is a silent wrong answer, which is what this script's style exists to avoid, so
+# a guard that dies is correct and has to be allowed to mention the name.
 for _v in AUTHBRIDGE_VERSION AUTHBRIDGE_REF AUTHBRIDGE_INSTALL_ONLY; do
-	_hits=$(grep -c "${_v}" "${INSTALL_SH}" || true)
-	check "${_v} is gone from install.sh entirely" "0" "${_hits}"
+	_guard=$(grep -c "^\[ -z \"\${${_v}:-}\" \] || die" "${INSTALL_SH}" || true)
+	check "${_v} has a guard that dies" "1" "${_guard}"
+	# Expanded ONLY on the guard line. A line count would fail on prose that merely
+	# names the var, which comments legitimately do; what matters is that nothing else
+	# reads it to decide anything.
+	_elsewhere=$(grep -v "^\[ -z \"\${${_v}:-}\" \] || die" "${INSTALL_SH}" | grep -c "\${${_v}" || true)
+	check "${_v} is not expanded anywhere else" "0" "${_elsewhere}"
 done
 
 for _v in AUTHBRIDGE_SKIP_DOWNLOAD AUTHBRIDGE_SCRIPT_REF; do
@@ -249,7 +276,20 @@ with_bootstrap() { # want_ref http_code_for_script_fetch newest_release_output
 		printf 'newest_release() { [ -n "%s" ] || return 1; printf "%%s\\n" "%s"; }\n' "${_newest}" "${_newest}"
 		# curl here is only the raw.githubusercontent fetch of the released script; -w
 		# makes the real one print the status code, so the stub prints the scenario's.
-		printf 'curl() { printf "%%s" "%s"; }\n' "${_http}"
+		#
+		# It must also WRITE the file, because the real curl does (-o "${boot}") and the
+		# branch under test is `[ "${http}" = "200" ] && [ -s "${boot}" ]`. A stub that
+		# only echoed the code left ${boot} empty, so the 200 arm was unreachable and
+		# every scenario silently fell through to the failure handling below — including
+		# the one asserting that a transport failure refuses to run main.
+		printf 'curl() {\n'
+		printf '  _out=""; _prev=""\n'
+		# shellcheck disable=SC2016 # literal on purpose: expanded by the probe, not here.
+		printf '  for _a in "$@"; do [ "${_prev}" = "-o" ] && _out="${_a}"; _prev="${_a}"; done\n'
+		# shellcheck disable=SC2016 # same.
+		printf '  [ -z "${_out}" ] || printf "#!/bin/sh\\nprintf \\"REEXECED\\\\n\\"\\nexit 0\\n" > "${_out}"\n'
+		printf '  printf "%%s" "%s"\n' "${_http}"
+		printf '}\n'
 		# shellcheck disable=SC2016 # literal on purpose: these expand in the
 		# generated probe, not here. Same reason install.sh disables SC2016.
 		printf 'mktemp() { printf "%%s\\n" "${TMPDIR:-/tmp}/boot.$$"; }\n'
@@ -285,6 +325,20 @@ check "--ref=CHANNEL_TAG behaves as --ref=main" \
 # the one path where the user was most explicit about X.
 check "--ref=v0.5.0 with a 404 script: script=main, install v0.5.0" \
 	"script=main version=v0.5.0" "$(with_bootstrap v0.5.0 404 v0.7.0-alpha.7)"
+
+# A transport failure is NOT a 404. We cannot tell whether a released installer exists,
+# so running main instead would break the exact guarantee the bootstrap provides — the
+# script has to refuse. This is the security-relevant arm and it was unreachable through
+# the harness until the curl stub started writing the file the real one writes.
+check "--ref=v0.5.0 with a transport failure refuses to run main" \
+	"DIED" "$(with_bootstrap v0.5.0 000 v0.7.0-alpha.7)"
+
+# HTTP 200 re-execs the released copy and exits with its status rather than continuing in
+# this process. Asserted on the child's OWN output, not on the absence of the probe's:
+# an empty result would also be produced by the probe dying early, which is exactly the
+# kind of vacuous pass that hid the unreachable arm above.
+check "--ref=v0.5.0 with a 200 script re-execs into it" \
+	"REEXECED" "$(with_bootstrap v0.5.0 200 v0.7.0-alpha.7)"
 
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -155,8 +155,8 @@ check_fails "an empty body fails" "${_st}"
 # `--ref=main` set only the script, because there was no main release to download
 # from. One rule now covers both.
 
-with_resolve_version() { # script_ref fixture-path [channel_requested]
-	_ref=$1; _f=$2; _req=${3:-}
+with_resolve_version() { # version_ref fixture-path
+	_ref=$1; _f=$2
 	{
 		printf 'REPO=rossoctl/cortex\n'
 		# CHANNEL_TAG is read out of install.sh, not restated here, so this probe
@@ -172,7 +172,6 @@ with_resolve_version() { # script_ref fixture-path [channel_requested]
 		printf 'curl() { cat "%s"; }\n' "${_f}"
 		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
 		sed -n '/^resolve_version()/,/^}/p' "${INSTALL_SH}"
-		printf 'CHANNEL_REQUESTED=%s\n' "${_req}"
 		printf 'resolve_version "%s"\n' "${_ref}"
 	} >"${TMP}/rv.sh"
 	sh "${TMP}/rv.sh" 2>/dev/null
@@ -187,15 +186,18 @@ EOF
 # hardcode it, or renaming the channel silently passes a stale test.
 CHANNEL_TAG=$(sed -n 's/^CHANNEL_TAG="\(.*\)"$/\1/p' "${INSTALL_SH}")
 check "install.sh defines a non-colliding CHANNEL_TAG" "1" "$(printf '%s' "${CHANNEL_TAG}" | grep -c '^main-' || true)"
-check "--ref=main installs the channel tag" "${CHANNEL_TAG}" "$(with_resolve_version main "${FIXTURE}" 1)"
+check "--ref=main installs the channel tag" "${CHANNEL_TAG}" "$(with_resolve_version main "${FIXTURE}")"
 
-# The bootstrap sets SCRIPT_REF=main for TWO other reasons: the release API was
-# unreachable, and the wanted release has no install.sh. Both mean "run main's script";
-# neither means "install main's binaries". Without this distinction a rate-limited user
-# who ran the plain one-liner silently received an unreleased build — and rate limiting
-# is reachable, not theoretical. Guarding on the literal "main" alone is what caused it,
-# so the test pins the fallback, not just the happy path.
-check "fallback to main's script still installs a RELEASE" "v0.7.0-alpha.7" "$(with_resolve_version main "${FIXTURE}")"
+# Both channel spellings resolve identically — CHANNEL_TAG is the title on the Releases
+# page, so it is what someone types after seeing it there.
+check "--ref=CHANNEL_TAG resolves the same" "${CHANNEL_TAG}" "$(with_resolve_version "${CHANNEL_TAG}" "${FIXTURE}")"
+
+# An empty VERSION_REF means "nobody named anything installable" and must resolve the
+# newest RELEASE. It must never fall through to the channel: that is what the bootstrap
+# passes when the API was unreachable, and the whole point is that a rate-limited plain
+# one-liner does not silently receive an unreleased build. Asserted here at the function
+# level and again against the real bootstrap block further down.
+check "empty version ref resolves a RELEASE, never the channel" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
 check "--ref=v0.7.0-alpha.4 installs that release" "v0.7.0-alpha.4" "$(with_resolve_version v0.7.0-alpha.4 "${FIXTURE}")"
 check "no ref resolves the newest v-tag" "v0.7.0-alpha.7" "$(with_resolve_version "" "${FIXTURE}")"
 
@@ -226,6 +228,63 @@ for _v in AUTHBRIDGE_SKIP_DOWNLOAD AUTHBRIDGE_SCRIPT_REF; do
 	_hits=$(grep -c "${_v}" "${INSTALL_SH}" || true)
 	check_fails "${_v} is still present" "${_hits}"
 done
+
+
+# --- bootstrap: which script runs vs which binaries get installed ---
+#
+# These two questions have different answers on every fallback, and conflating them let
+# the DEFAULT one-liner install channel binaries. The resolve_version cases above cannot
+# catch that: in isolation main -> CHANNEL_TAG is correct. The bug was in the bootstrap
+# deciding to pass "main" at all. So extract the bootstrap block itself and assert the
+# pair it produces.
+with_bootstrap() { # want_ref http_code_for_script_fetch newest_release_output
+	_want=$1; _http=$2; _newest=$3
+	_start=$(awk '/^SCRIPT_REF="\$\{AUTHBRIDGE_SCRIPT_REF:-\}"/{print NR; exit}' "${INSTALL_SH}")
+	_end=$(awk -v s="${_start}" 'NR>=s && /^fi$/{print NR; exit}' "${INSTALL_SH}")
+	{
+		printf 'REPO=rossoctl/cortex\n'
+		sed -n '/^CHANNEL_TAG=/p' "${INSTALL_SH}"
+		printf 'info() { :; }\nwarn() { :; }\ndie() { printf "DIED\\n"; exit 1; }\n'
+		# newest_release: empty output + non-zero mimics an unreachable/rate-limited API.
+		printf 'newest_release() { [ -n "%s" ] || return 1; printf "%%s\\n" "%s"; }\n' "${_newest}" "${_newest}"
+		# curl here is only the raw.githubusercontent fetch of the released script; -w
+		# makes the real one print the status code, so the stub prints the scenario's.
+		printf 'curl() { printf "%%s" "%s"; }\n' "${_http}"
+		# shellcheck disable=SC2016 # literal on purpose: these expand in the
+		# generated probe, not here. Same reason install.sh disables SC2016.
+		printf 'mktemp() { printf "%%s\\n" "${TMPDIR:-/tmp}/boot.$$"; }\n'
+		printf 'AUTHBRIDGE_SCRIPT_REF=""\nWANT_REF="%s"\n' "${_want}"
+		sed -n "${_start},${_end}p" "${INSTALL_SH}"
+		# shellcheck disable=SC2016 # same: the probe prints its own variables.
+		printf 'printf "script=%%s version=%%s\\n" "${SCRIPT_REF}" "${VERSION_REF}"\n'
+	} >"${TMP}/bs.sh"
+	sh "${TMP}/bs.sh" 2>/dev/null
+}
+
+# The plain one-liner while the release API is unreachable. VERSION_REF must be empty so
+# resolution still hunts for a release and fails loudly — NOT the channel. This is the
+# regression: before the channel existed this path died with "could not resolve the
+# newest release"; keying resolution on SCRIPT_REF turned it into a silent unreleased
+# install. Unauthenticated api.github.com is 60 req/hr per IP, so it is routine from
+# behind NAT, not a corner case.
+check "API unreachable, no --ref: script=main, nothing to install" \
+	"script=main version=" "$(with_bootstrap "" 000 "")"
+
+# --ref=main, the documented spelling.
+check "--ref=main: script=main, install main" \
+	"script=main version=main" "$(with_bootstrap main 000 v0.7.0-alpha.7)"
+
+# --ref=<CHANNEL_TAG>, which is the title shown on the Releases page, so someone will
+# type it after seeing it there. It must mean the same thing as --ref=main rather than
+# bootstrapping that tag's frozen script and then installing newest-release binaries.
+check "--ref=CHANNEL_TAG behaves as --ref=main" \
+	"script=main version=main" "$(with_bootstrap "${CHANNEL_TAG}" 000 v0.7.0-alpha.7)"
+
+# A pinned release whose tag predates authbridge/install.sh: fall back to main's SCRIPT,
+# but keep the pin for the BINARIES. Losing it here would break "--ref=X installs X" on
+# the one path where the user was most explicit about X.
+check "--ref=v0.5.0 with a 404 script: script=main, install v0.5.0" \
+	"script=main version=v0.5.0" "$(with_bootstrap v0.5.0 404 v0.7.0-alpha.7)"
 
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -92,5 +92,62 @@ fixture compact.json <<'EOF'
 EOF
 check "compact JSON resolves the newest tag, not the oldest" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
 
+# --- newest_release: the main channel must not hijack the default ---
+#
+# The rolling `main` release sorts first until the next tagged release, because the
+# API sorts by created_at and created_at is fixed at creation. Unfiltered, the
+# v[0-9]* shape check then rejects it and the whole default install dies.
+
+fixture main_first.json <<'EOF'
+[
+  {
+    "tag_name": "main",
+    "prerelease": true
+  },
+  {
+    "tag_name": "v0.7.0-alpha.7"
+  }
+]
+EOF
+check "a main release sorting first is skipped" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+fixture main_first_compact.json <<'EOF'
+[{"tag_name":"main"},{"tag_name":"v0.7.0-alpha.7"},{"tag_name":"v0.3.1"}]
+EOF
+check "main skipped in compact JSON too" "v0.7.0-alpha.7" "$(with_newest_release "${FIXTURE}")"
+
+fixture only_non_v.json <<'EOF'
+[{"tag_name":"main"},{"tag_name":"nightly"}]
+EOF
+set +e
+_out=$(with_newest_release "${FIXTURE}"); _st=$?
+set -e
+check_fails "a page with no v-tag returns non-zero rather than guessing" "${_st}"
+check "and prints nothing on stdout" "" "${_out}"
+
+# --- newest_release: hostile inputs still fail closed ---
+
+fixture ratelimit.json <<'EOF'
+{"message":"API rate limit exceeded","documentation_url":"https://x"}
+EOF
+set +e
+_out=$(with_newest_release "${FIXTURE}"); _st=$?
+set -e
+check_fails "rate-limit body fails" "${_st}"
+
+fixture html.json <<'EOF'
+<html><body>502 Bad Gateway</body></html>
+EOF
+set +e
+_st=0; _out=$(with_newest_release "${FIXTURE}") || _st=$?
+set -e
+check_fails "an HTML error page fails" "${_st}"
+
+fixture empty.json </dev/null
+set +e
+_st=0; _out=$(with_newest_release "${FIXTURE}") || _st=$?
+set -e
+check_fails "an empty body fails" "${_st}"
+
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]


### PR DESCRIPTION
## Summary

Lets a developer install unreleased `main` binaries without waiting for a tagged
release, and without changing the default one-liner's command or behaviour.

```sh
curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
  | sh -s -- --claude-code --ref=main
```

Every push to `main` overwrites the assets on one rolling pre-release. `--ref=X` now
means "install X" — script *and* binaries — for every X. That was already true for
`--ref=v0.7.0-alpha.4` and not for `--ref=main`, because there was nothing to download
from; the inconsistency disappears rather than growing a second flag.

**Nothing publishes when this merges.** The workflow is gated on the repo variable
`MAIN_CHANNEL_ENABLED`, which is unset. See "Sequencing" below — the ordering is
load-bearing.

## Why the guard matters

Publishing a release whose tag is not `v*` breaks the **default** install for every new
user, and quietly. `newest_release()` took the first entry of `?per_page=1`; the rolling
release sorts first (the API sorts by `created_at`, fixed at creation), the `v[0-9]*`
shape check rejects it, and the installer dies. It now fetches 10 and takes the first
`v`-shaped tag, so the channel is invisible to the default path.

## Sequencing (please don't skip)

The middle step is load-bearing, though not for the reason first stated here. Once `main`
carries the filter the default one-liner is safe: it resolves a `v` tag, re-execs that
released copy, and the copy matches `case "${SCRIPT_REF}" in v*)` and never calls
`newest_release`. What needs a *filtered release* is a RELEASED copy running as the
parent — including the pinned one-liner this installer prints in its own "abctl too old"
message. Cutting a release first stops that window growing; it cannot fix copies already
published.

1. merge this
2. cut a release (it contains the filter)
3. set `MAIN_CHANNEL_ENABLED=true` in repo variables

The next push to `main` publishes the rolling release. Enabling it before step 2 breaks
the default one-liner.

## Deviation from the approved spec: the tag is `main-latest`, not `main`

D1 said "tagged `main`". A GitHub release requires a git tag, so that would have created
a tag named `main` beside the branch. Verified consequences:

```
branch main -> 384d4de (c2)     tag main -> 5ae318a (c1)
git rev-parse main  ->  warning: refname 'main' is ambiguous.
                        5ae318a          <- the TAG wins
```

- `git rev-parse main` resolves to the tag; anything treating `main` as a revision
  silently reads the wrong commit — including the worktree bootstrap in root `CLAUDE.md`
- every git command warns `refname 'main' is ambiguous`, permanently, for everyone
- the tag freezes at the first publish (`gh release upload --clobber` never moves it)
  and drifts further on every merge
- unverified but plausible: the bootstrap fetches
  `raw.githubusercontent.com/<repo>/main/authbridge/install.sh`. If GitHub resolves that
  tag-first the way git does, `--ref=main` would fetch a frozen script forever — the
  channel appearing to work while serving a stale installer. Confirming it would have
  meant creating the colliding tag on a real repo.

Only the tag changed. `--ref=main` is still what people type; `resolve_version` maps it
to `CHANNEL_TAG`, and the tests read that constant out of `install.sh` rather than
restating it, so a rename can't leave a stale expectation passing. Recorded as **D9** in
the spec.

## Also in here

- **First committed tests for `install.sh`** (`authbridge/install_test.sh`, 35 cases,
  wired into `ci.yaml`). It had none; the only check was `shellcheck --severity=error`,
  which is why #902's tag-parser bug shipped. Plain POSIX sh — no bats/shunit2 in the
  repo and a framework isn't worth it for a handful of functions. Functions are extracted
  from the shipping script with `curl` stubbed, so the code under test can't drift from
  the code that runs.
- **Three vestigial env vars removed** (`AUTHBRIDGE_VERSION`, `AUTHBRIDGE_REF`,
  `AUTHBRIDGE_INSTALL_ONLY`) — zero references anywhere outside `install.sh`.
  `AUTHBRIDGE_SKIP_DOWNLOAD` stays but leaves `usage()`; `AUTHBRIDGE_SCRIPT_REF` is
  untouched (it's the recursion guard). Breaking for anyone with one of the three **exported in a shell profile**, not only for anyone scripting them: they are no longer read and the installer refuses to run rather than ignoring them, so a stale export fails the *default* one-liner with no flags passed. The die is deliberate — silently doing a full install on a stale `AUTHBRIDGE_INSTALL_ONLY=1` is the worse outcome — and the message names the replacement flag and echoes the value back. `CONTRIBUTING.md` says to unset them.

## Two bugs the plan didn't anticipate

Both in the workflow, both would have shipped a non-working channel:

- the publish step was tag-only, so a main push would have built 16 archives and
  published nothing
- the dry-run artifact step was `!= 'tag'`, which now also matches a main push — a
  redundant copy of all 16 assets on every merge

`TAG`/`VERSION` also now travel to the publish step via `GITHUB_ENV` instead of being
re-derived from `GITHUB_REF_NAME` there, which is `main` on a main push and would have
published to the wrong tag.

## Verification

- 35/35 tests; `shellcheck --severity=error` and `-s sh` clean; `sh -n` and `dash -n`
  clean; yamllint clean on both workflows
- **Harness proven able to fail**, not just observed passing: flipping the compact-JSON
  expectation to the old bug's answer fails with exit 1, and deleting the `>&2` in
  `resolve_version` fails 3 cases with the progress line captured into `$version`
- **End to end against the real API**, throwaway `HOME`, shifted ports, `service
  install` neutralized, both neutralizations asserted before running:
  `--ref=main` → requests `abctl_main-latest_darwin_arm64.tar.gz` (404, correct until
  published) · default → `v0.7.0-alpha.7`, installs, `abctl --version` agrees · re-run →
  `Already at … not re-downloading`
- **All five branches** of the CI `TAG`/`VERSION` derivation exercised locally, and the
  installer's requested URL cross-checked against the asset name CI produces — they match
- The one thing I could **not** verify: the `workflow_dispatch` dry run. It needs the
  workflow on the fork's default branch, which is behind, and I wasn't going to push to
  your fork's `main` to get it. The derivation test above covers the same logic more
  thoroughly; the build matrix itself is unchanged apart from one filename variable.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installers now support `--ref` for selecting a specific release or installing the latest unreleased `main` build.
  * Unreleased builds are provided through the rolling `main-latest` prerelease channel, while tagged releases remain the default.
* **Bug Fixes**
  * Improved release selection and validation, including safer handling of malformed or rate-limited responses.
  * Invalid legacy environment variables now stop installation with guidance to use supported flags.
* **Documentation**
  * Updated installation and contributor guidance for pinned releases and `main` builds.
* **Tests**
  * Added automated coverage for installer behavior and rolling-channel releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

