### PR TITLE
Fix: Keep abctl's events when a session leaves the server's list

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -185,7 +185,9 @@ So a session leaving the server's list does not remove anything from the
 UI. The events stay viewable, you stay in the pane you were reading, and a
 banner names what ended the live feed:
 
-- `proxy restarted — no longer live` — the list came back empty.
+- `server has no sessions (proxy restarted, or all aged out)` — the list
+  came back empty. Almost always a restart; an explicit `session.ttl`
+  sweep could also empty it, so the notice does not assert one cause.
 - `session no longer on server (evicted)` — it vanished while others stayed.
 
 The notice deliberately does not say "expired": time-based expiry is off by
@@ -193,7 +195,10 @@ default (`session.ttl` defaults to never), so it is almost never the cause.
 
 Cached events for a `gone` session are released when you select a
 *different* session — the point at which they have demonstrably stopped
-being what you were looking at. The one exception is a rekey, where the
+being what you were looking at, and the only point at which they are
+released (leaving the pod entirely also clears them). Nothing sweeps them
+on a timer, by design: that would be another mechanism deleting events out
+from under someone who stepped away. The one exception is a rekey, where the
 store renames the bootstrap `default` bucket to the server-assigned
 context id: those events follow the new id instead, and so does your
 selection.

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -8,14 +8,14 @@ and read individual events as pretty-printed JSON.
 
 ```
 ┌─ abctl · http://localhost:9094 ────────────────────────────────┐
-│ ID                       UPDATED    EVENTS  ACTIVE             │
-│ ► ctx-abc-1234…          3s ago     42      ●                  │
-│   ctx-def-5678…          18m ago    15                         │
-│   default                —          8      gone                │
-│                                                                 │
+│ ID                       UPDATED    EVENTS  TOKENS  ACTIVE     │
+│ ► ctx-abc-1234…          3s ago     42      1,500   ●          │
+│   ctx-def-5678…          18m ago    15      900                │
+│   default                —          8       320     gone       │
+│                                                                │
 │ ● connected   2.1 ev/s                                         │
 │ [↑↓/jk] nav  [↵] drill  [/] filter  [?] keys  [q] quit         │
-└─────────────────────────────────────────────────────────────────┘
+└────────────────────────────────────────────────────────────────┘
 ```
 
 ## Install
@@ -93,8 +93,10 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
 
 - **Sessions** (default): table of active sessions in the store, most
   recently updated first. Columns: ID, updated (relative), event count,
-  active marker. Sessions the server has stopped listing are kept at the
-  bottom marked `gone` — see [Retention](#retention).
+  token total, active marker. Sessions the server has stopped listing are
+  kept at the bottom marked `gone`, with their counts computed from
+  abctl's cache since no server summary remains — see
+  [Retention](#retention).
 - **Events**: per-session event table. `c` opens a column picker — a popup with
   a checkbox and a one-line description per column, since twelve abbreviated
   headers are not self-describing.

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -11,9 +11,9 @@ and read individual events as pretty-printed JSON.
 │ ID                       UPDATED    EVENTS  ACTIVE             │
 │ ► ctx-abc-1234…          3s ago     42      ●                  │
 │   ctx-def-5678…          18m ago    15                         │
-│   default                1h ago     8                          │
+│   default                —          8      gone                │
 │                                                                 │
-│ ● connected   2.1 ev/s   drops: 0                              │
+│ ● connected   2.1 ev/s                                         │
 │ [↑↓/jk] nav  [↵] drill  [/] filter  [?] keys  [q] quit         │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -93,7 +93,8 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
 
 - **Sessions** (default): table of active sessions in the store, most
   recently updated first. Columns: ID, updated (relative), event count,
-  active marker.
+  active marker. Sessions the server has stopped listing are kept at the
+  bottom marked `gone` — see [Retention](#retention).
 - **Events**: per-session event table. `c` opens a column picker — a popup with
   a checkbox and a one-line description per column, since twelve abbreviated
   headers are not self-describing.
@@ -172,6 +173,30 @@ Layered on top of all of them:
   appears in the overlay's footer only when the content overflows; the
   close hint stays pinned there at every scroll position. Resizing the
   terminal re-ranges the body without losing your place.
+
+### Retention
+
+The session store is in-memory and per-pod: it does not survive a proxy
+restart, and it evicts the oldest session once `session.max_sessions`
+(default 100) is exceeded. When that happens `abctl`'s cached copy of the
+events is the **only** copy left.
+
+So a session leaving the server's list does not remove anything from the
+UI. The events stay viewable, you stay in the pane you were reading, and a
+banner names what ended the live feed:
+
+- `proxy restarted — no longer live` — the list came back empty.
+- `session no longer on server (evicted)` — it vanished while others stayed.
+
+The notice deliberately does not say "expired": time-based expiry is off by
+default (`session.ttl` defaults to never), so it is almost never the cause.
+
+Cached events for a `gone` session are released when you select a
+*different* session — the point at which they have demonstrably stopped
+being what you were looking at. The one exception is a rekey, where the
+store renames the bootstrap `default` bucket to the server-assigned
+context id: those events follow the new id instead, and so does your
+selection.
 
 ## Keybindings
 

--- a/authbridge/cmd/abctl/go.mod
+++ b/authbridge/cmd/abctl/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.8
+	github.com/muesli/termenv v0.16.0
 	github.com/rossoctl/cortex/authbridge/authlib v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -46,7 +47,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -634,6 +634,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// reading. So nothing is deleted here and the focused pane is never changed
 		// out from under the user — see reconcileGone for the reasoning and for the
 		// one case (rekey) where cached events legitimately move.
+		//
+		// Must run BEFORE m.sessions is replaced: it detects a rekey by looking for
+		// an id absent from the previous list. See reconcileGone.
 		m.reconcileGone(msg)
 		m.sessions = []session.SessionSummary(msg)
 		m.connState.phase = connOpen

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -70,9 +70,14 @@ type connStateInfo struct {
 	err       error
 }
 
-// maxEventsPerSession caps per-session event retention in the TUI. Matches
-// the server's default maxEvents cap so we don't hold more than the server
-// itself does.
+// maxEventsPerSession caps per-session event retention in the TUI.
+//
+// This does NOT match the server's default max_events (500) — it is deliberately
+// twice it. The comment here used to claim they matched, which was never true.
+// Holding more than the server is the useful direction: the store is in-memory
+// and per-pod, so after a restart or an eviction abctl's buffer is the only
+// surviving copy of that history (see gone.go). Bounded all the same, since a
+// deep buffer times a few visited sessions is still small.
 const maxEventsPerSession = 1000
 
 // flashDuration is how long a one-shot status message (e.g. yank
@@ -216,11 +221,17 @@ type model struct {
 	// Data caches.
 	sessions []session.SessionSummary
 	events   map[string][]pipeline.SessionEvent // sessionID → ring buffer
-	eventCt  uint64                             // monotonic counter
+
+	// gone marks sessions whose events are still cached but which the server
+	// no longer lists — evicted under maxSessions, or lost to a proxy restart.
+	// The cached events stay viewable (that is the whole point of a debugging
+	// tool: it shows what it saw, and the store is per-pod and non-persistent,
+	// so abctl's copy is the only copy). The value is why, for the banner.
+	gone     map[string]goneReason
+	eventCt  uint64 // monotonic counter
 	lastTick time.Time
 	lastCt   uint64
 	rate     float64
-	drops    uint64
 
 	// Connection status.
 	connState connStateInfo
@@ -425,6 +436,8 @@ func (m *model) backToPodsPane() {
 	m.streamCh = nil
 	m.sessions = nil
 	m.events = make(map[string][]pipeline.SessionEvent)
+	// Tombstones describe the old pod's store; nothing to carry over.
+	m.gone = nil
 	// A different pod is a different aggregator: keep the view options the
 	// operator chose, drop the data they described.
 	m.usage.snap = nil
@@ -437,7 +450,6 @@ func (m *model) backToPodsPane() {
 	m.eventCt = 0
 	m.lastCt = 0
 	m.rate = 0
-	m.drops = 0
 	m.pipeline = nil
 	// Drop the cached /v1/plugins snapshot too — a different pod is a
 	// different framework instance with potentially different plugin
@@ -445,6 +457,13 @@ func (m *model) backToPodsPane() {
 	m.catalog = nil
 	m.catalogTbl.SetRows(nil)
 	m.previousPane = paneNone
+	// Close the picker with the pane it belongs to. The paneEvents gates on the
+	// key block and in View() make it inert and invisible once we leave, but the
+	// flag itself would outlive the pane: entering a session on the next pod puts
+	// m.pane back to paneEvents and the popup the user never reopened would be
+	// there again, owning the keyboard until they found esc. Gating covers "drawn
+	// over the wrong pane"; this covers the return trip.
+	m.colPicker = false
 	m.detailEvent = nil
 	m.detailPlugin = nil
 	m.selectedSess = ""
@@ -609,33 +628,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tickCmd()
 
 	case sessionsLoadedMsg:
-		// Server list is authoritative. Reconcile: drop cached events for
-		// sessions the server no longer knows about (typically the
-		// bootstrap "default" bucket after rekey). If the focused session
-		// disappeared, back out to the sessions pane so the user isn't
-		// stranded on an empty events view.
-		serverIDs := make(map[string]bool, len(msg))
-		for _, s := range msg {
-			serverIDs[s.ID] = true
-		}
-		for id := range m.events {
-			if !serverIDs[id] {
-				delete(m.events, id)
-			}
-		}
-		if m.selectedSess != "" && !serverIDs[m.selectedSess] && m.pane != paneSessions {
-			m.selectedSess = ""
-			m.pane = paneSessions
-			// Close the picker with the pane it belongs to.
-			//
-			// The paneEvents gates on the key block and in View() make it inert and
-			// invisible while the user is on the sessions table, but the flag itself
-			// outlived the pane: pressing enter on another session put m.pane back to
-			// paneEvents and the popup the user never reopened was there again, owning
-			// the keyboard until they found esc. Gating covers "drawn over the wrong
-			// pane"; this covers the return trip.
-			m.colPicker = false
-		}
+		// The server list is authoritative about what is LIVE, not about what is
+		// viewable. A session leaving the list means new events will stop arriving
+		// for it; it does not mean the events already on screen stopped being worth
+		// reading. So nothing is deleted here and the focused pane is never changed
+		// out from under the user — see reconcileGone for the reasoning and for the
+		// one case (rekey) where cached events legitimately move.
+		m.reconcileGone(msg)
 		m.sessions = []session.SessionSummary(msg)
 		m.connState.phase = connOpen
 		m.rebuildSessionsTable()
@@ -1075,6 +1074,10 @@ func (m *model) handleStreamEvent(ev apiclient.StreamEvent) {
 	}
 	e := *ev.Event
 	m.eventCt++
+	// A live event is proof the session is back (traffic resumed, or the same id
+	// after a restart). Clear the tombstone now rather than waiting up to one
+	// refresh interval for the list to agree.
+	delete(m.gone, e.SessionID)
 	buf := m.events[e.SessionID]
 	buf = append(buf, e)
 	if len(buf) > maxEventsPerSession {
@@ -1189,6 +1192,12 @@ func (m *model) paneView() string {
 		body = m.eventsTbl.View()
 		if banner := identityBanner(m.events[m.selectedSess]); banner != "" {
 			body = banner + "\n" + body
+		}
+		// Above the identity banner: the session is no longer live. Says which
+		// mechanism ended it, since the user's next move differs for a restart
+		// (reattach) and an eviction (raise max_sessions).
+		if reason, ok := m.gone[m.selectedSess]; ok {
+			body = goneBanner(reason, m.width) + "\n" + body
 		}
 	case paneDetail:
 		title = fmt.Sprintf("abctl · %s · event", trunc(m.selectedSess, 24))

--- a/authbridge/cmd/abctl/tui/events_columns_test.go
+++ b/authbridge/cmd/abctl/tui/events_columns_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -698,10 +699,11 @@ func TestFitColumns_ZeroDroppedMeansItFits(t *testing.T) {
 }
 
 // The picker must not own the keyboard, or draw itself, over a pane it does not
-// belong to. No KEY can switch panes underneath it, but a MESSAGE can: the
-// sessionsMsg handler drops to paneSessions when the selected session disappears
-// server-side, which left the popup drawn over the sessions table with its key
-// block swallowing enter/j/k — an inert pane until the user guessed esc.
+// belong to. No KEY can switch panes underneath it, but a MESSAGE can: a pod
+// teardown leaves paneEvents asynchronously, which left the popup drawn over the
+// pane below with its key block swallowing enter/j/k — an inert pane until the
+// user guessed esc. (This used to cite the sessionsLoadedMsg bounce to
+// paneSessions; that bounce was removed on purpose — see gone.go.)
 func TestColumnPicker_DoesNotStrandOnAnAsyncPaneChange(t *testing.T) {
 	m := newTestEventsModel(t)
 	m.handleKey(keyRune('c'))
@@ -730,8 +732,8 @@ func TestColumnPicker_DoesNotStrandOnAnAsyncPaneChange(t *testing.T) {
 
 // The picker must close with the pane it belongs to, not merely go quiet.
 //
-// The paneEvents gates make it inert and invisible while the user is bounced to
-// the sessions table, but the flag outlived the pane: pressing enter on another
+// The paneEvents gates make it inert and invisible while the user is away from
+// the events table, but the flag outlived the pane: pressing enter on another
 // session restored paneEvents and the popup was back without the user reopening
 // it, owning the keyboard until they found esc. Gating covers "drawn over the
 // wrong pane"; this covers the return trip.
@@ -743,12 +745,20 @@ func TestColumnPicker_DoesNotReturnAfterAnAsyncPaneChange(t *testing.T) {
 		t.Fatal("picker did not open")
 	}
 
-	// Drive the REAL handler, not a hand-set flag: the focused session disappears
-	// from the server's list, and sessionsLoadedMsg backs out to paneSessions. A
-	// test that assigned m.colPicker itself would pass without the fix.
-	m.Update(sessionsLoadedMsg{})
-	if m.pane != paneSessions {
-		t.Fatalf("handler did not back out to paneSessions (pane=%v)", m.pane)
+	// Drive the REAL transition, not a hand-set flag: backToPodsPane tears the
+	// session view down and leaves paneEvents. A test that assigned m.colPicker
+	// itself would pass without the fix.
+	//
+	// This used to drive sessionsLoadedMsg with an empty list, which back then
+	// bounced the user to paneSessions. That bounce is gone on purpose (see
+	// gone.go): a session leaving the server's list no longer moves the user or
+	// discards their events. The picker's lifecycle bug this test guards is
+	// unrelated to which transition triggers it, so it now uses the async pane
+	// change that remains.
+	m.parentCtx = context.Background() // backToPodsPane re-derives ctx from it
+	m.backToPodsPane()
+	if m.pane == paneEvents {
+		t.Fatalf("backToPodsPane left us on paneEvents (pane=%v)", m.pane)
 	}
 	if strings.Contains(m.View(), "COLUMNS") {
 		t.Error("popup still drawn over the sessions pane")

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -67,6 +67,11 @@ func (m *model) rebuildEventsTable() {
 		if len(distinctInboundIdentities(events)) > 0 {
 			h -= identityBannerHeight
 		}
+		// The gone notice is one rendered line and stacks above the identity
+		// banner; reclaim it too or the last row falls off-screen.
+		if _, gone := m.gone[m.selectedSess]; gone {
+			h -= goneBannerHeight
+		}
 		if h < 3 {
 			h = 3
 		}

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// footerView renders the bottom two lines: status (connection + rate + drops
+// footerView renders the bottom two lines: status (connection + rate
 // + optional transient flash) and a context-sensitive keybinding hint. No
 // lipgloss borders; parent view handles the frame.
 func (m *model) footerView() string {
@@ -35,14 +35,15 @@ func (m *model) footerView() string {
 
 	status.WriteString(styleMuted.Render("  "))
 
-	// Rate + drops.
+	// Rate. A "drops: N" indicator used to sit here, fed by m.drops — which was
+	// never incremented anywhere, so it read "drops: 0" unconditionally. That is
+	// worse than showing nothing: the one indicator an operator would check to
+	// tell "the stream lost events" from "nothing happened" was hardcoded to
+	// reassure. The store does drop events when a subscriber's channel fills
+	// (authlib/session/store.go publishLocked) but reports it only to the
+	// server's own slog, so a truthful counter needs the count on the wire
+	// first. Removed until then.
 	status.WriteString(styleMuted.Render(fmt.Sprintf("%.1f ev/s", m.rate)))
-	status.WriteString(styleMuted.Render("   "))
-	if m.drops > 0 {
-		status.WriteString(styleWarn.Render(fmt.Sprintf("drops: %d", m.drops)))
-	} else {
-		status.WriteString(styleMuted.Render("drops: 0"))
-	}
 	if m.paused {
 		status.WriteString(styleWarn.Render("   [paused]"))
 	}

--- a/authbridge/cmd/abctl/tui/gone.go
+++ b/authbridge/cmd/abctl/tui/gone.go
@@ -22,6 +22,15 @@ const (
 	// goneRestart: the server listed nothing at all. The store is in-memory and
 	// per-pod, so a restarted proxy comes back with zero sessions and stays that
 	// way until traffic arrives.
+	//
+	// An empty list is strong but not conclusive evidence of a restart. Eviction
+	// cannot produce one (it fires only when the count EXCEEDS max_sessions, so
+	// something always survives), which leaves one other route: an explicit
+	// session.ttl whose sweep aged out every session at once. That needs a
+	// non-default config, so the wording below leads with the restart and admits
+	// the alternative rather than asserting one cause. Distinguishing them for
+	// real needs a boot/instance id from the server — the count is not on the
+	// wire today. See the follow-up issue.
 	goneRestart
 )
 
@@ -59,6 +68,13 @@ func (m *model) reconcileGone(summaries []session.SessionSummary) {
 	// server-assigned contextId once the backend response reveals it, and the
 	// events under the old key are the same events. Migrate them so the history
 	// stays attached to the surviving id, and follow the user's selection over.
+	//
+	// ORDERING DEPENDENCY: soleNewSession compares against m.sessions, which must
+	// still hold the PREVIOUS list. The caller therefore has to invoke this before
+	// assigning m.sessions = msg (see the sessionsLoadedMsg case in app.go). Swap
+	// those two lines and every id looks familiar, soleNewSession returns "", and
+	// rekeys silently stop migrating — the events survive under the old id, so the
+	// bug shows up only as a stale duplicate bucket rather than as a failure.
 	if events, ok := m.events[session.DefaultSessionID]; ok && !serverIDs[session.DefaultSessionID] {
 		if newID := soleNewSession(serverIDs, m.sessions); newID != "" {
 			m.migrateSession(session.DefaultSessionID, newID, events)
@@ -134,6 +150,17 @@ func (m *model) migrateSession(oldID, newID string, events []pipeline.SessionEve
 // reliable signal available for when the data stopped mattering. The session
 // being opened is retained even when gone — that is precisely the case this
 // whole change exists to preserve.
+//
+// SOLE RELEASE POINT: enter on the sessions pane (keys.go) is the only caller, so
+// a user who never drills into another session after a restart keeps all N
+// tombstoned sessions for the process lifetime. That is the one path where
+// retention is unbounded in TIME; it stays bounded in SIZE by
+// maxEventsPerSession per session, and a whole pod switch clears the map outright
+// (backToPodsPane), so there is no need to release there too. Deliberate: a timer
+// or a count-based sweep would be another mechanism deleting events out from
+// under someone who stepped away, which is the exact failure this file exists to
+// remove. If a bound is ever wanted, cap the NUMBER of tombstones and evict the
+// least-recently-viewed — never the one on screen.
 func (m *model) forgetGoneExcept(keep string) {
 	for id := range m.gone {
 		if id == keep {
@@ -158,7 +185,7 @@ func goneBanner(reason goneReason, width int) string {
 	var msg string
 	switch reason {
 	case goneRestart:
-		msg = "proxy restarted — no longer live. Events below are abctl's copy; the server's is gone."
+		msg = "server has no sessions (proxy restarted, or all aged out) — events below are abctl's copy."
 	default:
 		msg = "session no longer on server (evicted) — events below are abctl's copy."
 	}

--- a/authbridge/cmd/abctl/tui/gone.go
+++ b/authbridge/cmd/abctl/tui/gone.go
@@ -1,0 +1,182 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+)
+
+// goneReason says why a session left the server's list. It drives the banner
+// text, so the user learns which of several unrelated mechanisms cost them
+// their live feed instead of guessing.
+type goneReason int
+
+const (
+	// goneEvicted: the session is absent while the server still lists others.
+	// Almost always the store's oldest-first eviction once max_sessions is
+	// exceeded (authlib/session/store.go evictOldestLocked), or a TTL sweep in
+	// the unusual case where session.ttl was set explicitly.
+	goneEvicted goneReason = iota
+	// goneRestart: the server listed nothing at all. The store is in-memory and
+	// per-pod, so a restarted proxy comes back with zero sessions and stays that
+	// way until traffic arrives.
+	goneRestart
+)
+
+// reconcileGone folds the server's session list into the local cache.
+//
+// The rule: the list is authoritative about what is LIVE, never about what is
+// VIEWABLE. Events already fetched stay in m.events, and the user stays in
+// whatever pane they were reading. Three reasons this is not the coin-flip it
+// looks like:
+//
+//   - Deleting is irreversible. The session store is in-memory and per-pod, so
+//     once abctl frees its copy the events exist nowhere. What deleting buys is
+//     memory already bounded by maxEventsPerSession times the number of sessions
+//     actually visited — an unmeasured saving traded against unrecoverable data.
+//   - The user is the only party who knows when the data stopped being
+//     interesting. Cleanup therefore happens on selecting a DIFFERENT session
+//     (see forgetGoneExcept), where it is harmless because nothing on screen
+//     depends on it.
+//   - Absence is a poor signal in the first place. The single-agent shape
+//     documented at session.DefaultSessionID puts nearly everything in one
+//     "default" bucket, so a restart empties the list and the old code deleted
+//     the only bucket the user had, 2s later, having also thrown them back to
+//     the sessions pane.
+//
+// A session that reappears (traffic resumed, or the same id after a restart)
+// is un-marked, and its cached events continue to accumulate.
+func (m *model) reconcileGone(summaries []session.SessionSummary) {
+	serverIDs := make(map[string]bool, len(summaries))
+	for _, s := range summaries {
+		serverIDs[s.ID] = true
+	}
+
+	// A rekey is the one case where cached events should MOVE rather than be
+	// dropped: the store renames the bootstrap "default" bucket to the
+	// server-assigned contextId once the backend response reveals it, and the
+	// events under the old key are the same events. Migrate them so the history
+	// stays attached to the surviving id, and follow the user's selection over.
+	if events, ok := m.events[session.DefaultSessionID]; ok && !serverIDs[session.DefaultSessionID] {
+		if newID := soleNewSession(serverIDs, m.sessions); newID != "" {
+			m.migrateSession(session.DefaultSessionID, newID, events)
+		}
+	}
+
+	for id := range m.events {
+		if serverIDs[id] {
+			// Live again — drop any stale tombstone.
+			delete(m.gone, id)
+			continue
+		}
+		if _, already := m.gone[id]; already {
+			continue
+		}
+		if m.gone == nil {
+			m.gone = make(map[string]goneReason)
+		}
+		// An empty list is a restart (or a not-yet-populated store); an absence
+		// alongside other live sessions is an eviction.
+		if len(summaries) == 0 {
+			m.gone[id] = goneRestart
+		} else {
+			m.gone[id] = goneEvicted
+		}
+	}
+}
+
+// soleNewSession returns the id the store rekeyed to, or "" when that cannot be
+// established unambiguously. A rekey shows up as exactly one id that the server
+// now lists and abctl has never seen before; if several appeared, guessing which
+// inherited "default" would be worse than leaving the events where they are
+// (they stay viewable under the old id either way, just marked gone).
+func soleNewSession(serverIDs map[string]bool, prev []session.SessionSummary) string {
+	seen := make(map[string]bool, len(prev))
+	for _, s := range prev {
+		seen[s.ID] = true
+	}
+	found := ""
+	for id := range serverIDs {
+		if seen[id] {
+			continue
+		}
+		if found != "" {
+			return "" // ambiguous
+		}
+		found = id
+	}
+	return found
+}
+
+// migrateSession moves cached events from oldID to newID, mirroring the store's
+// Rekey. It will not clobber an existing cache under newID: the store's own
+// Rekey is a no-op when newID already exists, so the events there are already
+// the authoritative copy.
+func (m *model) migrateSession(oldID, newID string, events []pipeline.SessionEvent) {
+	if _, exists := m.events[newID]; !exists {
+		for i := range events {
+			events[i].SessionID = newID
+		}
+		m.events[newID] = events
+	}
+	delete(m.events, oldID)
+	delete(m.gone, oldID)
+	if m.selectedSess == oldID {
+		m.selectedSess = newID
+	}
+}
+
+// forgetGoneExcept drops cached events for tombstoned sessions other than keep.
+// Called when the user selects a session: at that moment any OTHER gone session
+// has demonstrably stopped being what they are looking at, which is the only
+// reliable signal available for when the data stopped mattering. The session
+// being opened is retained even when gone — that is precisely the case this
+// whole change exists to preserve.
+func (m *model) forgetGoneExcept(keep string) {
+	for id := range m.gone {
+		if id == keep {
+			continue
+		}
+		delete(m.events, id)
+		delete(m.gone, id)
+	}
+}
+
+// goneBanner renders the notice shown above a tombstoned session's events. It
+// names the mechanism rather than saying "expired": time-based expiry is off by
+// default (session.ttl defaults to never), so "expired" would be wrong as well
+// as unhelpful.
+func goneBanner(reason goneReason, width int) string {
+	// Before the first WindowSizeMsg the width is 0 and trunc would return an
+	// empty string, while rebuildEventsTable has already reserved a row for the
+	// banner. Fall back to a sane width so the reservation and the render agree.
+	if width <= 0 {
+		width = 80
+	}
+	var msg string
+	switch reason {
+	case goneRestart:
+		msg = "proxy restarted — no longer live. Events below are abctl's copy; the server's is gone."
+	default:
+		msg = "session no longer on server (evicted) — events below are abctl's copy."
+	}
+	return styleWarn.Render(trunc(fmt.Sprintf("⚠ %s", msg), width))
+}
+
+// goneBannerHeight is the rendered height of goneBanner: one line, since trunc
+// keeps it to a single row.
+const goneBannerHeight = 1
+
+// goneIDs lists tombstoned sessions in a stable order. Sorted rather than map
+// order so the sessions table does not reshuffle under the cursor on every 2s
+// refresh.
+func (m *model) goneIDs() []string {
+	out := make([]string, 0, len(m.gone))
+	for id := range m.gone {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/authbridge/cmd/abctl/tui/gone.go
+++ b/authbridge/cmd/abctl/tui/gone.go
@@ -75,16 +75,35 @@ func (m *model) reconcileGone(summaries []session.SessionSummary) {
 	// those two lines and every id looks familiar, soleNewSession returns "", and
 	// rekeys silently stop migrating — the events survive under the old id, so the
 	// bug shows up only as a stale duplicate bucket rather than as a failure.
-	if events, ok := m.events[session.DefaultSessionID]; ok && !serverIDs[session.DefaultSessionID] {
+	//
+	// Two further conditions narrow this to a rename, because "default vanished
+	// and one unfamiliar id appeared" is also what an eviction of default plus an
+	// unrelated new session looks like — and migrating then would file the events
+	// under a session they never belonged to. A rename keeps the list the same
+	// size, and starts from a list that actually contained "default". Neither is
+	// proof (the server does not tell us), which is why the failure mode is now
+	// merely a missed migration rather than a wrong one: declining leaves the
+	// events viewable under the old id, tombstoned by the loop below.
+	if events, ok := m.events[session.DefaultSessionID]; ok && !serverIDs[session.DefaultSessionID] &&
+		len(summaries) == len(m.sessions) && hasSession(m.sessions, session.DefaultSessionID) {
 		if newID := soleNewSession(serverIDs, m.sessions); newID != "" {
 			m.migrateSession(session.DefaultSessionID, newID, events)
 		}
 	}
 
-	for id := range m.events {
+	for id, cached := range m.events {
 		if serverIDs[id] {
 			// Live again — drop any stale tombstone.
 			delete(m.gone, id)
+			continue
+		}
+		if len(cached) == 0 {
+			// A key with no events. snapshotLoadedMsg assigns m.events[id]
+			// unconditionally, so drilling into a session that has nothing yet
+			// creates the key with an empty slice. Tombstoning it would render
+			// "id — 0 — gone": a row advertising retained events that do not exist,
+			// held until the user selects something else. The tombstone is justified
+			// by abctl holding the only copy; with no copy there is nothing to hold.
 			continue
 		}
 		if _, already := m.gone[id]; already {
@@ -101,6 +120,16 @@ func (m *model) reconcileGone(summaries []session.SessionSummary) {
 			m.gone[id] = goneEvicted
 		}
 	}
+}
+
+// hasSession reports whether summaries contains id.
+func hasSession(summaries []session.SessionSummary, id string) bool {
+	for _, s := range summaries {
+		if s.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // soleNewSession returns the id the store rekeyed to, or "" when that cannot be
@@ -127,16 +156,22 @@ func soleNewSession(serverIDs map[string]bool, prev []session.SessionSummary) st
 }
 
 // migrateSession moves cached events from oldID to newID, mirroring the store's
-// Rekey. It will not clobber an existing cache under newID: the store's own
-// Rekey is a no-op when newID already exists, so the events there are already
-// the authoritative copy.
+// Rekey. It never clobbers an existing cache under newID, and never deletes
+// oldID's events unless they were successfully moved — see the early return.
 func (m *model) migrateSession(oldID, newID string, events []pipeline.SessionEvent) {
-	if _, exists := m.events[newID]; !exists {
-		for i := range events {
-			events[i].SessionID = newID
-		}
-		m.events[newID] = events
+	if _, exists := m.events[newID]; exists {
+		// Already holding a cache under newID. Do NOT drop oldID's events: this is
+		// the one place a delete could still lose the only copy of a history, which
+		// is exactly what this file exists to prevent. Leaving them alone lets
+		// reconcileGone's loop tombstone oldID on its own, so they stay viewable.
+		// (The server's own Rekey is a no-op in this situation, but abctl's cache is
+		// not the server's store — that distinction is the whole point here.)
+		return
 	}
+	for i := range events {
+		events[i].SessionID = newID
+	}
+	m.events[newID] = events
 	delete(m.events, oldID)
 	delete(m.gone, oldID)
 	if m.selectedSess == oldID {

--- a/authbridge/cmd/abctl/tui/gone.go
+++ b/authbridge/cmd/abctl/tui/gone.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/session"
@@ -69,24 +70,25 @@ func (m *model) reconcileGone(summaries []session.SessionSummary) {
 	// events under the old key are the same events. Migrate them so the history
 	// stays attached to the surviving id, and follow the user's selection over.
 	//
-	// ORDERING DEPENDENCY: soleNewSession compares against m.sessions, which must
-	// still hold the PREVIOUS list. The caller therefore has to invoke this before
+	// ORDERING DEPENDENCY: rekeyedTo compares against m.sessions, which must still
+	// hold the PREVIOUS list. The caller therefore has to invoke this before
 	// assigning m.sessions = msg (see the sessionsLoadedMsg case in app.go). Swap
-	// those two lines and every id looks familiar, soleNewSession returns "", and
-	// rekeys silently stop migrating — the events survive under the old id, so the
-	// bug shows up only as a stale duplicate bucket rather than as a failure.
+	// those two lines and the previous "default" summary is gone, rekeyedTo returns
+	// "", and rekeys silently stop migrating — the events survive under the old id,
+	// so the bug shows up only as a stale duplicate bucket rather than as a failure.
 	//
-	// Two further conditions narrow this to a rename, because "default vanished
-	// and one unfamiliar id appeared" is also what an eviction of default plus an
-	// unrelated new session looks like — and migrating then would file the events
-	// under a session they never belonged to. A rename keeps the list the same
-	// size, and starts from a list that actually contained "default". Neither is
-	// proof (the server does not tell us), which is why the failure mode is now
-	// merely a missed migration rather than a wrong one: declining leaves the
-	// events viewable under the old id, tombstoned by the loop below.
-	if events, ok := m.events[session.DefaultSessionID]; ok && !serverIDs[session.DefaultSessionID] &&
-		len(summaries) == len(m.sessions) && hasSession(m.sessions, session.DefaultSessionID) {
-		if newID := soleNewSession(serverIDs, m.sessions); newID != "" {
+	// The discriminator is CreatedAt, not the shape of the list. Earlier revisions
+	// of this code guessed from "default vanished and one unfamiliar id appeared",
+	// narrowed with list-length and prior-membership checks. Those heuristics fail
+	// in the ordinary steady state at max_sessions: Append evicts when the count
+	// EXCEEDS the cap and evictOldestLocked removes exactly one entry, so session
+	// #101 arriving means one id vanishes and one appears with the length
+	// unchanged. If the evicted one was a stale "default" (it is spared only while
+	// it is activeID), every heuristic passed and default's history was filed under
+	// an unrelated session — the precise outcome the old comment claimed to
+	// prevent. See TestEvictionAtCapacity_DoesNotMisMigrate.
+	if events, ok := m.events[session.DefaultSessionID]; ok && !serverIDs[session.DefaultSessionID] {
+		if newID := rekeyedTo(summaries, m.sessions); newID != "" {
 			m.migrateSession(session.DefaultSessionID, newID, events)
 		}
 	}
@@ -122,35 +124,56 @@ func (m *model) reconcileGone(summaries []session.SessionSummary) {
 	}
 }
 
-// hasSession reports whether summaries contains id.
-func hasSession(summaries []session.SessionSummary, id string) bool {
-	for _, s := range summaries {
-		if s.ID == id {
-			return true
+// rekeyedTo returns the id that "default" was renamed to, or "" when no rename
+// can be proven. It is a proof, not a guess.
+//
+// Store.Rekey renames in place on the same *entry, so a rekeyed session carries
+// default's ORIGINAL CreatedAt; a session the store creates fresh gets
+// CreatedAt: now. Both values ride the wire as SessionSummary.CreatedAt
+// ("createdAt") and apiclient.ListSessions decodes them, so the timestamps are
+// available on both the previous list and the incoming one. Equal CreatedAt on an
+// id the client has never seen therefore identifies a rename and nothing else —
+// an evicted default plus an unrelated new session cannot fake it, because the
+// new session's CreatedAt is its own.
+//
+// Ambiguity still yields "": if several unseen ids share default's CreatedAt,
+// guessing which inherited the history would be worse than declining, and
+// declining is cheap (the events stay viewable under the old id, tombstoned).
+func rekeyedTo(summaries, prev []session.SessionSummary) string {
+	var created time.Time
+	for _, s := range prev {
+		if s.ID == session.DefaultSessionID {
+			created = s.CreatedAt
+			break
 		}
 	}
-	return false
-}
+	// No previous default summary — nothing to match against. Note this is also
+	// what a caller that already overwrote m.sessions looks like.
+	if created.IsZero() {
+		return ""
+	}
 
-// soleNewSession returns the id the store rekeyed to, or "" when that cannot be
-// established unambiguously. A rekey shows up as exactly one id that the server
-// now lists and abctl has never seen before; if several appeared, guessing which
-// inherited "default" would be worse than leaving the events where they are
-// (they stay viewable under the old id either way, just marked gone).
-func soleNewSession(serverIDs map[string]bool, prev []session.SessionSummary) string {
 	seen := make(map[string]bool, len(prev))
 	for _, s := range prev {
 		seen[s.ID] = true
 	}
+
 	found := ""
-	for id := range serverIDs {
-		if seen[id] {
+	for _, s := range summaries {
+		if seen[s.ID] {
+			continue
+		}
+		// .Equal, never ==: these came back through JSON, so the wall clocks match
+		// but the monotonic readings and *Location pointers need not. == compares
+		// the struct fields and returns false for the same instant — which would
+		// silently disable migration altogether rather than fail loudly.
+		if !s.CreatedAt.Equal(created) {
 			continue
 		}
 		if found != "" {
 			return "" // ambiguous
 		}
-		found = id
+		found = s.ID
 	}
 	return found
 }

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -318,6 +318,57 @@ func TestEvictionPlusNewSession_IsNotTreatedAsRekey(t *testing.T) {
 	}
 }
 
+// forgetGoneExcept frees other tombstones, and the sessions table renders its
+// tombstone rows from m.gone — so the table must be rebuilt at that call site.
+//
+// Without the rebuild the freed session keeps a row for up to one 2s refresh, and
+// the row lies: it still shows the event count from before the cache was dropped.
+// Backing out and selecting it then lands on an empty events pane AND flashes a
+// 404, because the snapshot guard keys off m.gone[id] — which was just deleted for
+// exactly that id, so it no longer looks gone.
+func TestForgetGone_RebuildsSessionsTable(t *testing.T) {
+	m := newTestGoneModel(t, "keep")
+	m.events["freed"] = make([]pipeline.SessionEvent, 3)
+	m.Update(sessionsLoadedMsg{})
+	m.rebuildSessionsTable()
+	if len(m.sessionsTbl.Rows()) != 2 {
+		t.Fatalf("precondition: want 2 tombstone rows, got %d", len(m.sessionsTbl.Rows()))
+	}
+
+	// Drive the REAL handler, so removing the rebuild from keys.go fails here. A
+	// test that called rebuildSessionsTable itself would pass either way.
+	m.pane = paneSessions
+	for i, r := range m.sessionsTbl.Rows() {
+		if r[0] == "keep" {
+			m.sessionsTbl.SetCursor(i)
+		}
+	}
+	m.handleKey(keyRune('l')) // enter/right/l on the sessions pane
+	if m.selectedSess != "keep" {
+		t.Fatalf("precondition: handler did not open \"keep\" (got %q)", m.selectedSess)
+	}
+
+	for _, r := range m.sessionsTbl.Rows() {
+		if r[0] == "freed" {
+			t.Errorf("freed tombstone still has a row advertising %q events, "+
+				"but its cache holds %d", r[2], len(m.events["freed"]))
+		}
+	}
+	if _, ok := m.gone["keep"]; !ok {
+		t.Error("the opened session lost its tombstone, so the snapshot guard " +
+			"can no longer suppress a 404 fetch")
+	}
+	var keptRow bool
+	for _, r := range m.sessionsTbl.Rows() {
+		if r[0] == "keep" {
+			keptRow = true
+		}
+	}
+	if !keptRow {
+		t.Error("the opened session lost its row; its retained events are unreachable")
+	}
+}
+
 // Two unseen ids at once cannot identify which inherited "default". Guessing
 // would be worse than holding still: the events stay viewable under the old id
 // either way, just marked gone.

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -92,8 +92,10 @@ func TestGoneSessionStaysInSessionsTable(t *testing.T) {
 	for _, r := range m.sessionsTbl.Rows() {
 		if r[0] == "vanished" {
 			found = true
-			if !strings.Contains(r[2], "3") {
-				t.Errorf("tombstone row lost its event count: %v", r)
+			// Exact, not Contains: "13" and "30" contain "3" and would sail
+			// through a substring check on a count that had drifted.
+			if r[2] != "3" {
+				t.Errorf("tombstone row lost its event count: got %q, want %q in %v", r[2], "3", r)
 			}
 		}
 	}
@@ -160,6 +162,36 @@ func TestRekey_MigratesEventsAndSelection(t *testing.T) {
 		if e.SessionID != "ctx-42" {
 			t.Errorf("migrated event kept the stale SessionID %q", e.SessionID)
 		}
+	}
+}
+
+// Guards the ordering dependency the rekey detection rests on: reconcileGone
+// must run while m.sessions still holds the PREVIOUS list, because that is how it
+// tells a rekeyed id from one it already knew.
+//
+// This drives Update (not reconcileGone directly), so reordering the two lines in
+// the sessionsLoadedMsg case fails here. Without it a reorder would be silent: no
+// id looks new, soleNewSession returns "", and the rekey just stops migrating —
+// leaving a stale duplicate bucket rather than an error.
+func TestRekeyDetection_RunsBeforeSessionsIsReplaced(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	// "known" is already in the previous list, so only "ctx-42" is new. Were
+	// m.sessions replaced first, both would look known and nothing would migrate.
+	m.sessions = []session.SessionSummary{
+		{ID: session.DefaultSessionID}, {ID: "known"},
+	}
+
+	m.Update(sessionsLoadedMsg{
+		{ID: "known", UpdatedAt: time.Now()},
+		{ID: "ctx-42", UpdatedAt: time.Now()},
+	})
+
+	if len(m.events["ctx-42"]) != 3 {
+		t.Fatalf("rekey did not migrate: reconcileGone likely ran after m.sessions " +
+			"was replaced, so no id looked new")
+	}
+	if _, stale := m.events[session.DefaultSessionID]; stale {
+		t.Error("old bucket left behind as a duplicate")
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -264,15 +264,24 @@ func TestMigrateDeclined_DoesNotDropTheSource(t *testing.T) {
 func TestMigrateDeclined_TombstonesTheSource(t *testing.T) {
 	m := newTestGoneModel(t, session.DefaultSessionID)
 	m.events["ctx-42"] = make([]pipeline.SessionEvent, 1)
-	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID}, {ID: "ctx-42"}}
+	// "ctx-42" must NOT be in the previous list, or it is not an unseen id and
+	// rekeyedTo skips it — leaving migrateSession unentered and this test a
+	// duplicate of TestEvictionPlusNewSession_IsNotTreatedAsRekey. The matching
+	// CreatedAt is what proves the rename and gets us into migrateSession, which
+	// then declines because ctx-42 is already cached.
+	created := time.Now().Add(-time.Hour)
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID, CreatedAt: created}}
 
-	m.Update(sessionsLoadedMsg{{ID: "ctx-42", UpdatedAt: time.Now()}})
+	m.Update(sessionsLoadedMsg{{ID: "ctx-42", CreatedAt: created, UpdatedAt: time.Now()}})
 
 	if len(m.events[session.DefaultSessionID]) != 3 {
 		t.Fatal("source events were dropped")
 	}
 	if _, ok := m.gone[session.DefaultSessionID]; !ok {
 		t.Error("source was neither migrated nor tombstoned — retained but unreachable")
+	}
+	if got := len(m.events["ctx-42"]); got != 1 {
+		t.Errorf("existing target cache was clobbered: got %d events, want 1", got)
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -181,9 +181,12 @@ func TestForgetGoneExcept_KeepsTheOpenedSession(t *testing.T) {
 // events are the same events, so they follow the id — and so does the selection.
 func TestRekey_MigratesEventsAndSelection(t *testing.T) {
 	m := newTestGoneModel(t, session.DefaultSessionID)
-	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID}}
+	// Store.Rekey renames in place on the same *entry, so the new id reports
+	// default's ORIGINAL CreatedAt. That equality is what proves a rename.
+	created := time.Now().Add(-time.Hour)
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID, CreatedAt: created}}
 
-	m.Update(sessionsLoadedMsg{{ID: "ctx-42", UpdatedAt: time.Now()}})
+	m.Update(sessionsLoadedMsg{{ID: "ctx-42", CreatedAt: created, UpdatedAt: time.Now()}})
 
 	if len(m.events["ctx-42"]) != 3 {
 		t.Errorf("events did not follow the rekey: %d under the new id", len(m.events["ctx-42"]))
@@ -209,20 +212,23 @@ func TestRekey_MigratesEventsAndSelection(t *testing.T) {
 // tells a rekeyed id from one it already knew.
 //
 // This drives Update (not reconcileGone directly), so reordering the two lines in
-// the sessionsLoadedMsg case fails here. Without it a reorder would be silent: no
-// id looks new, soleNewSession returns "", and the rekey just stops migrating —
-// leaving a stale duplicate bucket rather than an error.
+// the sessionsLoadedMsg case fails here. Without it a reorder would be silent:
+// there is no previous "default" summary to read a CreatedAt from, rekeyedTo
+// returns "", and the rekey just stops migrating — leaving a stale duplicate
+// bucket rather than an error.
 func TestRekeyDetection_RunsBeforeSessionsIsReplaced(t *testing.T) {
 	m := newTestGoneModel(t, session.DefaultSessionID)
+	created := time.Now().Add(-time.Hour)
 	// "known" is already in the previous list, so only "ctx-42" is new. Were
-	// m.sessions replaced first, both would look known and nothing would migrate.
+	// m.sessions replaced first, there would be no default summary to match.
 	m.sessions = []session.SessionSummary{
-		{ID: session.DefaultSessionID}, {ID: "known"},
+		{ID: session.DefaultSessionID, CreatedAt: created},
+		{ID: "known", CreatedAt: created},
 	}
 
 	m.Update(sessionsLoadedMsg{
-		{ID: "known", UpdatedAt: time.Now()},
-		{ID: "ctx-42", UpdatedAt: time.Now()},
+		{ID: "known", CreatedAt: created, UpdatedAt: time.Now()},
+		{ID: "ctx-42", CreatedAt: created, UpdatedAt: time.Now()},
 	})
 
 	if len(m.events["ctx-42"]) != 3 {
@@ -292,19 +298,53 @@ func TestEmptyCacheKey_IsNotTombstoned(t *testing.T) {
 	}
 }
 
-// An eviction of "default" plus an unrelated new session looks exactly like a
-// rename to a naive check: default gone, one unfamiliar id present. Migrating
-// then would file the events under a session they never belonged to. The list
-// shrinking (2 previous, 2 now, but one of the previous was itself evicted) is
-// the tell — here the list grows past what a rename could produce.
-func TestEvictionPlusNewSession_IsNotTreatedAsRekey(t *testing.T) {
+// The steady state at max_sessions, which every list-shape heuristic gets wrong.
+//
+// Append evicts only when the count EXCEEDS the cap and evictOldestLocked removes
+// exactly one entry, so at capacity session #101 arriving means one id vanishes
+// and one appears with the LENGTH UNCHANGED. A stale "default" is the prime
+// candidate for eviction (it is spared only while it is activeID). An earlier
+// revision gated on list length plus prior membership and mis-migrated here,
+// filing default's history under a session it never belonged to — while the
+// banner correctly called it "evicted". CreatedAt is what separates the two: the
+// new session's own creation time cannot match default's.
+func TestEvictionAtCapacity_DoesNotMisMigrate(t *testing.T) {
 	m := newTestGoneModel(t, session.DefaultSessionID)
-	// Previously: default only. Now: two unrelated sessions, default evicted.
-	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID}}
+	created := time.Now().Add(-time.Hour)
+	// Previous list and new list are the SAME LENGTH, and the previous one did
+	// contain default — the two conditions the old heuristics checked.
+	m.sessions = []session.SessionSummary{
+		{ID: session.DefaultSessionID, CreatedAt: created},
+		{ID: "keeper", CreatedAt: created},
+	}
 
 	m.Update(sessionsLoadedMsg{
-		{ID: "other", UpdatedAt: time.Now()},
-		{ID: "unrelated", UpdatedAt: time.Now()},
+		{ID: "keeper", CreatedAt: created, UpdatedAt: time.Now()},
+		// Brand new: its own CreatedAt, not default's.
+		{ID: "unrelated-new", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	})
+
+	if ev, ok := m.events["unrelated-new"]; ok {
+		t.Errorf("default's %d events were filed under an unrelated session", len(ev))
+	}
+	if len(m.events[session.DefaultSessionID]) != 3 {
+		t.Error("default's events left their bucket without a proven rename")
+	}
+	if _, ok := m.gone[session.DefaultSessionID]; !ok {
+		t.Error("default should be tombstoned, not silently migrated")
+	}
+}
+
+// An eviction that also changes the list length must not migrate either.
+func TestEvictionPlusNewSession_IsNotTreatedAsRekey(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	created := time.Now().Add(-time.Hour)
+	// Previously: default only. Now: two unrelated sessions, default evicted.
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID, CreatedAt: created}}
+
+	m.Update(sessionsLoadedMsg{
+		{ID: "other", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "unrelated", CreatedAt: time.Now(), UpdatedAt: time.Now()},
 	})
 
 	if _, ok := m.events["other"]; ok {
@@ -366,6 +406,36 @@ func TestForgetGone_RebuildsSessionsTable(t *testing.T) {
 	}
 	if !keptRow {
 		t.Error("the opened session lost its row; its retained events are unreachable")
+	}
+}
+
+// CreatedAt must be compared with .Equal(), not ==. Both sides arrive via JSON,
+// so the same instant can carry different monotonic readings and *Location
+// pointers; == compares struct fields and returns false, which would silently
+// disable migration rather than fail loudly. This models the round trip by
+// re-parsing an RFC3339 timestamp, the way encoding/json does.
+func TestRekeyDetection_UsesEqualNotStructCompare(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	viaJSON, err := time.Parse(time.RFC3339Nano, base.Format(time.RFC3339Nano))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if base == viaJSON {
+		t.Skip("this platform's == happens to match; the .Equal contract still holds")
+	}
+	if !base.Equal(viaJSON) {
+		t.Fatal("precondition: the two should be the same instant")
+	}
+
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID, CreatedAt: base}}
+
+	// The incoming summary carries the JSON-round-tripped timestamp.
+	m.Update(sessionsLoadedMsg{{ID: "ctx-42", CreatedAt: viaJSON, UpdatedAt: time.Now()}})
+
+	if len(m.events["ctx-42"]) != 3 {
+		t.Error("migration declined across a JSON round trip — CreatedAt is being " +
+			"compared with == rather than .Equal()")
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -285,6 +285,49 @@ func TestMigrateDeclined_TombstonesTheSource(t *testing.T) {
 	}
 }
 
+// The README documents the sessions table's columns and shows a tombstone row
+// populating TOKENS. Pin the column set so the doc and the table cannot drift
+// again — they had, silently: the README listed four columns for five.
+func TestSessionsTable_ColumnsMatchDocumentedSet(t *testing.T) {
+	want := []string{"ID", "UPDATED", "EVENTS", "TOKENS", "ACTIVE"}
+	tbl := newSessionsTable()
+	got := make([]string, 0, len(want))
+	for _, c := range tbl.Columns() {
+		got = append(got, c.Title)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("column count changed: got %v, want %v — update abctl/README.md", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("column %d: got %q, want %q — update abctl/README.md", i, got[i], want[i])
+		}
+	}
+}
+
+// And a tombstone row really does populate TOKENS from the cache, as the README's
+// diagram shows — it is not blank just because the server summary is gone.
+func TestGoneRow_PopulatesTokensFromCache(t *testing.T) {
+	m := newTestGoneModel(t, "vanished")
+	evs := m.events["vanished"]
+	evs[0].Phase = pipeline.SessionResponse
+	evs[0].Inference = &pipeline.InferenceExtension{TotalTokens: 320}
+	m.events["vanished"] = evs
+
+	m.Update(sessionsLoadedMsg{})
+	m.rebuildSessionsTable()
+
+	for _, r := range m.sessionsTbl.Rows() {
+		if r[0] == "vanished" {
+			if r[3] != "320" {
+				t.Errorf("TOKENS on a tombstone row = %q, want %q", r[3], "320")
+			}
+			return
+		}
+	}
+	t.Error("tombstone row missing")
+}
+
 // A cache key with no events must not be tombstoned. snapshotLoadedMsg assigns
 // m.events[id] unconditionally, so drilling into an empty session creates the key;
 // a tombstone there renders "id — 0 — gone", advertising events that do not exist.

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -1,0 +1,207 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+)
+
+// The regression this whole file exists for.
+//
+// Nearly every deployment of the single-agent shape names its session "default"
+// (session.DefaultSessionID). Restart the proxy and /v1/sessions returns an empty
+// list — not an error — until traffic arrives. The old reconcile read that as
+// "the server does not know these sessions" and deleted every cached event 2s
+// later, then threw the user back to the sessions pane. Since the store is
+// in-memory and per-pod, abctl's copy was the only one, so the events the user
+// was reading were gone for good, without them doing anything.
+func TestEmptySessionList_KeepsEventsAndPane(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+
+	m.Update(sessionsLoadedMsg{})
+
+	if got := len(m.events[session.DefaultSessionID]); got != 3 {
+		t.Errorf("events were deleted on an empty server list: got %d, want 3", got)
+	}
+	if m.pane != paneEvents {
+		t.Errorf("pane changed under the user: got %v, want paneEvents", m.pane)
+	}
+	if m.selectedSess != session.DefaultSessionID {
+		t.Errorf("selection cleared: got %q", m.selectedSess)
+	}
+	if m.gone[session.DefaultSessionID] != goneRestart {
+		t.Errorf("an empty list should read as a restart, got %v", m.gone[session.DefaultSessionID])
+	}
+}
+
+// A session missing while OTHERS are still listed is an eviction, not a restart —
+// different cause, different advice in the banner, same retention.
+func TestMissingWhileOthersLive_MarksEvicted(t *testing.T) {
+	m := newTestGoneModel(t, "old")
+
+	m.Update(sessionsLoadedMsg{{ID: "fresh", UpdatedAt: time.Now()}})
+
+	if len(m.events["old"]) != 3 {
+		t.Error("evicted session's cached events were deleted")
+	}
+	if m.gone["old"] != goneEvicted {
+		t.Errorf("want goneEvicted, got %v", m.gone["old"])
+	}
+}
+
+// The notice must name the real mechanism. Time-based expiry is OFF by default
+// (session.ttl defaults to never), so "expired" would be actively misleading —
+// it is what the original issue guessed, and it sent the diagnosis the wrong way.
+func TestGoneBanner_DoesNotClaimExpiry(t *testing.T) {
+	for _, r := range []goneReason{goneRestart, goneEvicted} {
+		b := goneBanner(r, 200)
+		if strings.Contains(strings.ToLower(b), "expir") {
+			t.Errorf("banner blames expiry: %q", b)
+		}
+		if !strings.Contains(b, "⚠") {
+			t.Errorf("banner is not marked as a warning: %q", b)
+		}
+	}
+}
+
+// The banner reserves a row in rebuildEventsTable, so it must always render one.
+// At width 0 (before the first WindowSizeMsg) trunc would otherwise return "",
+// reserving a row that draws nothing and pushing the last event off-screen.
+func TestGoneBanner_NeverEmpty(t *testing.T) {
+	for _, w := range []int{0, -1, 10, 200} {
+		if goneBanner(goneRestart, w) == "" {
+			t.Errorf("empty banner at width %d, but a row was reserved for it", w)
+		}
+	}
+}
+
+// A tombstoned session still holds events, so it must stay reachable in the
+// sessions table — retaining events the user cannot navigate to would be a
+// half-fix.
+func TestGoneSessionStaysInSessionsTable(t *testing.T) {
+	m := newTestGoneModel(t, "vanished")
+	m.sessionsTbl = newSessionsTable()
+
+	m.Update(sessionsLoadedMsg{})
+	m.rebuildSessionsTable()
+
+	var found bool
+	for _, r := range m.sessionsTbl.Rows() {
+		if r[0] == "vanished" {
+			found = true
+			if !strings.Contains(r[2], "3") {
+				t.Errorf("tombstone row lost its event count: %v", r)
+			}
+		}
+	}
+	if !found {
+		t.Error("tombstoned session disappeared from the sessions table")
+	}
+}
+
+// Traffic resuming under the same id proves the session is live again.
+func TestReappearingSession_ClearsTombstone(t *testing.T) {
+	m := newTestGoneModel(t, "s")
+	m.Update(sessionsLoadedMsg{})
+	if _, ok := m.gone["s"]; !ok {
+		t.Fatal("precondition: session should be tombstoned")
+	}
+
+	m.Update(sessionsLoadedMsg{{ID: "s", UpdatedAt: time.Now()}})
+
+	if _, ok := m.gone["s"]; ok {
+		t.Error("tombstone survived the session coming back")
+	}
+}
+
+// Cleanup is deferred to the moment the user picks a DIFFERENT session — the one
+// reliable signal that the old events stopped being what they were looking at.
+// The session being opened is kept even when gone; that is the point.
+func TestForgetGoneExcept_KeepsTheOpenedSession(t *testing.T) {
+	m := newTestGoneModel(t, "a")
+	m.events["b"] = make([]pipeline.SessionEvent, 2)
+	m.gone = map[string]goneReason{"a": goneRestart, "b": goneRestart}
+
+	m.forgetGoneExcept("a")
+
+	if len(m.events["a"]) != 3 {
+		t.Error("the session the user opened was dropped")
+	}
+	if _, ok := m.events["b"]; ok {
+		t.Error("an unrelated gone session was not cleaned up on selection")
+	}
+}
+
+// A rekey is the one case where cached events legitimately MOVE: the store
+// renames the bootstrap "default" bucket to the server-assigned contextId. The
+// events are the same events, so they follow the id — and so does the selection.
+func TestRekey_MigratesEventsAndSelection(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID}}
+
+	m.Update(sessionsLoadedMsg{{ID: "ctx-42", UpdatedAt: time.Now()}})
+
+	if len(m.events["ctx-42"]) != 3 {
+		t.Errorf("events did not follow the rekey: %d under the new id", len(m.events["ctx-42"]))
+	}
+	if _, ok := m.events[session.DefaultSessionID]; ok {
+		t.Error("the old bucket was left behind as a duplicate")
+	}
+	if m.selectedSess != "ctx-42" {
+		t.Errorf("selection did not follow the rekey: %q", m.selectedSess)
+	}
+	if _, ok := m.gone["ctx-42"]; ok {
+		t.Error("a rekeyed session should be live, not tombstoned")
+	}
+	for _, e := range m.events["ctx-42"] {
+		if e.SessionID != "ctx-42" {
+			t.Errorf("migrated event kept the stale SessionID %q", e.SessionID)
+		}
+	}
+}
+
+// Two unseen ids at once cannot identify which inherited "default". Guessing
+// would be worse than holding still: the events stay viewable under the old id
+// either way, just marked gone.
+func TestAmbiguousRekey_DoesNotGuess(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+
+	m.Update(sessionsLoadedMsg{
+		{ID: "ctx-1", UpdatedAt: time.Now()},
+		{ID: "ctx-2", UpdatedAt: time.Now()},
+	})
+
+	if len(m.events[session.DefaultSessionID]) != 3 {
+		t.Error("events were moved or dropped on an ambiguous rekey")
+	}
+	if m.gone[session.DefaultSessionID] != goneEvicted {
+		t.Error("the unmoved bucket should be tombstoned, not silently live")
+	}
+}
+
+// newTestGoneModel builds a model focused on sessionID with 3 cached events.
+func newTestGoneModel(t *testing.T, sessionID string) *model {
+	t.Helper()
+	events := make([]pipeline.SessionEvent, 3)
+	for i := range events {
+		events[i] = pipeline.SessionEvent{
+			At:        time.Now(),
+			Direction: pipeline.Outbound,
+			Phase:     pipeline.SessionRequest,
+			Host:      "api.example.com",
+			SessionID: sessionID,
+		}
+	}
+	m := &model{
+		pane: paneEvents, selectedSess: sessionID, bodyHeight: 12, width: 200,
+		events:       map[string][]pipeline.SessionEvent{sessionID: events},
+		eventColumns: defaultColumnSelection(),
+	}
+	m.eventsTbl = newEventsTable()
+	m.sessionsTbl = newSessionsTable()
+	m.rebuildEventsTable()
+	return m
+}

--- a/authbridge/cmd/abctl/tui/gone_test.go
+++ b/authbridge/cmd/abctl/tui/gone_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/session"
 )
@@ -104,6 +107,42 @@ func TestGoneSessionStaysInSessionsTable(t *testing.T) {
 	}
 }
 
+// The gap that let an ANSI-styled table cell through: every other test here
+// asserts on Rows() DATA, which never exercises rendering, and CI has no TTY —
+// lipgloss emits no escape sequences when its profile is Ascii, so a styled cell
+// measures its visible width and truncation is a no-op.
+//
+// This forces a colour profile, renders the real View(), and asserts the label
+// survives. bubbles v1.0.0 truncates each cell with runewidth.Truncate BEFORE
+// styling (table.go renderRow); runewidth is not ANSI-aware, so a styled "gone"
+// measures 11 against the ACTIVE column's width of 8 and renders as "gon…" with
+// the closing reset stripped, bleeding colour into every later cell.
+func TestGoneMarker_SurvivesRenderingUnderColor(t *testing.T) {
+	orig := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(orig) })
+
+	m := newTestGoneModel(t, "vanished")
+	m.pane = paneSessions
+	m.width, m.height = 200, 40
+	m.Update(sessionsLoadedMsg{})
+	m.rebuildSessionsTable()
+
+	view := m.sessionsTbl.View()
+	if !strings.Contains(view, "gone") {
+		t.Errorf("the gone marker did not survive rendering; got truncated or mangled:\n%s", view)
+	}
+	if strings.Contains(view, "gon…") {
+		t.Error("the gone marker was truncated mid-label — a styled cell is being " +
+			"measured with its escape bytes counted against the column width")
+	}
+	// An odd number of SGR introducers without matching resets is how the colour
+	// bleed manifests: Truncate drops the trailing \x1b[0m.
+	if opens, resets := strings.Count(view, "\x1b["), strings.Count(view, "\x1b[0m"); opens > 0 && resets == 0 {
+		t.Errorf("styled output has %d escape sequences and no resets — colour will bleed", opens)
+	}
+}
+
 // Traffic resuming under the same id proves the session is live again.
 func TestReappearingSession_ClearsTombstone(t *testing.T) {
 	m := newTestGoneModel(t, "s")
@@ -192,6 +231,90 @@ func TestRekeyDetection_RunsBeforeSessionsIsReplaced(t *testing.T) {
 	}
 	if _, stale := m.events[session.DefaultSessionID]; stale {
 		t.Error("old bucket left behind as a duplicate")
+	}
+}
+
+// migrateSession must not delete the source when it declines to migrate. When
+// newID is already cached the move is skipped, and an unconditional
+// delete(m.events, oldID) would discard the default bucket with no migration and
+// no tombstone — the one unrecoverable deletion path this file exists to remove.
+func TestMigrateDeclined_DoesNotDropTheSource(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	// Already holding a cache under the target id.
+	m.events["ctx-42"] = make([]pipeline.SessionEvent, 1)
+
+	m.migrateSession(session.DefaultSessionID, "ctx-42", m.events[session.DefaultSessionID])
+
+	if got := len(m.events[session.DefaultSessionID]); got != 3 {
+		t.Errorf("source events dropped without being migrated: got %d, want 3", got)
+	}
+	if got := len(m.events["ctx-42"]); got != 1 {
+		t.Errorf("existing target cache was clobbered: got %d, want 1", got)
+	}
+}
+
+// And the declined case still leaves the source reachable: reconcileGone's loop
+// tombstones it, so the events stay viewable under the old id.
+func TestMigrateDeclined_TombstonesTheSource(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	m.events["ctx-42"] = make([]pipeline.SessionEvent, 1)
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID}, {ID: "ctx-42"}}
+
+	m.Update(sessionsLoadedMsg{{ID: "ctx-42", UpdatedAt: time.Now()}})
+
+	if len(m.events[session.DefaultSessionID]) != 3 {
+		t.Fatal("source events were dropped")
+	}
+	if _, ok := m.gone[session.DefaultSessionID]; !ok {
+		t.Error("source was neither migrated nor tombstoned — retained but unreachable")
+	}
+}
+
+// A cache key with no events must not be tombstoned. snapshotLoadedMsg assigns
+// m.events[id] unconditionally, so drilling into an empty session creates the key;
+// a tombstone there renders "id — 0 — gone", advertising events that do not exist.
+func TestEmptyCacheKey_IsNotTombstoned(t *testing.T) {
+	m := newTestGoneModel(t, "real")
+	m.events["empty"] = nil
+
+	m.Update(sessionsLoadedMsg{})
+
+	if _, ok := m.gone["empty"]; ok {
+		t.Error("a session with no cached events was tombstoned")
+	}
+	if _, ok := m.gone["real"]; !ok {
+		t.Error("the session that does hold events was not tombstoned")
+	}
+	for _, r := range m.sessionsTbl.Rows() {
+		if r[0] == "empty" {
+			t.Errorf("empty session rendered a tombstone row: %v", r)
+		}
+	}
+}
+
+// An eviction of "default" plus an unrelated new session looks exactly like a
+// rename to a naive check: default gone, one unfamiliar id present. Migrating
+// then would file the events under a session they never belonged to. The list
+// shrinking (2 previous, 2 now, but one of the previous was itself evicted) is
+// the tell — here the list grows past what a rename could produce.
+func TestEvictionPlusNewSession_IsNotTreatedAsRekey(t *testing.T) {
+	m := newTestGoneModel(t, session.DefaultSessionID)
+	// Previously: default only. Now: two unrelated sessions, default evicted.
+	m.sessions = []session.SessionSummary{{ID: session.DefaultSessionID}}
+
+	m.Update(sessionsLoadedMsg{
+		{ID: "other", UpdatedAt: time.Now()},
+		{ID: "unrelated", UpdatedAt: time.Now()},
+	})
+
+	if _, ok := m.events["other"]; ok {
+		t.Error("events migrated to an unrelated session id")
+	}
+	if len(m.events[session.DefaultSessionID]) != 3 {
+		t.Error("events left the default bucket without a real rename")
+	}
+	if _, ok := m.gone[session.DefaultSessionID]; !ok {
+		t.Error("default should be tombstoned, not silently migrated")
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -410,7 +410,16 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			}
 			m.selectedSess = id
 			m.pane = paneEvents
+			// Now that the user has chosen, any OTHER tombstoned session has
+			// demonstrably stopped being what they are looking at — the one
+			// reliable cue for when cached events stopped mattering.
+			m.forgetGoneExcept(id)
 			m.rebuildEventsTable()
+			if _, gone := m.gone[id]; gone {
+				// No server-side session to snapshot: the fetch would 404 and
+				// flash an error over the events we deliberately kept.
+				return nil
+			}
 			// Snapshot in case the stream hasn't yet delivered history.
 			return m.snapshotCmd(id)
 		case paneEvents:

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -414,6 +414,14 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			// demonstrably stopped being what they are looking at — the one
 			// reliable cue for when cached events stopped mattering.
 			m.forgetGoneExcept(id)
+			// forgetGoneExcept mutates m.gone, and the sessions table renders its
+			// tombstone rows from that map — so rebuild it here rather than waiting
+			// for the 2s refresh. Otherwise a freed tombstone keeps a row that still
+			// advertises its old event count, and backing out and selecting it lands
+			// on an empty events pane plus a 404 error-flash from the snapshot fetch
+			// (the :418 guard below does not catch it: the tombstone for THAT id was
+			// freed, so it no longer looks gone).
+			m.rebuildSessionsTable()
 			m.rebuildEventsTable()
 			if _, gone := m.gone[id]; gone {
 				// No server-side session to snapshot: the fetch would 404 and

--- a/authbridge/cmd/abctl/tui/sessions_pane.go
+++ b/authbridge/cmd/abctl/tui/sessions_pane.go
@@ -36,7 +36,7 @@ func (m *model) rebuildSessionsTable() {
 		prev = rows[m.sessionsTbl.Cursor()][0]
 	}
 	now := time.Now()
-	rows := make([]table.Row, 0, len(m.sessions))
+	rows := make([]table.Row, 0, len(m.sessions)+len(m.gone))
 	for _, s := range m.sessions {
 		if m.filter != "" && !strings.Contains(s.ID, m.filter) {
 			continue
@@ -51,6 +51,23 @@ func (m *model) rebuildSessionsTable() {
 			fmt.Sprintf("%d", s.EventCount),
 			sessionTokens(s.TotalTokens, m.events[s.ID]),
 			active,
+		})
+	}
+	// Tombstones. The server has stopped listing these, but abctl still holds
+	// their events — so they have to stay reachable here, or the events would be
+	// retained and yet unnavigable. Marked "gone" in the active column and
+	// counted from the local cache, since no server summary exists any more.
+	for _, id := range m.goneIDs() {
+		if m.filter != "" && !strings.Contains(id, m.filter) {
+			continue
+		}
+		cached := m.events[id]
+		rows = append(rows, table.Row{
+			id,
+			"—",
+			fmt.Sprintf("%d", len(cached)),
+			sessionTokens(0, cached),
+			styleWarn.Render("gone"),
 		})
 	}
 	m.sessionsTbl.SetRows(rows)

--- a/authbridge/cmd/abctl/tui/sessions_pane.go
+++ b/authbridge/cmd/abctl/tui/sessions_pane.go
@@ -67,7 +67,14 @@ func (m *model) rebuildSessionsTable() {
 			"—",
 			fmt.Sprintf("%d", len(cached)),
 			sessionTokens(0, cached),
-			styleWarn.Render("gone"),
+			// Plain text, NOT styleWarn.Render: bubbles v1.0.0 truncates each cell
+			// with runewidth.Truncate before styling it (table.go renderRow), and
+			// runewidth is not ANSI-aware. A styled "gone" measures 11 columns
+			// against this column's width of 8, so it renders as "gon…" with the
+			// trailing reset stripped — bleeding the colour into everything after
+			// it. Invisible without a TTY, where lipgloss emits no escapes at all.
+			// The colour lives on the events-pane banner instead.
+			"gone",
 		})
 	}
 	m.sessionsTbl.SetRows(rows)


### PR DESCRIPTION
Fixes #870.

`abctl` deleted its own cached events for any session the server stopped listing, and threw the user out of the pane they were reading. The store is in-memory and per-pod, so abctl's copy was the only copy.

Deterministic for the single-agent shape where nearly everything is one `default` bucket: after a proxy restart `/v1/sessions` returns an empty list (not an error), so it arrived as a normal `sessionsLoadedMsg`, matched nothing, and wiped the only bucket 2s later.

**On the root cause of #870, corrected.** An earlier revision of this body said
"time-based expiry was never involved — `session.ttl` defaults to never." That is
true of `main` today but *not* of the code the reporter was running. The `never`
default arrived in #904 (`caf38e4e`, merged 2026-09-08); before that the default
was `30m`. #870 was filed 2026-09-04, so at the time the reporter lost the events
they were analyzing, an idle session really could age out on its own after 30
minutes — which fits their description of being interrupted and coming back.

So TTL was plausibly a genuine cause of the original report, and the issue's first
hypothesis ("did Cortex expire them because they were too old?") was reasonable
rather than mistaken. #904 removed that cause; this PR fixes a second, independent
one that #904 did not touch, and which is what remains reproducible on current
`main`: `abctl` deleting its own cache. Both were needed — after #904, a restart or
an eviction still cost the user their events, because the deletion was client-side.

Worth knowing when closing #870: the fix is spread across #904 and this PR, and the
reporter's diagnosis was not wrong for their build.

The server list is now authoritative about what is **live**, not what is **viewable**:

| Trigger | Behavior |
|---|---|
| Empty list (restart, or all aged out) | keep events, banner naming both possibilities |
| Missing while others live | keep events, banner "evicted" |
| Genuine rekey | migrate events + selection to the new id |
| User selects another session | *now* release the old cache |

Tombstoned sessions stay listed as `gone` so retained events remain reachable; the pane is never changed underneath the user.

Two adjacent bugs found while tracing this, both separable:

- The footer's `drops: N` was fed by `m.drops`, never incremented anywhere, so it read `drops: 0` unconditionally. Removed — an honest counter needs the drop count on the SSE wire first (the server logs it only to its own slog).
- `maxEventsPerSession` claimed to match the server's `max_events`; it is 1000 against 500. Corrected the comment, kept the value.

`backToPodsPane` did not clear `colPicker` — the same latent bug `TestColumnPicker_DoesNotReturnAfterAnAsyncPaneChange` guards, on the async transition that survives this change. Fixed, and that test re-pointed at it.

Build, vet, `-race` and the full `abctl` suite pass. 15 new tests, each verified to
fail against the code it guards — including the render test, which is vacuous
without a forced colour profile since CI has no TTY.

Two follow-ups this PR deliberately leaves out of scope, both needing a server-side
change: putting the SSE drop count on the wire (so the removed footer indicator can
return with a real number), and a boot/instance id so `abctl` can detect a restart
directly instead of inferring it from an empty session list. The banner wording is
hedged accordingly until the latter exists.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Sessions no longer listed by the server remain visible as “gone,” with cached events and token totals accessible.
  - Warning banners explain unavailable sessions, including eviction and proxy restart scenarios.
  - Session retention and cache behavior are now documented, including configurable limits and optional time-based expiry.

- **Bug Fixes**
  - Prevented unnecessary fetch errors for gone sessions.
  - Event tables now account for status banners.
  - Session rekeying preserves associated events and selection.

- **UI Changes**
  - Removed the event-drop counter from the footer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
