### PR TITLE
Fix: Resolve the newest release without depending on the API quota

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ rebuilds a rolling pre-release, so `--ref=main` tracks the tip.
 you get that ref's *script* with the newest *release's* binaries. The installer warns
 when that happens rather than leaving you to infer it.
 
+You should not need `--ref` to get a release. The plain one-liner resolves the newest
+release itself, from the releases API and — when that is unavailable — from
+`releases.atom`, which is not bound by the API's 60-requests-per-hour-per-IP limit.
+
 Each binary reports its own build: `abctl --version` → `main-a1b2c3d`. Quote that,
 not "main", in a bug report — the channel moves under you.
 

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -200,16 +200,60 @@ newest_release() {
 	# Not /releases/latest either: it excludes prereleases, and this project ships them,
 	# so it names a tag from January. Listing releases asks what we actually mean — the
 	# newest release, whatever its flags.
-	_tag=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=10" 2>/dev/null \
-		| tr ',{}' '\n' \
-		| grep '^[[:space:]]*"tag_name"[[:space:]]*:' \
-		| cut -d'"' -f4 \
-		| grep -m1 '^v[0-9]')
+	# TWO sources, because one was not enough. api.github.com allows 60 requests per
+	# hour per IP unauthenticated — shared by everyone behind one NAT, and each install
+	# spends two. Exhausting it killed the documented one-liner outright and told the
+	# person to go find a version and pass --ref, which is the opposite of a one-line
+	# install. Observed on a normal laptop, not contrived.
+	_tag=$(release_tag_from_api)
+	[ -n "${_tag}" ] || _tag=$(release_tag_from_feed)
 	case "${_tag}" in
 		v[0-9]*) ;;
 		*) return 1 ;;
 	esac
 	printf '%s\n' "${_tag}"
+}
+
+# release_tag_from_api prints the newest v-tag per the releases API, or nothing.
+release_tag_from_api() {
+	# The status is captured rather than discarded so a 403 can be NAMED. Nearly always
+	# that is the unauthenticated rate limit, which is a wait-or-pin situation and not a
+	# bug — and the old message said only "could not resolve the newest release", which
+	# told nobody that waiting would fix it.
+	_body="${TMPDIR:-/tmp}/cortex-rel.$$"
+	_code=$(curl -sSL -o "${_body}" -w '%{http_code}' \
+		"https://api.github.com/repos/${REPO}/releases?per_page=10" 2>/dev/null) || _code="000"
+	if [ "${_code}" = "403" ] || [ "${_code}" = "429" ]; then
+		# Only worth saying if it is really the quota; a 403 for another reason should
+		# not be mislabelled.
+		if grep -q 'rate limit' "${_body}" 2>/dev/null; then
+			warn "GitHub's API rate limit for this network is exhausted (60/hour per IP, unauthenticated); trying the releases feed instead"
+		fi
+	fi
+	if [ "${_code}" = "200" ]; then
+		tr ',{}' '\n' <"${_body}" \
+			| grep '^[[:space:]]*"tag_name"[[:space:]]*:' \
+			| cut -d'"' -f4 \
+			| grep -m1 '^v[0-9]' || true
+	fi
+	rm -f "${_body}"
+}
+
+# release_tag_from_feed prints the newest v-tag per the releases Atom feed, or nothing.
+#
+# github.com, not api.github.com: the feed is not bound by the API's 60/hour, which is
+# the whole reason it is here. It lists releases newest-first and includes prereleases,
+# so it answers the same question the API does.
+#
+# The parse is anchored to the <title> ELEMENT rather than grepping for a version-shaped
+# line. Release notes are ours to author and appear in the same document, so an
+# unanchored match could be hijacked by a notes line that happens to start with a
+# version — the same shape of bug as the unanchored "tag_name" match this file already
+# guards against. Notes arrive HTML-escaped (&lt;p&gt;), so they cannot forge a <title>.
+release_tag_from_feed() {
+	curl -fsSL "https://github.com/${REPO}/releases.atom" 2>/dev/null \
+		| sed -n 's|.*<title>\(v[0-9][^<]*\)</title>.*|\1|p' \
+		| head -1
 }
 
 # resolve_version prints the release tag whose binaries should be installed, given the

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -53,18 +53,47 @@ fixture() { # name; body on stdin. Sets $FIXTURE to the path.
 	cat >"${FIXTURE}"
 }
 
+# emit_curl_stub prints a `curl` replacement that dispatches on the URL.
+#
+# One definition, used by every probe. newest_release() has two sources now, and a stub
+# serving one body to both could not tell them apart: the feed fallback would look
+# exercised while never running. Writing this twice is the drift that has already cost
+# this file two vacuous passes.
+# shellcheck disable=SC2016 # every expression below is literal on purpose: it is
+# expanded by the generated probe, not here. One directive for the whole function beats
+# five identical ones inline.
+emit_curl_stub() { # api-fixture feed-fixture api-http-code
+	printf 'curl() {\n'
+	printf '  _u=""; for _a in "$@"; do case "$_a" in http*) _u="$_a" ;; esac; done\n'
+	printf '  _o=""; _p=""; for _a in "$@"; do [ "${_p}" = "-o" ] && _o="$_a"; _p="$_a"; done\n'
+	printf '  case "${_u}" in\n'
+	printf '    *api.github.com*)\n'
+	printf '      [ -z "${_o}" ] || cat "%s" > "${_o}"\n' "$1"
+	printf '      [ -n "${_o}" ] || cat "%s"\n' "$1"
+	printf '      printf "%%s" "%s"\n' "$3"
+	printf '      [ "%s" = "200" ] || return 22\n' "$3"
+	printf '      ;;\n'
+	printf '    *releases.atom*) cat "%s" ;;\n' "$2"
+	printf '  esac\n'
+	printf '}\n'
+}
+
 # with_newest_release runs install.sh's newest_release() against a fixture.
 #
 # The function is extracted by line range rather than sourcing install.sh, because
 # sourcing would run the whole installer. `curl` is replaced by a function so the
 # extracted code is unmodified — testing what ships, not a copy of it.
-with_newest_release() { # fixture-path
+with_newest_release() { # api-fixture-path [feed-fixture-path] [api-http-code]
 	_f=$1
+	_feed=${2:-/dev/null}
+	_code=${3:-200}
 	{
 		printf 'REPO=rossoctl/cortex\n'
 		printf 'warn() { printf "warning: %%s\\n" "$*" >&2; }\n'
-		printf 'curl() { cat "%s"; }\n' "${_f}"
+		emit_curl_stub "${_f}" "${_feed}" "${_code}"
 		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
+		sed -n '/^release_tag_from_api()/,/^}/p' "${INSTALL_SH}"
+		sed -n '/^release_tag_from_feed()/,/^}/p' "${INSTALL_SH}"
 		printf 'newest_release\n'
 	} >"${TMP}/probe.sh"
 	sh "${TMP}/probe.sh" 2>/dev/null
@@ -169,8 +198,10 @@ with_resolve_version() { # version_ref fixture-path
 		# "stdout carries no progress text" case below unable to fail, which is the
 		# one thing it exists to catch.
 		printf 'info() { printf "%%s\\n" "$*"; }\n'
-		printf 'curl() { cat "%s"; }\n' "${_f}"
+		emit_curl_stub "${_f}" /dev/null 200
 		sed -n '/^newest_release()/,/^}/p' "${INSTALL_SH}"
+		sed -n '/^release_tag_from_api()/,/^}/p' "${INSTALL_SH}"
+		sed -n '/^release_tag_from_feed()/,/^}/p' "${INSTALL_SH}"
 		sed -n '/^resolve_version()/,/^}/p' "${INSTALL_SH}"
 		printf 'resolve_version "%s"\n' "${_ref}"
 	} >"${TMP}/rv.sh"
@@ -339,6 +370,82 @@ check "--ref=v0.5.0 with a transport failure refuses to run main" \
 # kind of vacuous pass that hid the unreachable arm above.
 check "--ref=v0.5.0 with a 200 script re-execs into it" \
 	"REEXECED" "$(with_bootstrap v0.5.0 200 v0.7.0-alpha.7)"
+
+# --- the one-liner survives an exhausted API quota ---
+#
+# This is the reason the feed source exists. 60 requests/hour per IP, unauthenticated,
+# shared behind NAT, two spent per install: exhausting it used to kill the documented
+# one-liner and tell the person to look up a version and pass --ref, which is the
+# opposite of a one-line install. The API failing must be invisible, not fatal.
+
+fixture feed.xml <<'EOF'
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Release notes from cortex</title>
+  <entry>
+    <title>v0.7.0-alpha.8</title>
+    <content type="html">&lt;p&gt;Prebuilt binaries&lt;/p&gt;</content>
+  </entry>
+  <entry>
+    <title>v0.7.0-alpha.7</title>
+  </entry>
+</feed>
+EOF
+FEED="${FIXTURE}"
+
+fixture ratelimit403.json <<'EOF'
+{"message":"API rate limit exceeded for 203.0.113.7.","documentation_url":"https://x"}
+EOF
+check "API 403 falls back to the feed" "v0.7.0-alpha.8" \
+	"$(with_newest_release "${FIXTURE}" "${FEED}" 403)"
+
+# The feed's own <title> is the repo's, not a release, and must not be mistaken for one.
+check "the feed's own title is not mistaken for a release" "v0.7.0-alpha.8" \
+	"$(with_newest_release "${FIXTURE}" "${FEED}" 403)"
+
+# A channel release appears in the feed too, and must be skipped there exactly as it is
+# in the API response — otherwise the fallback would reintroduce the bug the v-tag filter
+# exists to prevent.
+fixture feed_channel.xml <<'EOF'
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Release notes from cortex</title>
+  <entry><title>main-latest</title></entry>
+  <entry><title>v0.7.0-alpha.8</title></entry>
+</feed>
+EOF
+check "the feed skips the channel release" "v0.7.0-alpha.8" \
+	"$(with_newest_release "${TMP}/ratelimit403.json" "${FIXTURE}" 403)"
+
+# Release notes are ours to author and live in the same document, so a version-shaped
+# line inside them must not win. The parse is anchored to the <title> element for this
+# reason; notes arrive HTML-escaped and cannot forge one.
+fixture feed_poisoned.xml <<'EOF'
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Release notes from cortex</title>
+  <entry>
+    <title>v0.7.0-alpha.8</title>
+    <content type="html">v9.9.9-evil is not a release
+&lt;p&gt;notes&lt;/p&gt;</content>
+  </entry>
+</feed>
+EOF
+check "notes text cannot pose as a release title" "v0.7.0-alpha.8" \
+	"$(with_newest_release "${TMP}/ratelimit403.json" "${FIXTURE}" 403)"
+
+# Both sources down is the only remaining failure, and it must stay a failure rather
+# than guess.
+fixture empty_feed.xml </dev/null
+set +e
+_st=0; _out=$(with_newest_release "${TMP}/ratelimit403.json" "${FIXTURE}" 403) || _st=$?
+set -e
+check_fails "both sources failing still fails" "${_st}"
+check "and prints nothing" "" "${_out}"
+
+# A healthy API must still be used — the fallback is a fallback, not a replacement.
+fixture api_ok.json <<'EOF'
+[{"tag_name":"v0.7.0-alpha.8"},{"tag_name":"v0.7.0-alpha.7"}]
+EOF
+check "a healthy API is used without touching the feed" "v0.7.0-alpha.8" \
+	"$(with_newest_release "${FIXTURE}" /dev/null 200)"
 
 # --- the channel tag is one string, in two files ---
 #


### PR DESCRIPTION
## Summary

The documented one-liner died on a normal laptop today:

```
$ curl -fsSL https://raw.githubusercontent.com/rossoctl/cortex/main/authbridge/install.sh \
    | sh -s -- --claude-code
warning: could not resolve the newest release; continuing with the copy from main
error: could not resolve the newest release (pass --ref=vX.Y.Z to pin one)
```

`api.github.com` allows **60 requests/hour per IP** unauthenticated. That is shared by
everyone behind one NAT and each install spends two, so a corporate network can exhaust it
with nobody doing anything unusual. When it goes, the install does not degrade — it stops,
and asks the person to go find a version and pass `--ref`. That is the opposite of a
one-line install.

**Not a regression.** The pre-#922 script fails identically under a 403 — same two
messages, `AUTHBRIDGE_VERSION` in the hint instead of `--ref`. This is a long-standing
fragility that only surfaces when the quota happens to be gone.

## The fix

`newest_release()` gains a second source. The API stays primary — documented, versioned,
structured — and `releases.atom` is the fallback:

| | |
|---|---|
| served by | `github.com`, not `api.github.com` |
| quota | not bound by the API's 60/hour |
| ordering | newest first |
| prereleases | included, which `/releases/latest` is not |

Only *both* failing is fatal, and that still refuses rather than guessing. No new
dependency — `curl` and `sed`, both already required.

A 403 that really is the quota now says so, instead of every failure printing one
indistinguishable line. Knowing that waiting an hour fixes it is the difference between a
dead end and a wait.

## The feed parse is anchored, deliberately

Release notes are ours to author and live in the same document, so grepping for a
version-shaped line could be hijacked by a notes line beginning with a version — the same
shape as the unanchored `"tag_name"` bug this file already guards against. The parse is
anchored to the `<title>` **element**; notes arrive HTML-escaped (`&lt;p&gt;`) and cannot
forge one. There is a poisoned-feed test.

## Verification

Over the real network, not only fixtures:

```
API -> unreachable host, feed live   -> resolves v0.7.0-alpha.8, installs
API -> unreachable, feed unreachable -> refuses: "could not resolve the newest release"
healthy API                          -> used, feed never touched
```

42 cases total; 7 new ones cover the 403 fallback, the feed's own `<title>` not being
mistaken for a release, the channel release being skipped in the feed exactly as in the
API, a poisoned feed, both-sources-down, and a healthy API not touching the feed. The
fallback is mutation-verified — deleting it fails the case that motivated the change.

Clean under `sh` and `dash`; `shellcheck` clean at `--severity=error` and `-s sh`.

## One refactor included

Both probes now share a single `curl` stub. Writing that twice is what produced two
vacuous passes earlier in this file's short life, and `newest_release()` having two
sources makes a single-body stub actively misleading — the fallback would look exercised
while never running.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
