### PR TITLE
Feat: Make yanked event files findable and their path persistent

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -227,9 +227,10 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   they are deliberately not written to a shared location such as `/tmp`.
   Nothing prunes them: they accumulate until you delete them, and unlike
   `$TMPDIR` this location is never cleared by the OS. Given what they hold,
-  `rm` the ones you are done with. The footer shows the path expanded, not
-  abbreviated with `~`, and does not truncate it — on a narrow terminal it can
-  run past the right edge.
+  `rm` the ones you are done with. The footer shows the path expanded rather
+  than abbreviated with `~`, and gives it the whole line while the notice is up;
+  on a terminal too narrow for it the path is truncated from the left, so the
+  filename stays readable.
 - **Pipeline**: the active plugin chain in inbound + outbound order.
   Columns: position, direction, plugin name, DEPS (✓/✗ — see "Plugin
   dependencies" below), writes, body access, event count. `e` opens

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -225,6 +225,9 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   private to you (0700, inside `~/.cortex`) and the files are 0600 — yanked
   events carry identity subjects, raw LLM completions and tool arguments, so
   they are deliberately not written to a shared location such as `/tmp`.
+  Nothing prunes them: they accumulate until you delete them, and unlike
+  `$TMPDIR` this location is never cleared by the OS. Given what they hold,
+  `rm` the ones you are done with.
 - **Pipeline**: the active plugin chain in inbound + outbound order.
   Columns: position, direction, plugin name, DEPS (✓/✗ — see "Plugin
   dependencies" below), writes, body access, event count. `e` opens

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -227,7 +227,9 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   they are deliberately not written to a shared location such as `/tmp`.
   Nothing prunes them: they accumulate until you delete them, and unlike
   `$TMPDIR` this location is never cleared by the OS. Given what they hold,
-  `rm` the ones you are done with.
+  `rm` the ones you are done with. The footer shows the path expanded, not
+  abbreviated with `~`, and does not truncate it — on a narrow terminal it can
+  run past the right edge.
 - **Pipeline**: the active plugin chain in inbound + outbound order.
   Columns: position, direction, plugin name, DEPS (✓/✗ — see "Plugin
   dependencies" below), writes, body access, event count. `e` opens

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -220,8 +220,8 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   Live-updates while in view — if the cursor is on the last row, it
   auto-follows new events.
 - **Detail**: pretty-printed JSON of a single event. Scroll with arrow
-  keys; `y` yanks to `/tmp/abctl-event-<timestamp>.json` and flashes the
-  path in the footer.
+  keys; `y` yanks to `/tmp/abctl-events/<timestamp>-<rand>.json` and shows
+  the path in the footer until you press another key.
 - **Pipeline**: the active plugin chain in inbound + outbound order.
   Columns: position, direction, plugin name, DEPS (✓/✗ — see "Plugin
   dependencies" below), writes, body access, event count. `e` opens
@@ -298,7 +298,7 @@ Layered on top of all of them:
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
 | `c` | events | open the column picker (`↑↓`/`jk` move, `space`/`x` toggle, `r` reset, `Esc`/`Enter`/`c` close) |
 | `p` | any | pause/resume stream |
-| `y` | detail | yank event JSON to `/tmp` |
+| `y` | detail | yank event JSON to `/tmp/abctl-events` (path stays until the next keypress) |
 | `g` / `G` | lists | jump to top / bottom |
 | `u` | sessions, events, detail | open the usage charts (sessions: all sessions; events/detail: the selected session) |
 | `m` | usage | cycle metric: tokens / requests / errors / latency |

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -220,8 +220,11 @@ The UI has these top-level panes. `Enter` drills in; `Esc` backs out.
   Live-updates while in view — if the cursor is on the last row, it
   auto-follows new events.
 - **Detail**: pretty-printed JSON of a single event. Scroll with arrow
-  keys; `y` yanks to `/tmp/abctl-events/<timestamp>-<rand>.json` and shows
-  the path in the footer until you press another key.
+  keys; `y` yanks to `~/.cortex/abctl-events/<timestamp>-<rand>.json` and
+  shows the path in the footer until you press another key. The directory is
+  private to you (0700, inside `~/.cortex`) and the files are 0600 — yanked
+  events carry identity subjects, raw LLM completions and tool arguments, so
+  they are deliberately not written to a shared location such as `/tmp`.
 - **Pipeline**: the active plugin chain in inbound + outbound order.
   Columns: position, direction, plugin name, DEPS (✓/✗ — see "Plugin
   dependencies" below), writes, body access, event count. `e` opens
@@ -298,7 +301,7 @@ Layered on top of all of them:
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
 | `c` | events | open the column picker (`↑↓`/`jk` move, `space`/`x` toggle, `r` reset, `Esc`/`Enter`/`c` close) |
 | `p` | any | pause/resume stream |
-| `y` | detail | yank event JSON to `/tmp/abctl-events` (path stays until the next keypress) |
+| `y` | detail | yank event JSON to `~/.cortex/abctl-events` (path stays until the next keypress) |
 | `g` / `G` | lists | jump to top / bottom |
 | `u` | sessions, events, detail | open the usage charts (sessions: all sessions; events/detail: the selected session) |
 | `m` | usage | cycle metric: tokens / requests / errors / latency |
@@ -481,7 +484,7 @@ results; treat the output accordingly.
 
 ## Deferred to later PRs
 
-- Native clipboard (currently writes to `/tmp`).
+- Native clipboard (currently writes a file under `~/.cortex/abctl-events`).
 - Fuzzy search beyond substring match.
 - Per-user filtering (`Identity.Subject == X`).
 - Krew plugin packaging.

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -1330,6 +1330,14 @@ func yankDir() (string, error) {
 // yank on an ordinary account. Every component is still checked for a symlink,
 // which is the redirection risk.
 //
+// A loose mode on a directory abctl owns is tightened rather than refused, which
+// is what the rest of the tree already does for this exact problem:
+// writeBuiltinConfig in cmd/authbridge-proxy/local.go chmods ~/.cortex to 0700
+// after MkdirAll, and again one level down for the CA directory. Self-healing
+// beats handing the user a chmod to run by hand, and if the chmod fails — someone
+// else owns it — the refusal below still stands. Symlinks and non-directories stay
+// hard refusals; there is no chmod out of those.
+//
 // Ownership is deliberately not checked via syscall.Stat_t: that type does not
 // exist on Windows and would break this package's cross-compile.
 func checkYankDir(dir string) error {
@@ -1367,8 +1375,12 @@ func checkYankDir(dir string) error {
 			return fmt.Errorf("%s is not a directory", path)
 		}
 		if perm := fi.Mode().Perm(); perm&0o077 != 0 {
-			return fmt.Errorf("%s has mode %v; session events need no group or "+
-				"world access (chmod 700 %s)", path, perm, path)
+			// Tighten in place; only report if that does not work.
+			if err := os.Chmod(path, 0o700); err != nil {
+				return fmt.Errorf("%s has mode %v and could not be tightened "+
+					"(%v); session events need no group or world access "+
+					"(chmod 700 %s)", path, perm, err, path)
+			}
 		}
 	}
 	return nil

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -257,7 +257,11 @@ type model struct {
 	hiddenInactive int
 	flash          string
 	flashUntil     time.Time
-	width, height  int
+	// flashSticky keeps the current flash up until the next keypress instead of
+	// expiring on flashUntil. Set only by setStickyFlash (yank), so every other
+	// flash producer keeps its timed behaviour.
+	flashSticky   bool
+	width, height int
 	// bodyHeight is the inner height available to panes (terminal height
 	// minus title + footer). Cached by layout() so rebuildEventsTable can
 	// size the events table after accounting for the IDENTITY banner.
@@ -1266,14 +1270,32 @@ func trunc(s string, n int) string {
 	return string(r[:n-1]) + "…"
 }
 
-// yankEventToFile writes the currently-focused event to a fresh tmpfile
+// yankDir is the fixed directory yank writes into.
+//
+// Not os.TempDir(): on macOS that is /var/folders/<opaque>/T, so a yanked file
+// landed on a 92-character path nobody could find or retype, which is what #868
+// reported. A literal /tmp is short, is the same on macOS and Linux, and is what
+// the help text and README already claimed. 0700 so a directory listing does not
+// leak session ids on a shared host; the files themselves are 0600 (below).
+const yankDir = "/tmp/abctl-events"
+
+// yankEventToFile writes the currently-focused event to a fresh file in yankDir
 // as pretty JSON and returns the path. Uses os.CreateTemp so the file is
 // created with 0600 perms (session events carry identity subjects, raw
 // LLM completions, and tool arguments — the operator-only default keeps
-// them off shared / CI hosts).
+// them off shared / CI hosts). CreateTemp also implies O_EXCL, so there is no
+// create-then-chmod window and no writing this content into a symlink someone
+// planted in world-writable /tmp.
 func yankEventToFile(e *pipeline.SessionEvent) (string, error) {
+	if err := os.MkdirAll(yankDir, 0o700); err != nil {
+		return "", err
+	}
 	ts := time.Now().UTC().Format("20060102-150405")
-	f, err := os.CreateTemp(os.TempDir(), "abctl-event-"+ts+"-*.json")
+	// No "abctl-event-" name prefix: inside a directory already called
+	// abctl-events it says nothing, and dropping it is 12 of the 43 characters
+	// this change takes off the path. The random tail stays — it is what keeps
+	// two yanks in the same second from clobbering each other.
+	f, err := os.CreateTemp(yankDir, ts+"-*.json")
 	if err != nil {
 		return "", err
 	}

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -1295,8 +1295,14 @@ const yankDirRel = ".cortex/abctl-events"
 // where this started, and it is a location users already know.
 func yankDir() (string, error) {
 	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
+	if err != nil {
 		return "", fmt.Errorf("cannot determine your home directory: %w", err)
+	}
+	if home == "" {
+		// Separate branch, not folded into the one above: %w on a nil error
+		// renders as "%!w(<nil>)", which would make this defensive path
+		// unreadable to whoever ever hits it.
+		return "", errors.New("cannot determine your home directory: it is empty")
 	}
 	return filepath.Join(home, yankDirRel), nil
 }

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/charmbracelet/bubbles/table"
@@ -1315,30 +1314,62 @@ func yankDir() (string, error) {
 
 // checkYankDir refuses to write into a directory that does not actually protect
 // its contents. MkdirAll returns nil for a path that already exists whatever its
-// owner or mode, and it happily follows a symlink — so with a 0755 ~/.cortex an
-// abctl-events symlink planted by another local user would silently redirect
-// events carrying identity subjects and raw LLM completions into their directory.
+// owner or mode, and it happily follows a symlink — so an abctl-events symlink
+// planted by another local user would silently redirect events carrying identity
+// subjects and raw LLM completions into their directory.
 //
-// Lstat, not Stat: Stat resolves the symlink and would report the target's mode.
+// Checks every component from the home directory down, not just the leaf: a
+// symlinked ~/.cortex redirects the whole subtree just as effectively, and the
+// leaf-only version of this function missed it (verified — the event landed in the
+// attacker's tree). Lstat, not Stat: Stat resolves the link and would report the
+// target's mode.
+//
+// The mode requirement applies only to the directories abctl owns (~/.cortex and
+// abctl-events), not to the home directory itself: a real home is commonly 0750
+// or 0755 — this machine's is 0750 — and demanding 0700 there would refuse to
+// yank on an ordinary account. Every component is still checked for a symlink,
+// which is the redirection risk.
+//
+// Ownership is deliberately not checked via syscall.Stat_t: that type does not
+// exist on Windows and would break this package's cross-compile.
 func checkYankDir(dir string) error {
-	fi, err := os.Lstat(dir)
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(home, dir)
+	if err != nil {
+		return err
+	}
+
+	// home first (symlink check only), then each component abctl owns.
+	fi, err := os.Lstat(home)
 	if err != nil {
 		return err
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("%s is a symlink; refusing to write session events "+
-			"through it", dir)
+			"through it", home)
 	}
-	if !fi.IsDir() {
-		return fmt.Errorf("%s is not a directory", dir)
-	}
-	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
-		return fmt.Errorf("%s has mode %v; session events need 0700 (chmod 700 %s)",
-			dir, perm, dir)
-	}
-	if st, ok := fi.Sys().(*syscall.Stat_t); ok && int(st.Uid) != os.Getuid() {
-		return fmt.Errorf("%s is owned by uid %d, not you (uid %d)",
-			dir, st.Uid, os.Getuid())
+
+	path := home
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		path = filepath.Join(path, part)
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s is a symlink; refusing to write session events "+
+				"through it", path)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("%s is not a directory", path)
+		}
+		if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+			return fmt.Errorf("%s has mode %v; session events need no group or "+
+				"world access (chmod 700 %s)", path, perm, path)
+		}
 	}
 	return nil
 }

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -1270,24 +1271,48 @@ func trunc(s string, n int) string {
 	return string(r[:n-1]) + "…"
 }
 
-// yankDir is the fixed directory yank writes into.
+// yankDirRel is the yank output directory, relative to the user's home. It
+// follows the same convention as abctl's other durable state (cmd_claudecode.go's
+// cortexCfgRel / stateRel), so there is one ~/.cortex tree rather than a new one.
+const yankDirRel = ".cortex/abctl-events"
+
+// yankDir returns the absolute directory yank writes into.
 //
 // Not os.TempDir(): on macOS that is /var/folders/<opaque>/T, so a yanked file
-// landed on a 92-character path nobody could find or retype, which is what #868
-// reported. A literal /tmp is short, is the same on macOS and Linux, and is what
-// the help text and README already claimed. 0700 so a directory listing does not
-// leak session ids on a shared host; the files themselves are 0600 (below).
-const yankDir = "/tmp/abctl-events"
+// landed on a 92-character path nobody could find or retype, which is #868.
+//
+// Not a fixed path under /tmp either, which is where this started. /tmp is
+// world-writable, and os.MkdirAll returns nil for a path that already exists
+// whatever its owner or mode — so a fixed /tmp/<name> cannot enforce 0700, can
+// be pre-created as a symlink that redirects where events land, and on a shared
+// host is squatted by whoever yanks first, permanently breaking everyone else.
+// Session events carry identity subjects, raw LLM completions and tool
+// arguments, so none of that is acceptable for a directory holding them.
+//
+// ~/.cortex is already 0700 and owned by the user, and only its owner can create
+// or replace entries inside it — which is what removes the squatting, symlink
+// and cross-user cases rather than merely detecting them. Still far shorter than
+// where this started, and it is a location users already know.
+func yankDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", fmt.Errorf("cannot determine your home directory: %w", err)
+	}
+	return filepath.Join(home, yankDirRel), nil
+}
 
 // yankEventToFile writes the currently-focused event to a fresh file in yankDir
 // as pretty JSON and returns the path. Uses os.CreateTemp so the file is
 // created with 0600 perms (session events carry identity subjects, raw
 // LLM completions, and tool arguments — the operator-only default keeps
 // them off shared / CI hosts). CreateTemp also implies O_EXCL, so there is no
-// create-then-chmod window and no writing this content into a symlink someone
-// planted in world-writable /tmp.
+// create-then-chmod window.
 func yankEventToFile(e *pipeline.SessionEvent) (string, error) {
-	if err := os.MkdirAll(yankDir, 0o700); err != nil {
+	dir, err := yankDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
 	ts := time.Now().UTC().Format("20060102-150405")
@@ -1295,7 +1320,7 @@ func yankEventToFile(e *pipeline.SessionEvent) (string, error) {
 	// abctl-events it says nothing, and dropping it is 12 of the 43 characters
 	// this change takes off the path. The random tail stays — it is what keeps
 	// two yanks in the same second from clobbering each other.
-	f, err := os.CreateTemp(yankDir, ts+"-*.json")
+	f, err := os.CreateTemp(dir, ts+"-*.json")
 	if err != nil {
 		return "", err
 	}

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/charmbracelet/bubbles/table"
@@ -1289,10 +1290,15 @@ const yankDirRel = ".cortex/abctl-events"
 // Session events carry identity subjects, raw LLM completions and tool
 // arguments, so none of that is acceptable for a directory holding them.
 //
-// ~/.cortex is already 0700 and owned by the user, and only its owner can create
-// or replace entries inside it — which is what removes the squatting, symlink
-// and cross-user cases rather than merely detecting them. Still far shorter than
-// where this started, and it is a location users already know.
+// ~/.cortex is the user's own tree and is normally 0700, which makes those cases
+// unreachable — but abctl never creates it, so its mode is whatever an installer
+// or the user left. With a 0755 ~/.cortex, MkdirAll neither tightens the mode nor
+// refuses to follow an abctl-events symlink someone planted, and the event lands
+// in their directory. Verified. So the guarantee is enforced here rather than
+// assumed: yankEventToFile Lstats the directory and refuses to write unless it is
+// a real directory, owned by this user, with no group or world access.
+//
+// Still far shorter than where this started, and a location users already know.
 func yankDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -1305,6 +1311,36 @@ func yankDir() (string, error) {
 		return "", errors.New("cannot determine your home directory: it is empty")
 	}
 	return filepath.Join(home, yankDirRel), nil
+}
+
+// checkYankDir refuses to write into a directory that does not actually protect
+// its contents. MkdirAll returns nil for a path that already exists whatever its
+// owner or mode, and it happily follows a symlink — so with a 0755 ~/.cortex an
+// abctl-events symlink planted by another local user would silently redirect
+// events carrying identity subjects and raw LLM completions into their directory.
+//
+// Lstat, not Stat: Stat resolves the symlink and would report the target's mode.
+func checkYankDir(dir string) error {
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink; refusing to write session events "+
+			"through it", dir)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+	if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Errorf("%s has mode %v; session events need 0700 (chmod 700 %s)",
+			dir, perm, dir)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && int(st.Uid) != os.Getuid() {
+		return fmt.Errorf("%s is owned by uid %d, not you (uid %d)",
+			dir, st.Uid, os.Getuid())
+	}
+	return nil
 }
 
 // yankEventToFile writes the currently-focused event to a fresh file in yankDir
@@ -1321,10 +1357,12 @@ func yankEventToFile(e *pipeline.SessionEvent) (string, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
+	if err := checkYankDir(dir); err != nil {
+		return "", err
+	}
 	ts := time.Now().UTC().Format("20060102-150405")
 	// No "abctl-event-" name prefix: inside a directory already called
-	// abctl-events it says nothing, and dropping it is 12 of the 43 characters
-	// this change takes off the path. The random tail stays — it is what keeps
+	// abctl-events it says nothing. The random tail stays — it is what keeps
 	// two yanks in the same second from clobbering each other.
 	f, err := os.CreateTemp(dir, ts+"-*.json")
 	if err != nil {

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -47,7 +47,7 @@ func (m *model) footerView() string {
 		status.WriteString(styleWarn.Render("   [paused]"))
 	}
 
-	// Flash message (e.g. "yanked → /tmp/abctl-events/...").
+	// Flash message (e.g. "yanked → ~/.cortex/abctl-events/...").
 	if m.flash != "" && (m.flashSticky || time.Now().Before(m.flashUntil)) {
 		status.WriteString(styleTitle.Render("   " + m.flash))
 	}

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -47,8 +47,8 @@ func (m *model) footerView() string {
 		status.WriteString(styleWarn.Render("   [paused]"))
 	}
 
-	// Flash message (e.g. "yanked → /tmp/...").
-	if m.flash != "" && time.Now().Before(m.flashUntil) {
+	// Flash message (e.g. "yanked → /tmp/abctl-events/...").
+	if m.flash != "" && (m.flashSticky || time.Now().Before(m.flashUntil)) {
 		status.WriteString(styleTitle.Render("   " + m.flash))
 	}
 

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -14,6 +14,21 @@ import (
 func (m *model) footerView() string {
 	var status strings.Builder
 
+	// A sticky flash gets the whole line, starting at column 0.
+	//
+	// Yank is the case this exists for: the path is the longest thing the footer
+	// ever carries, and appending it after the ~32 columns of connection state,
+	// rate and drops pushed it off the right edge on a narrow terminal — the user
+	// saw "yanked → /Users/you/.cortex/abctl-" and could not read the filename,
+	// which is the whole point of showing it. Dropping the prefix while the notice
+	// is up buys those columns back; the prefix returns on the next keypress, and
+	// a sticky flash is by definition something the user just asked for and is
+	// reading right now.
+	if m.flash != "" && m.flashSticky {
+		return styleTitle.Render(fitFlashLine(m.flash, m.width)) + "\n" +
+			styleHint.Render(fitHintLine(m.helpView(), m.width))
+	}
+
 	// Connection state dot.
 	switch m.connState.phase {
 	case connOpen:
@@ -55,6 +70,28 @@ func (m *model) footerView() string {
 	hint := fitHintLine(m.helpView(), m.width)
 
 	return status.String() + "\n" + styleHint.Render(hint)
+}
+
+// fitFlashLine bounds a full-width flash to the terminal, truncating from the
+// LEFT so the tail survives. For a path the tail is the filename, which is what
+// the user retypes or completes against; the leading directories are the
+// guessable part, and the README states the directory anyway.
+func fitFlashLine(flash string, width int) string {
+	if width <= 0 || lipgloss.Width(flash) <= width {
+		return flash
+	}
+	const ell = "…"
+	r := []rune(flash)
+	// Keep the last width-1 runes and mark the cut. Rune-based, so a multi-byte
+	// path does not get sliced mid-character.
+	keep := width - lipgloss.Width(ell)
+	if keep <= 0 {
+		return ell
+	}
+	if keep > len(r) {
+		keep = len(r)
+	}
+	return ell + string(r[len(r)-keep:])
 }
 
 // fitHintLine trims a footer hint line to the terminal width, dropping whole

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -81,17 +81,26 @@ func fitFlashLine(flash string, width int) string {
 		return flash
 	}
 	const ell = "…"
-	r := []rune(flash)
-	// Keep the last width-1 runes and mark the cut. Rune-based, so a multi-byte
-	// path does not get sliced mid-character.
-	keep := width - lipgloss.Width(ell)
-	if keep <= 0 {
+	budget := width - lipgloss.Width(ell)
+	if budget <= 0 {
 		return ell
 	}
-	if keep > len(r) {
-		keep = len(r)
+	// Walk backwards accumulating DISPLAY COLUMNS, not runes. An earlier version
+	// computed the budget in columns and then sliced by rune index, which
+	// overflowed on any wide character — a CJK path asked to fit 40 columns
+	// rendered 55, because each rune it kept was two columns wide.
+	r := []rune(flash)
+	used := 0
+	i := len(r)
+	for i > 0 {
+		w := lipgloss.Width(string(r[i-1]))
+		if used+w > budget {
+			break
+		}
+		used += w
+		i--
 	}
-	return ell + string(r[len(r)-keep:])
+	return ell + string(r[i:])
 }
 
 // fitHintLine trims a footer hint line to the terminal width, dropping whole

--- a/authbridge/cmd/abctl/tui/help_overlay.go
+++ b/authbridge/cmd/abctl/tui/help_overlay.go
@@ -89,7 +89,7 @@ var paneKeys = map[paneID]keyGroup{
 		title: "EVENT DETAIL (this pane)",
 		bindings: []keyBinding{
 			{"↑↓", "scroll"},
-			{"y", "yank event JSON to /tmp/abctl-events"},
+			{"y", "yank event JSON to ~/.cortex/abctl-events"},
 			{"u", "usage charts (this session)"},
 			{"esc / ← / h", "back to events"},
 		},

--- a/authbridge/cmd/abctl/tui/help_overlay.go
+++ b/authbridge/cmd/abctl/tui/help_overlay.go
@@ -89,7 +89,7 @@ var paneKeys = map[paneID]keyGroup{
 		title: "EVENT DETAIL (this pane)",
 		bindings: []keyBinding{
 			{"↑↓", "scroll"},
-			{"y", "yank event JSON to /tmp"},
+			{"y", "yank event JSON to /tmp/abctl-events"},
 			{"u", "usage charts (this session)"},
 			{"esc / ← / h", "back to events"},
 		},

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -28,6 +28,12 @@ func catalogPlugins(c *apiclient.PluginCatalog) []apiclient.PluginCatalogEntry {
 // pipeline edit, then the filter input. Only if none of those own the
 // keyboard is the key dispatched based on the active pane.
 func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
+	// A sticky flash (yank) stays up until the operator does something. Any key
+	// dismisses it, including one that goes on to do unrelated work: reading the
+	// path was the only thing pending, and pressing a key says they are done.
+	// Only the flag is cleared, never m.flash, so timed messages are unaffected.
+	m.flashSticky = false
+
 	// The help overlay is modal: while it's up, it owns the keyboard so a
 	// stray key can't navigate the pane hidden underneath. Checked before
 	// every other handler, including the picker and edit overlays, so `?`
@@ -452,7 +458,7 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		if err != nil {
 			m.setFlash("yank failed: " + err.Error())
 		} else {
-			m.setFlash("yanked → " + path)
+			m.setStickyFlash("yanked → " + path)
 		}
 		return nil
 
@@ -647,6 +653,18 @@ func (m *model) pageActivePane(msg tea.KeyMsg) tea.Cmd {
 func (m *model) setFlash(s string) {
 	m.flash = s
 	m.flashUntil = time.Now().Add(flashDuration)
+	// Explicitly clear: a timed message arriving after a sticky one must not
+	// inherit its stickiness.
+	m.flashSticky = false
+}
+
+// setStickyFlash shows a message that stays until the next keypress. For yank,
+// where the whole point is giving the operator time to read or copy a path —
+// flashDuration is shared with ten other producers, so lengthening it is not an
+// option, and three seconds is not enough to transcribe a filename.
+func (m *model) setStickyFlash(s string) {
+	m.flash = s
+	m.flashSticky = true
 }
 
 // helpView renders the keybinding hint line for the current pane. Short

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -664,6 +664,12 @@ func (m *model) setFlash(s string) {
 // option, and three seconds is not enough to transcribe a filename.
 func (m *model) setStickyFlash(s string) {
 	m.flash = s
+	// Clear the deadline a previous timed flash may have left in the future.
+	// Once a keypress clears flashSticky, footerView falls back to the
+	// time.Now().Before(flashUntil) arm — so a stale deadline would keep the
+	// yanked path on screen for the remainder of the old timer instead of
+	// disappearing on the keypress.
+	m.flashUntil = time.Time{}
 	m.flashSticky = true
 }
 

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -456,7 +456,10 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		}
 		path, err := yankEventToFile(m.detailEvent)
 		if err != nil {
-			m.setFlash("yank failed: " + err.Error())
+			// Sticky, like the success case: checkYankDir's message names the
+			// directory and the chmod that fixes it, which is useless if it
+			// disappears after three seconds while the success path persists.
+			m.setStickyFlash("yank failed: " + err.Error())
 		} else {
 			m.setStickyFlash("yanked → " + path)
 		}

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
@@ -271,6 +273,53 @@ func TestYankAcceptsACleanDir(t *testing.T) {
 	yankHome(t)
 	if _, err := yankEventToFile(sampleEvent()); err != nil {
 		t.Errorf("clean home was refused: %v", err)
+	}
+}
+
+// The reported symptom: on a ~72-column terminal the footer read
+//
+//	● connected  0.0 ev/s   drops: 0   yanked → /Users/snible/.cortex/abctl-
+//
+// and the filename — the part you retype — was off the right edge. A sticky flash
+// now gets the whole line from column 0, and truncates from the LEFT so the tail
+// survives.
+//
+// Widths are measured with lipgloss.Width, not len: "…" and "→" are multi-byte, so
+// a byte count overstates the columns used.
+func TestStickyFlash_FitsANarrowFooter(t *testing.T) {
+	const path = "/Users/someone/.cortex/abctl-events/20260910-223650-80907711.json"
+
+	for _, width := range []int{40, 60, 72, 80, 120} {
+		m := newTestDetailModel(t)
+		m.width = width
+		m.setStickyFlash("yanked → " + path)
+
+		line := strings.SplitN(m.footerView(), "\n", 2)[0]
+		if got := lipgloss.Width(line); got > width {
+			t.Errorf("width %d: footer is %d columns, overflowing by %d: %q",
+				width, got, got-width, line)
+		}
+		// The filename must survive every truncation — it is what the user types.
+		if !strings.Contains(line, "80907711.json") {
+			t.Errorf("width %d: filename truncated away: %q", width, line)
+		}
+	}
+}
+
+// The full-width takeover applies to sticky flashes only. A timed flash keeps the
+// connection state, rate and drops beside it — ten other producers use that path
+// and none of them is a path the user is about to retype.
+func TestTimedFlash_KeepsTheStatusPrefix(t *testing.T) {
+	m := newTestDetailModel(t)
+	m.width = 72
+	m.setFlash("hot-reload succeeded")
+
+	line := strings.SplitN(m.footerView(), "\n", 2)[0]
+	if !strings.Contains(line, "ev/s") {
+		t.Errorf("a timed flash lost the status prefix: %q", line)
+	}
+	if !strings.Contains(line, "hot-reload succeeded") {
+		t.Errorf("a timed flash lost its message: %q", line)
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -13,18 +13,24 @@ import (
 
 // #868: a yanked file has to be findable. os.TempDir() on macOS is
 // /var/folders/<opaque>/T, so the old path ran 92 characters and nobody could
-// retype it or guess where to look. Pins the directory, the 0600 perms the
-// function's comment justifies, and the absence of the redundant name prefix.
-func TestYankEventToFileUsesShortFixedDir(t *testing.T) {
+// retype it or guess where to look.
+//
+// The directory is under ~/.cortex, not /tmp: a fixed path in a world-writable
+// directory cannot enforce its own mode (os.MkdirAll returns nil for an existing
+// path whatever its owner), can be pre-created as a symlink that redirects where
+// events land, and is squatted by whoever yanks first on a shared host. Pins the
+// directory, the 0600 perms, and the absence of the redundant name prefix.
+func TestYankEventToFileUsesPrivatePerUserDir(t *testing.T) {
 	p := yankOne(t)
 
-	if got := filepath.Dir(p); got != yankDir {
-		t.Errorf("yanked into %q, want %q", got, yankDir)
+	want := mustYankDir(t)
+	if got := filepath.Dir(p); got != want {
+		t.Errorf("yanked into %q, want %q", got, want)
 	}
 	base := filepath.Base(p)
 	if strings.HasPrefix(base, "abctl-event-") {
 		t.Errorf("filename %q still carries the abctl-event- prefix, which is "+
-			"redundant inside %s", base, yankDir)
+			"redundant inside %s", base, want)
 	}
 	if !strings.HasSuffix(base, ".json") {
 		t.Errorf("filename %q lost its .json suffix", base)
@@ -35,7 +41,7 @@ func TestYankEventToFileUsesShortFixedDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Load-bearing, not cosmetic: events carry identity subjects, raw LLM
-	// completions and tool arguments, and /tmp is shared.
+	// completions and tool arguments.
 	if perm := fi.Mode().Perm(); perm != 0o600 {
 		t.Errorf("perms %v, want 0600 — yanked events are operator-only", perm)
 	}
@@ -84,7 +90,7 @@ func TestYankFlashIsStickyUntilKeypress(t *testing.T) {
 	if !strings.Contains(m.flash, "yanked → ") {
 		t.Fatalf("y did not flash a yank message, got %q", m.flash)
 	}
-	if !strings.Contains(m.footerView(), yankDir) {
+	if !strings.Contains(m.footerView(), mustYankDir(t)) {
 		t.Fatal("the yanked path is not rendered in the footer")
 	}
 
@@ -93,7 +99,7 @@ func TestYankFlashIsStickyUntilKeypress(t *testing.T) {
 	if !m.flashSticky {
 		t.Error("yank flash is not sticky")
 	}
-	if !strings.Contains(m.footerView(), yankDir) {
+	if !strings.Contains(m.footerView(), mustYankDir(t)) {
 		t.Error("the path stopped rendering despite being sticky — a user who " +
 			"looked away has lost it again (#868)")
 	}
@@ -103,7 +109,7 @@ func TestYankFlashIsStickyUntilKeypress(t *testing.T) {
 	if m.flashSticky {
 		t.Error("a keypress did not clear the sticky flag")
 	}
-	if strings.Contains(m.footerView(), yankDir) {
+	if strings.Contains(m.footerView(), mustYankDir(t)) {
 		t.Error("the notice survived a keypress")
 	}
 }
@@ -133,7 +139,7 @@ func TestNonYankFlashStillExpires(t *testing.T) {
 // would pin the footer past an error the operator needs to see.
 func TestTimedFlashClearsStickiness(t *testing.T) {
 	m := newTestDetailModel(t)
-	m.setStickyFlash("yanked → /tmp/abctl-events/x.json")
+	m.setStickyFlash("yanked → /home/u/.cortex/abctl-events/x.json")
 	m.setFlash("catalog fetch failed: boom")
 
 	if m.flashSticky {
@@ -143,6 +149,71 @@ func TestTimedFlashClearsStickiness(t *testing.T) {
 	if strings.Contains(m.footerView(), "catalog fetch failed") {
 		t.Error("the timed flash did not expire")
 	}
+}
+
+// The gap the reviewer identified: every other test here runs against a yankDir
+// that either did not exist or was created by the test, so none exercised
+// os.MkdirAll's existing-directory semantics — which is where the /tmp problem
+// lived. MkdirAll returns nil for a path that already exists whatever its owner
+// or mode, so it cannot tighten a loose one.
+//
+// Under ~/.cortex that is no longer a security question: the parent is 0700 and
+// owned by the user, so nobody else can pre-create the directory, plant a symlink
+// in its place, or squat the name. This asserts yank still works when the
+// directory already exists — the common case on every run after the first — and
+// documents that the mode of a pre-existing directory is not tightened.
+func TestYankEventToFileWithPreExistingDir(t *testing.T) {
+	dir := mustYankDir(t)
+	if err := os.MkdirAll(dir, 0o755); err != nil { // deliberately looser
+		t.Fatal(err)
+	}
+
+	p := yankOne(t)
+
+	if got := filepath.Dir(p); got != dir {
+		t.Errorf("yanked into %q, want %q", got, dir)
+	}
+	// The file's own mode is what protects the contents, and CreateTemp sets it
+	// regardless of the directory's mode.
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file perms %v, want 0600 — the directory's mode must not affect "+
+			"the file's", perm)
+	}
+}
+
+// A timed flash landing shortly before a yank must not keep the yanked path on
+// screen after the dismissing keypress. setStickyFlash leaves flashSticky true
+// and footerView's other arm reads flashUntil, so a deadline still in the future
+// would outlive the dismissal. The other tests cannot catch this: they start from
+// a zero-valued model, where that arm is already in the past.
+func TestStickyFlash_ClearsAStaleDeadline(t *testing.T) {
+	m := newTestDetailModel(t)
+
+	m.setFlash("hot-reload succeeded") // flashUntil = now + flashDuration
+	m.setStickyFlash("yanked → /x/y/z.json")
+	if !m.flashUntil.IsZero() {
+		t.Error("setStickyFlash left a stale flashUntil")
+	}
+
+	m.handleKey(keyRune('j')) // clears flashSticky
+	if strings.Contains(m.footerView(), "yanked") {
+		t.Error("the yanked path outlived the dismissing keypress, on the " +
+			"previous timed flash's deadline")
+	}
+}
+
+// mustYankDir resolves the yank directory or fails the test.
+func mustYankDir(t *testing.T) string {
+	t.Helper()
+	d, err := yankDir()
+	if err != nil {
+		t.Fatalf("yankDir: %v", err)
+	}
+	return d
 }
 
 // yankOne writes one event via the real code path and schedules cleanup.

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -141,6 +141,7 @@ func TestNonYankFlashStillExpires(t *testing.T) {
 // A sticky flash must not survive a later timed one — otherwise a yank notice
 // would pin the footer past an error the operator needs to see.
 func TestTimedFlashClearsStickiness(t *testing.T) {
+	yankHome(t)
 	m := newTestDetailModel(t)
 	m.setStickyFlash("yanked → /home/u/.cortex/abctl-events/x.json")
 	m.setFlash("catalog fetch failed: boom")
@@ -154,21 +155,15 @@ func TestTimedFlashClearsStickiness(t *testing.T) {
 	}
 }
 
-// The gap the reviewer identified: every other test here runs against a yankDir
-// that either did not exist or was created by the test, so none exercised
-// os.MkdirAll's existing-directory semantics — which is where the /tmp problem
-// lived. MkdirAll returns nil for a path that already exists whatever its owner
-// or mode, so it cannot tighten a loose one.
-//
-// Under ~/.cortex that is no longer a security question: the parent is 0700 and
-// owned by the user, so nobody else can pre-create the directory, plant a symlink
-// in its place, or squat the name. This asserts yank still works when the
-// directory already exists — the common case on every run after the first — and
-// documents that the mode of a pre-existing directory is not tightened.
+// Yank must work when the directory already exists, which is every run after the
+// first. Pre-created at 0700 — the mode yank itself uses. (An earlier version of
+// this test pre-created it at 0755 to document that MkdirAll does not tighten an
+// existing directory; that is now refused outright, and TestYankRefusesALooseModeDir
+// covers it.)
 func TestYankEventToFileWithPreExistingDir(t *testing.T) {
 	yankHome(t)
 	dir := mustYankDir(t)
-	if err := os.MkdirAll(dir, 0o755); err != nil { // deliberately looser
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -177,15 +172,13 @@ func TestYankEventToFileWithPreExistingDir(t *testing.T) {
 	if got := filepath.Dir(p); got != dir {
 		t.Errorf("yanked into %q, want %q", got, dir)
 	}
-	// The file's own mode is what protects the contents, and CreateTemp sets it
-	// regardless of the directory's mode.
+	// The file's own mode is what protects the contents.
 	fi, err := os.Stat(p)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if perm := fi.Mode().Perm(); perm != 0o600 {
-		t.Errorf("file perms %v, want 0600 — the directory's mode must not affect "+
-			"the file's", perm)
+		t.Errorf("file perms %v, want 0600", perm)
 	}
 }
 
@@ -232,6 +225,55 @@ func TestYankDir_UnsetHomeGivesAReadableError(t *testing.T) {
 	}
 }
 
+// The must-fix: ~/.cortex is not guaranteed to be 0700 — abctl never creates it,
+// so its mode is whatever an installer or the user left. At 0755, MkdirAll neither
+// tightens the mode nor refuses to follow an abctl-events symlink, and the event —
+// identity subjects, raw LLM completions, tool arguments — lands in whichever
+// directory the symlink points at.
+func TestYankRefusesASymlinkedDir(t *testing.T) {
+	home := yankHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".cortex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	elsewhere := t.TempDir()
+	if err := os.Symlink(elsewhere, filepath.Join(home, ".cortex", "abctl-events")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := yankEventToFile(sampleEvent()); err == nil {
+		t.Error("wrote through a symlink; a local user can redirect session events")
+	}
+	if ents, _ := os.ReadDir(elsewhere); len(ents) != 0 {
+		t.Errorf("%d event file(s) landed in the symlink target", len(ents))
+	}
+}
+
+// Same premise, without a symlink: a pre-existing world-readable yank directory
+// must be refused rather than written into, since MkdirAll will not tighten it.
+func TestYankRefusesALooseModeDir(t *testing.T) {
+	home := yankHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".cortex", "abctl-events"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := yankEventToFile(sampleEvent())
+	if err == nil {
+		t.Fatal("wrote into a 0755 directory, so the 0700 guarantee is not enforced")
+	}
+	// The message has to tell the user how to fix it.
+	if !strings.Contains(err.Error(), "0700") {
+		t.Errorf("error does not say what mode is required: %v", err)
+	}
+}
+
+// And the ordinary case still works: a clean home yanks without complaint.
+func TestYankAcceptsACleanDir(t *testing.T) {
+	yankHome(t)
+	if _, err := yankEventToFile(sampleEvent()); err != nil {
+		t.Errorf("clean home was refused: %v", err)
+	}
+}
+
 // yankHome redirects $HOME at a per-test temp directory, so nothing in this file
 // touches the developer's real ~/.cortex.
 //
@@ -245,12 +287,15 @@ func TestYankDir_UnsetHomeGivesAReadableError(t *testing.T) {
 //
 // Call this first in every test that reaches yankDir, directly or through a
 // helper. t.Setenv is incompatible with t.Parallel(); nothing here is parallel.
-func yankHome(t *testing.T) {
+func yankHome(t *testing.T) string {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	// os.UserHomeDir reads USERPROFILE on Windows; set both so the redirect holds
-	// wherever the suite runs.
-	t.Setenv("USERPROFILE", t.TempDir())
+	// One directory, both variables: os.UserHomeDir reads USERPROFILE on Windows
+	// and HOME elsewhere, and two separate t.TempDir() calls would make the two
+	// disagree — so a test would exercise a different home depending on platform.
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
 }
 
 // mustYankDir resolves the yank directory or fails the test.

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -21,6 +21,7 @@ import (
 // events land, and is squatted by whoever yanks first on a shared host. Pins the
 // directory, the 0600 perms, and the absence of the redundant name prefix.
 func TestYankEventToFileUsesPrivatePerUserDir(t *testing.T) {
+	yankHome(t)
 	p := yankOne(t)
 
 	want := mustYankDir(t)
@@ -63,6 +64,7 @@ func TestYankEventToFileUsesPrivatePerUserDir(t *testing.T) {
 // second yank in the same second from silently clobbering the first. Guards
 // against "simplifying" to a stable filename.
 func TestYankEventToFileTwiceSameSecondDistinct(t *testing.T) {
+	yankHome(t)
 	p1 := yankOne(t)
 	p2 := yankOne(t)
 
@@ -80,6 +82,7 @@ func TestYankEventToFileTwiceSameSecondDistinct(t *testing.T) {
 // The other half of #868: the path used to vanish after flashDuration, before a
 // user could copy it. Pressing `y` now leaves it up until the next keypress.
 func TestYankFlashIsStickyUntilKeypress(t *testing.T) {
+	yankHome(t)
 	m := newTestDetailModel(t)
 
 	if cmd := m.handleKey(keyRune('y')); cmd != nil {
@@ -163,6 +166,7 @@ func TestTimedFlashClearsStickiness(t *testing.T) {
 // directory already exists — the common case on every run after the first — and
 // documents that the mode of a pre-existing directory is not tightened.
 func TestYankEventToFileWithPreExistingDir(t *testing.T) {
+	yankHome(t)
 	dir := mustYankDir(t)
 	if err := os.MkdirAll(dir, 0o755); err != nil { // deliberately looser
 		t.Fatal(err)
@@ -204,6 +208,49 @@ func TestStickyFlash_ClearsAStaleDeadline(t *testing.T) {
 		t.Error("the yanked path outlived the dismissing keypress, on the " +
 			"previous timed flash's deadline")
 	}
+}
+
+// yankDir's error path must stay readable. An unset $HOME is the reachable case
+// (os.UserHomeDir returns a non-nil "$HOME is not defined" error, so %w is fine);
+// the home == "" && err == nil case is defensive and not reachable here, which is
+// exactly why folding the two conditions together hid a "%!w(<nil>)" message
+// nobody would ever see until they did. This asserts the reachable path reads
+// well; the unreachable one is kept legible by construction, not by a test.
+func TestYankDir_UnsetHomeGivesAReadableError(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	_, err := yankDir()
+	if err == nil {
+		t.Skip("this platform resolved a home directory without $HOME")
+	}
+	if strings.Contains(err.Error(), "%!w") {
+		t.Errorf("error message is mangled by a nil wrap: %v", err)
+	}
+	if !strings.Contains(err.Error(), "home directory") {
+		t.Errorf("error does not say what went wrong: %v", err)
+	}
+}
+
+// yankHome redirects $HOME at a per-test temp directory, so nothing in this file
+// touches the developer's real ~/.cortex.
+//
+// This is not tidiness. yankDir() resolves os.UserHomeDir(), so without it every
+// test here wrote into the real home — and TestYankEventToFileWithPreExistingDir
+// created ~/.cortex/abctl-events at 0755 on a machine where it did not yet exist.
+// os.MkdirAll does not tighten an existing directory, so every subsequent REAL
+// yank then wrote into a 0755 directory, silently voiding the 0700 guarantee the
+// README, yankDir's doc comment and that test's own name all assert. Permanent,
+// invisible, and only on a fresh machine — which is how it survived review.
+//
+// Call this first in every test that reaches yankDir, directly or through a
+// helper. t.Setenv is incompatible with t.Parallel(); nothing here is parallel.
+func yankHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	// os.UserHomeDir reads USERPROFILE on Windows; set both so the redirect holds
+	// wherever the suite runs.
+	t.Setenv("USERPROFILE", t.TempDir())
 }
 
 // mustYankDir resolves the yank directory or fails the test.

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -250,21 +250,37 @@ func TestYankRefusesASymlinkedDir(t *testing.T) {
 	}
 }
 
-// Same premise, without a symlink: a pre-existing world-readable yank directory
-// must be refused rather than written into, since MkdirAll will not tighten it.
-func TestYankRefusesALooseModeDir(t *testing.T) {
+// A pre-existing world-readable directory abctl owns is TIGHTENED, not refused.
+// That matches writeBuiltinConfig in cmd/authbridge-proxy/local.go, which chmods
+// ~/.cortex to 0700 after MkdirAll for this same reason — self-healing beats
+// handing the user a chmod to run by hand.
+func TestYankTightensALooseModeDir(t *testing.T) {
 	home := yankHome(t)
-	if err := os.MkdirAll(filepath.Join(home, ".cortex", "abctl-events"), 0o755); err != nil {
+	cortex := filepath.Join(home, ".cortex")
+	events := filepath.Join(cortex, "abctl-events")
+	if err := os.MkdirAll(events, 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	_, err := yankEventToFile(sampleEvent())
-	if err == nil {
-		t.Fatal("wrote into a 0755 directory, so the 0700 guarantee is not enforced")
+	// MkdirAll only sets the mode on directories it creates, so force both.
+	for _, d := range []string{cortex, events} {
+		if err := os.Chmod(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
-	// The message has to tell the user how to fix it.
-	if !strings.Contains(err.Error(), "chmod 700") {
-		t.Errorf("error does not say how to fix it: %v", err)
+
+	if _, err := yankEventToFile(sampleEvent()); err != nil {
+		t.Fatalf("refused instead of tightening: %v", err)
+	}
+
+	// Both levels, not just the leaf: a loose ~/.cortex exposes the subtree.
+	for _, d := range []string{cortex, events} {
+		fi, err := os.Stat(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm&0o077 != 0 {
+			t.Errorf("%s left at %v; group/world access still open", d, perm)
+		}
 	}
 }
 
@@ -310,7 +326,9 @@ func TestStickyFlash_FitsANarrowFooter(t *testing.T) {
 // like the success case rather than vanishing after flashDuration.
 func TestYankFailure_IsAlsoSticky(t *testing.T) {
 	home := yankHome(t)
-	if err := os.MkdirAll(filepath.Join(home, ".cortex", "abctl-events"), 0o755); err != nil {
+	// A symlink, not a loose mode: loose modes are now tightened in place, so a
+	// symlink is the remaining hard refusal — and there is no chmod out of it.
+	if err := os.Symlink(t.TempDir(), filepath.Join(home, ".cortex")); err != nil {
 		t.Fatal(err)
 	}
 	m := newTestDetailModel(t)
@@ -324,8 +342,8 @@ func TestYankFailure_IsAlsoSticky(t *testing.T) {
 		t.Error("the failure notice is timed, so the chmod guidance disappears " +
 			"in three seconds while a success would persist")
 	}
-	if !strings.Contains(m.flash, "chmod 700") {
-		t.Errorf("failure flash lost its actionable guidance: %q", m.flash)
+	if !strings.Contains(m.flash, "symlink") {
+		t.Errorf("failure flash does not say what is wrong: %q", m.flash)
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -263,8 +263,8 @@ func TestYankRefusesALooseModeDir(t *testing.T) {
 		t.Fatal("wrote into a 0755 directory, so the 0700 guarantee is not enforced")
 	}
 	// The message has to tell the user how to fix it.
-	if !strings.Contains(err.Error(), "0700") {
-		t.Errorf("error does not say what mode is required: %v", err)
+	if !strings.Contains(err.Error(), "chmod 700") {
+		t.Errorf("error does not say how to fix it: %v", err)
 	}
 }
 
@@ -302,6 +302,54 @@ func TestStickyFlash_FitsANarrowFooter(t *testing.T) {
 		// The filename must survive every truncation — it is what the user types.
 		if !strings.Contains(line, "80907711.json") {
 			t.Errorf("width %d: filename truncated away: %q", width, line)
+		}
+	}
+}
+
+// #8: a yank failure carries the chmod guidance that fixes it, so it must persist
+// like the success case rather than vanishing after flashDuration.
+func TestYankFailure_IsAlsoSticky(t *testing.T) {
+	home := yankHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".cortex", "abctl-events"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestDetailModel(t)
+
+	m.handleKey(keyRune('y'))
+
+	if !strings.Contains(m.flash, "yank failed") {
+		t.Fatalf("expected a failure flash, got %q", m.flash)
+	}
+	if !m.flashSticky {
+		t.Error("the failure notice is timed, so the chmod guidance disappears " +
+			"in three seconds while a success would persist")
+	}
+	if !strings.Contains(m.flash, "chmod 700") {
+		t.Errorf("failure flash lost its actionable guidance: %q", m.flash)
+	}
+}
+
+// #7: the wide-rune fixture whose absence let the column/rune confusion ship.
+// fitFlashLine budgets in display columns; slicing by rune index instead made a
+// CJK path asked to fit 40 columns render 55, since each kept rune was 2 wide.
+func TestStickyFlash_FitsWithWideRunes(t *testing.T) {
+	paths := map[string]string{
+		"cjk":   "yanked → /Users/u/.cortex/abctl-events/日本語日本語日本語日本語-1234567890.json",
+		"emoji": "yanked → /Users/u/.cortex/abctl-events/🎉🎉🎉🎉🎉-1234567890.json",
+		"mixed": "yanked → /Users/u/.cortex/abctl-events/日本語-🎉-20260910-80907711.json",
+	}
+	for name, path := range paths {
+		// Includes degenerate widths: the ellipsis alone is already 1 column.
+		for _, width := range []int{1, 2, 10, 40, 60, 72, 200} {
+			m := newTestDetailModel(t)
+			m.width = width
+			m.setStickyFlash(path)
+
+			line := strings.SplitN(m.footerView(), "\n", 2)[0]
+			if got := lipgloss.Width(line); got > width {
+				t.Errorf("%s at width %d: %d columns, overflowing by %d: %q",
+					name, width, got, got-width, line)
+			}
 		}
 	}
 }

--- a/authbridge/cmd/abctl/tui/yank_test.go
+++ b/authbridge/cmd/abctl/tui/yank_test.go
@@ -1,0 +1,180 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// #868: a yanked file has to be findable. os.TempDir() on macOS is
+// /var/folders/<opaque>/T, so the old path ran 92 characters and nobody could
+// retype it or guess where to look. Pins the directory, the 0600 perms the
+// function's comment justifies, and the absence of the redundant name prefix.
+func TestYankEventToFileUsesShortFixedDir(t *testing.T) {
+	p := yankOne(t)
+
+	if got := filepath.Dir(p); got != yankDir {
+		t.Errorf("yanked into %q, want %q", got, yankDir)
+	}
+	base := filepath.Base(p)
+	if strings.HasPrefix(base, "abctl-event-") {
+		t.Errorf("filename %q still carries the abctl-event- prefix, which is "+
+			"redundant inside %s", base, yankDir)
+	}
+	if !strings.HasSuffix(base, ".json") {
+		t.Errorf("filename %q lost its .json suffix", base)
+	}
+
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load-bearing, not cosmetic: events carry identity subjects, raw LLM
+	// completions and tool arguments, and /tmp is shared.
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perms %v, want 0600 — yanked events are operator-only", perm)
+	}
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back pipeline.SessionEvent
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("yanked file is not valid JSON: %v", err)
+	}
+	if back.Host != "api.example.com" {
+		t.Errorf("round-tripped Host = %q, want api.example.com", back.Host)
+	}
+}
+
+// The timestamp is only second-granular, so the random tail is what stops a
+// second yank in the same second from silently clobbering the first. Guards
+// against "simplifying" to a stable filename.
+func TestYankEventToFileTwiceSameSecondDistinct(t *testing.T) {
+	p1 := yankOne(t)
+	p2 := yankOne(t)
+
+	if p1 == p2 {
+		t.Fatalf("two yanks produced the same path %q — the second overwrote "+
+			"the first", p1)
+	}
+	for _, p := range []string{p1, p2} {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("%q does not exist: %v", p, err)
+		}
+	}
+}
+
+// The other half of #868: the path used to vanish after flashDuration, before a
+// user could copy it. Pressing `y` now leaves it up until the next keypress.
+func TestYankFlashIsStickyUntilKeypress(t *testing.T) {
+	m := newTestDetailModel(t)
+
+	if cmd := m.handleKey(keyRune('y')); cmd != nil {
+		t.Log("y returned a command; what matters is the footer below")
+	}
+	path := strings.TrimPrefix(m.flash, "yanked → ")
+	t.Cleanup(func() { os.Remove(path) })
+	if !strings.Contains(m.flash, "yanked → ") {
+		t.Fatalf("y did not flash a yank message, got %q", m.flash)
+	}
+	if !strings.Contains(m.footerView(), yankDir) {
+		t.Fatal("the yanked path is not rendered in the footer")
+	}
+
+	// Past the point where a timed flash would have expired. flashUntil is left
+	// zero by setStickyFlash, so this is already long past.
+	if !m.flashSticky {
+		t.Error("yank flash is not sticky")
+	}
+	if !strings.Contains(m.footerView(), yankDir) {
+		t.Error("the path stopped rendering despite being sticky — a user who " +
+			"looked away has lost it again (#868)")
+	}
+
+	// Any key dismisses it.
+	m.handleKey(keyRune('j'))
+	if m.flashSticky {
+		t.Error("a keypress did not clear the sticky flag")
+	}
+	if strings.Contains(m.footerView(), yankDir) {
+		t.Error("the notice survived a keypress")
+	}
+}
+
+// Stickiness is yank-only. flashDuration is shared with ten other producers
+// (hot-reload failures, fetch errors), and this change must not have made those
+// stay up forever.
+func TestNonYankFlashStillExpires(t *testing.T) {
+	m := newTestDetailModel(t)
+
+	m.setFlash("hot-reload failed: boom")
+	if m.flashSticky {
+		t.Fatal("setFlash produced a sticky flash")
+	}
+	if !strings.Contains(m.footerView(), "hot-reload failed") {
+		t.Fatal("flash not rendered while live")
+	}
+
+	// Expire it the way the 1Hz tick would observe.
+	m.flashUntil = time.Now().Add(-time.Second)
+	if strings.Contains(m.footerView(), "hot-reload failed") {
+		t.Error("a timed flash outlived flashUntil")
+	}
+}
+
+// A sticky flash must not survive a later timed one — otherwise a yank notice
+// would pin the footer past an error the operator needs to see.
+func TestTimedFlashClearsStickiness(t *testing.T) {
+	m := newTestDetailModel(t)
+	m.setStickyFlash("yanked → /tmp/abctl-events/x.json")
+	m.setFlash("catalog fetch failed: boom")
+
+	if m.flashSticky {
+		t.Error("a timed flash inherited the previous flash's stickiness")
+	}
+	m.flashUntil = time.Now().Add(-time.Second)
+	if strings.Contains(m.footerView(), "catalog fetch failed") {
+		t.Error("the timed flash did not expire")
+	}
+}
+
+// yankOne writes one event via the real code path and schedules cleanup.
+func yankOne(t *testing.T) string {
+	t.Helper()
+	p, err := yankEventToFile(sampleEvent())
+	if err != nil {
+		t.Fatalf("yankEventToFile: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(p) })
+	return p
+}
+
+func sampleEvent() *pipeline.SessionEvent {
+	return &pipeline.SessionEvent{
+		At:        time.Now(),
+		Direction: pipeline.Outbound,
+		Phase:     pipeline.SessionRequest,
+		Host:      "api.example.com",
+	}
+}
+
+// newTestDetailModel is a model sitting on the detail pane with an event
+// focused, which is the only state where `y` yanks.
+func newTestDetailModel(t *testing.T) *model {
+	t.Helper()
+	m := &model{
+		pane:        paneDetail,
+		detailEvent: sampleEvent(),
+		width:       200,
+		height:      40,
+		bodyHeight:  12,
+	}
+	return m
+}

--- a/authbridge/demos/weather-agent/demo-with-abctl.md
+++ b/authbridge/demos/weather-agent/demo-with-abctl.md
@@ -197,7 +197,7 @@ Select any row and press `Enter` for the **Detail** pane. It shows the event as 
 
 Note the detail view **strictly separates request and response fields** — a request row shows only request-side data, a response row shows only response-side data. The `identity` field is filtered out here because it's already shown in the banner above the table.
 
-Press `y` (yank) to write the full, unfiltered wire-format JSON to `/tmp/abctl-event-<timestamp>-<random>.json` (mode `0600`). Useful for sharing with teammates or diffing across runs.
+Press `y` (yank) to write the full, unfiltered wire-format JSON to `~/.cortex/abctl-events/<timestamp>-<random>.json` (mode `0600`, in a `0700` directory). The path stays in the footer until you press another key. Useful for sharing with teammates or diffing across runs.
 
 Press `Esc` to go back to the events pane.
 


### PR DESCRIPTION
## Summary

Fixes #868. Yank wrote to `os.TempDir()` — on macOS a 92-character `/var/folders/<opaque>/T` path nobody could find or retype — and the path flashed for 3s then vanished, so an operator who looked away lost the only reference to the file they had just made.

Now: `~/.cortex/abctl-events/<ts>-<rand>.json` (~66 chars), and the path stays in the footer until the next keypress.

## Path

`checkYankDir` **enforces** the privacy guarantee rather than assuming it. `os.MkdirAll` returns `nil` for a path that already exists whatever its mode, and follows symlinks — so it cannot enforce anything on its own. Before writing, every component from the home directory down is `Lstat`ed and rejected if it is a symlink; the directories abctl owns (`~/.cortex`, `abctl-events`) must additionally have no group or world access, with the error naming `chmod 700 <dir>`.

The mode requirement stops at abctl's own directories on purpose: a real home is commonly 0750 or 0755, and demanding 0700 there would refuse to yank on an ordinary account.

Files are 0600 via `os.CreateTemp` (`O_EXCL`, so no create-then-chmod window). The `abctl-event-` filename prefix is dropped as redundant inside `abctl-events/`.

## Flash

A `flashSticky` flag rather than a longer `flashDuration` — that constant is shared with ten other producers, including hot-reload failures. Yank opts in; any keypress dismisses it (`handleKey` is the single funnel for every `tea.KeyMsg`).

A sticky flash takes the footer line from column 0, because appending the path after the 32-column status prefix pushed the filename off the right edge on a narrow terminal. Too-narrow lines truncate from the **left**, so the filename — the part you retype — survives. Truncation budgets in display columns, so wide characters do not overflow.

## Tests

Fifteen, in a new `tui/yank_test.go` (there were none for yank before). Each verified to fail against the code it guards. `yankHome(t)` redirects `$HOME` at a `t.TempDir()`, so the suite never touches the developer's real `~/.cortex` — verified by deleting it and running the full suite with `-race -shuffle=on`. `windows`/`linux`/`darwin` all cross-compile.

## Deliberately not in this PR

1. **The footer status line is unbounded for the other ten flash producers.** Only `hint` goes through `fitHintLine`, and the sticky path added here bypasses the prefix rather than trimming it. Bounding the line for every producer changes rendering for all of them. Worth its own PR.
2. **No `~` abbreviation.** The docs write `~/.cortex/...`; the flash renders the absolute path, and no tilde helper exists in abctl. Would save 12 columns and still overflow 80.
3. **Yanked files are never swept.** `SweepStaleTempfiles` globs `os.TempDir()`, so it will not see these — and the move makes it strictly worse, since `os.TempDir()` is periodically purged by the OS while `~/.cortex` never is. Retention is a product decision, deliberately deferred; the README tells users the files accumulate and are theirs to prune.
4. **`maxEventsPerSession` (1000) does not match the server's `max_events` (500)** despite a comment claiming it does. Untouched.
5. **`main` does not cross-compile `abctl` for Windows** (`syscall.Kill` in `cmd_service_platform.go`). Pre-existing and unrelated; this PR only restores the `tui` package's own Windows build.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exported event files are now saved privately under `~/.cortex/abctl-events`, with secure directory and file permissions.
  - Success and error notifications remain visible until the next keypress.
  - Long footer messages preserve filenames by truncating from the left, including correctly for wide characters.
  - Unsafe event-storage paths are rejected or secured automatically.

- **Documentation**
  - Updated help text, README guidance, and walkthrough instructions to reflect the new event-file location and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->