### PR TITLE
Fix: Say when a new CA leaves running agents unobservable

### DIFF
--- a/authbridge/cmd/abctl/cmd_service.go
+++ b/authbridge/cmd/abctl/cmd_service.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -521,6 +523,29 @@ func serviceStatus(p servicePaths, stdout io.Writer) int {
 			w, version)
 	}
 
+	// The CA cutoff, because "installed and healthy" is not the same as "seeing
+	// anything". A client reads its CA file once at startup, so an agent older than
+	// this CA is being tunnelled rather than observed — and nothing on its side says
+	// so, because tunnelling is not an error. This is the only place that fact is
+	// discoverable without reading the proxy log.
+	if nb, caFile := bridgeCANotBefore(p.configFile); nb != "" {
+		fmt.Fprintf(stdout, "TLS bridge CA: %s (minted %s)\n", caFile, nb)
+		fmt.Fprintf(stdout, "  Agents started before that cannot be observed until restarted.\n")
+		if p.forwardAddr != "" {
+			// Filtered to the CLIENT side and paired with start times, because the
+			// bare `lsof -nP -iTCP:<port>` this used to print does not answer the
+			// question: it lists the proxy's own listening socket and its server-side
+			// half of every connection, and shows no start times at all — so nothing
+			// in it can be compared against the cutoff printed one line above.
+			//
+			// Matching the destination suffix rather than an IP literal keeps it
+			// correct whichever loopback address the listener is on.
+			fmt.Fprintf(stdout, "  Find them:  lsof -nP -iTCP -sTCP:ESTABLISHED"+
+				" | awk '$9 ~ /->.*:%s$/ {print $2}' | sort -u"+
+				" | xargs ps -o pid,lstart,comm -p\n", portOfAddr(p.forwardAddr))
+		}
+	}
+
 	if p.healthURL == "" {
 		return 0
 	}
@@ -733,4 +758,38 @@ func serviceIsCurrent(p servicePaths) bool {
 		return false // cannot confirm it is serving, so do not claim it is
 	}
 	return waitHealthy(p.healthURL, 2*time.Second)
+}
+
+// bridgeCANotBefore returns the bridge CA's NotBefore in RFC3339 and the file it
+// came from, or empty strings when there is no bridge, no CA yet, or the config
+// will not load. Every failure is silent: this is one advisory line in `status`,
+// and a broken config must still let status report the things it can.
+func bridgeCANotBefore(cortexCfg string) (notBefore, caFile string) {
+	cfg, err := config.Load(cortexCfg)
+	if err != nil || cfg.TLSBridge == nil || cfg.TLSBridge.CADir == "" {
+		return "", ""
+	}
+	caFile = filepath.Join(cfg.TLSBridge.CADir, "ca.crt")
+	pemBytes, err := os.ReadFile(caFile)
+	if err != nil {
+		return "", ""
+	}
+	blk, _ := pem.Decode(pemBytes)
+	if blk == nil {
+		return "", ""
+	}
+	crt, err := x509.ParseCertificate(blk.Bytes)
+	if err != nil {
+		return "", ""
+	}
+	return crt.NotBefore.Local().Format(time.RFC3339), caFile
+}
+
+// portOfAddr is the port of a host:port, or the input unchanged when it has no
+// colon — so the suggested lsof command is still recognisable rather than empty.
+func portOfAddr(addr string) string {
+	if _, port, err := net.SplitHostPort(addr); err == nil && port != "" {
+		return port
+	}
+	return addr
 }

--- a/authbridge/cmd/abctl/cmd_service_test.go
+++ b/authbridge/cmd/abctl/cmd_service_test.go
@@ -329,3 +329,50 @@ func TestSupervisionIsPlatformCorrect(t *testing.T) {
 		t.Error("systemd unit lost its own restart policy")
 	}
 }
+
+// TestBridgeCANotBefore_SilentWithoutACA: this is one advisory line in `status`, so
+// every failure to determine it must be silent. A broken or bridgeless config must
+// still let status report everything else.
+func TestBridgeCANotBefore_SilentWithoutACA(t *testing.T) {
+	dir := t.TempDir()
+
+	missing := filepath.Join(dir, "nope.yaml")
+	if nb, f := bridgeCANotBefore(missing); nb != "" || f != "" {
+		t.Errorf("missing config: got (%q,%q), want empty", nb, f)
+	}
+
+	noBridge := filepath.Join(dir, "nobridge.yaml")
+	if err := os.WriteFile(noBridge, []byte("mode: proxy-sidecar\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if nb, f := bridgeCANotBefore(noBridge); nb != "" || f != "" {
+		t.Errorf("config without a bridge: got (%q,%q), want empty", nb, f)
+	}
+
+	// A configured bridge whose ca.crt is not there yet (first boot) is also silent
+	// rather than reporting a cutoff of the zero time, which would read as 1 Jan
+	// year 1 and make every client look stale.
+	caDir := filepath.Join(dir, "ca")
+	withBridge := filepath.Join(dir, "bridge.yaml")
+	body := "mode: proxy-sidecar\ntls_bridge:\n  mode: enabled\n  ca_dir: " + caDir + "\n"
+	if err := os.WriteFile(withBridge, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if nb, _ := bridgeCANotBefore(withBridge); nb != "" {
+		t.Errorf("bridge configured but no ca.crt yet: got %q, want empty", nb)
+	}
+}
+
+// TestPortOfAddr: the value is pasted into an lsof command, so a bare port or an
+// unexpected shape must still produce something recognisable rather than "".
+func TestPortOfAddr(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"127.0.0.1:47600", "47600"},
+		{":47600", "47600"},
+		{"47600", "47600"},
+	} {
+		if got := portOfAddr(tc.in); got != tc.want {
+			t.Errorf("portOfAddr(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -470,9 +470,20 @@ func main() {
 			log.Fatalf("tls-bridge CA init failed: %v", cerr)
 		}
 		if generated {
+			// "already running" is the half people miss. A client reads its CA file
+			// ONCE, at process start, so every agent that was already up is holding
+			// the previous CA — or none — and will reject the leaves this new one
+			// signs. It does not fail loudly: the bridge falls back to tunnelling,
+			// so the traffic still flows and every body-reading plugin goes blind
+			// with nothing on the client side to notice.
+			//
+			// Reached on a first install and after ~/.cortex is deleted and
+			// recreated — which the uninstall instructions tell people to do. A
+			// plain upgrade preserves the CA and is unaffected.
 			slog.Warn("tls-bridge: generated self-signed CA (generate_ca=true; standalone/demo)",
 				"ca_dir", cfg.TLSBridge.CADir,
-				"hint", "clients must trust it, e.g. NODE_EXTRA_CA_CERTS="+cfg.TLSBridge.CADir+"/ca.crt")
+				"hint", "clients must trust it, e.g. NODE_EXTRA_CA_CERTS="+cfg.TLSBridge.CADir+"/ca.crt",
+				"restart_clients", "agents already running trust a different CA (or none) and cannot be observed until restarted")
 		}
 		// Assemble the CA + platform-roots bundle for tools whose CA setting
 		// REPLACES their trust store rather than extending it (Go's SSL_CERT_FILE,

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -311,6 +311,20 @@ Leaving it behind means a CA whose private key you have deleted stays trusted fo
 TLS — harmless in itself, since nothing can sign with it any more, but it is trust
 you did not intend to keep.
 
+#### If you reinstall afterwards, restart your agents
+
+Deleting `~/.cortex` deletes the CA, so a later install mints a **new** one. Every
+agent that is already running still trusts the old CA — a client reads its CA file
+once, at startup — and will refuse the new certificates.
+
+That failure is quiet. Cortex falls back to tunnelling rather than breaking the
+connection, so the traffic keeps flowing and nothing on the agent's side complains;
+it simply stops being parsed, which shows up as `tunnel` rows in `abctl observe`.
+Restart those agents and they are visible again.
+
+An ordinary upgrade is unaffected — it keeps the existing CA. This only applies when
+`~/.cortex` has been deleted, or on a first install with agents already running.
+
 #### If `abctl` is already gone
 
 The service can be removed by hand:

--- a/authbridge/install.sh
+++ b/authbridge/install.sh
@@ -522,6 +522,24 @@ sha_check() {
 	fi
 }
 
+# ca_fingerprint prints a hash of the bridge CA, or nothing when there is no CA yet.
+# Same tool preference as sha_check: shasum on macOS, sha256sum elsewhere. Prints
+# nothing rather than failing when neither exists — this drives one advisory message,
+# and an installer must not die over that.
+ca_fingerprint() {
+	[ -f "${ca_dir}/ca.crt" ] || return 0
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "${ca_dir}/ca.crt" 2>/dev/null | cut -d' ' -f1
+	elif command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "${ca_dir}/ca.crt" 2>/dev/null | cut -d' ' -f1
+	fi
+	# Explicit, because the caller assigns this in a bare `fp="$(ca_fingerprint)"` and a
+	# non-zero status there aborts under set -e. An if/elif with no matching branch
+	# happens to yield 0 today, but that stops being true the moment someone adds an
+	# else — too subtle a thing to leave the installer's survival resting on.
+	return 0
+}
+
 # Demo listener ports — loopback, and deliberately uncommon to avoid colliding
 # with common dev tools. Keep in sync with the built-in config in
 # authbridge/cmd/authbridge-proxy/local.go.
@@ -1104,6 +1122,23 @@ if [ ! -f "${CORTEX_DIR}/config.yaml" ]; then
 	fi
 fi
 
+# A fingerprint of the CA as it stands BEFORE anything starts the proxy, so the summary
+# below can tell whether a new one was minted. Sampled here because the proxy mints on
+# first start and afterwards it is too late to ask — and before BOTH start paths, since
+# the --no-service path mints just as the supervised one does.
+#
+# A newly-minted CA invalidates every client that was already running — they read their
+# CA file once, at startup — and that is invisible to them: the bridge tunnels instead
+# of failing, so traffic flows and the parsers just stop seeing it.
+#
+# Comparing the CONTENT rather than testing for ca.crt's existence, because
+# EnsureFileSource mints when ANY of tls.crt / tls.key / ca.crt is missing, not only when
+# all three are. A directory holding ca.crt but no tls.key — a truncated copy, a
+# half-finished cleanup — gets a brand-new CA while an existence check says "already had
+# one" and suppresses the notice, which is exactly the case that needs it. Hashing also
+# covers any future change to the minting condition without this line tracking it.
+ca_fp_before="$(ca_fingerprint)"
+
 # SUPERVISED records which start path actually took, so the closing summary offers
 # `service stop` only where a service really exists.
 SUPERVISED=""
@@ -1240,6 +1275,19 @@ info "    (tools scan only proposes the prune list; the actual \$ saved shows li
 info ""
 if [ -z "${SUPERVISED}" ]; then
 	print_local_start_help
+	info ""
+fi
+# Said only when the CA actually CHANGED just now, and said late so it is the last
+# thing on screen rather than scrolled past. Silent on the common case — an upgrade
+# leaves all three CA files in place, so nothing is minted and nothing already running
+# is affected.
+ca_fp_after="$(ca_fingerprint)"
+if [ -n "${ca_fp_after}" ] && [ "${ca_fp_before}" != "${ca_fp_after}" ]; then
+	info "  NOTE: a new CA was created for this machine."
+	info "    Agents that were ALREADY RUNNING trust a different CA (or none) and"
+	info "    cannot be observed until restarted — a client reads its CA file once,"
+	info "    at startup. Traffic still flows, so nothing on their side will complain:"
+	info "    it tunnels through unparsed instead. Restart them to see their traffic."
 	info ""
 fi
 # The full, harness-agnostic environment block. `abctl claude-code enable` wires

--- a/authbridge/install_test.sh
+++ b/authbridge/install_test.sh
@@ -671,5 +671,35 @@ check "svc action: unknown non-zero, ports free -> fallback (default; Cortex sti
 check "svc action: refusal wins over ports-busy" "refused" \
 	"$(with_service_install_action 1 'refused: unsafe config' yes)"
 
+# --- the new-CA notice is gated on the CA CHANGING, not on ca.crt existing ---
+#
+# An existence check has a false negative that matters: EnsureFileSource mints when ANY
+# of tls.crt / tls.key / ca.crt is missing, not only when all three are, so a directory
+# holding ca.crt but no tls.key gets a brand-new CA while "ca.crt exists" reports the
+# machine already had one — suppressing the notice in exactly the case that needs it.
+# Verified against the real proxy: removing tls.key produced a different ca.crt hash.
+
+_fp_fn=$(sed -n '/^ca_fingerprint()/,/^}/p' "${INSTALL_SH}")
+check "the CA gate hashes rather than testing existence" "1" \
+	"$(printf '%s' "${_fp_fn}" | grep -cE 'shasum|sha256sum' >/dev/null && echo 1 || echo 0)"
+check "the notice compares before against after" "1" \
+	"$(grep -c 'ca_fp_before}" != "${ca_fp_after' "${INSTALL_SH}" || true)"
+check "no existence-only gate remains" "0" \
+	"$(grep -c 'ca_existed' "${INSTALL_SH}" || true)"
+
+# The fingerprint helper must not abort the installer when no checksum tool exists: the
+# caller assigns it bare, and a non-zero status there dies under set -e.
+_probe="${TMP}/fp.sh"
+{
+	printf 'set -eu\nca_dir=%s\n' "${TMP}/noca"
+	printf '%s\n' "${_fp_fn}"
+	printf 'fp="$(ca_fingerprint)"\nprintf "survived:[%%s]" "${fp}"\n'
+} >"${_probe}"
+mkdir -p "${TMP}/noca"
+check "fingerprint of a missing CA is empty and does not abort" "survived:[]" "$(sh "${_probe}" 2>/dev/null)"
+: >"${TMP}/noca/ca.crt"
+check "fingerprint of a present CA is non-empty" "1" \
+	"$(sh "${_probe}" 2>/dev/null | grep -c 'survived:\[.\+\]' || true)"
+
 printf '\n%s passed, %s failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" = "0" ]


### PR DESCRIPTION
## Summary

A newly-minted CA silently blinds every agent that was already running. Clients read
their CA file **once, at process start**, so anything up before the CA existed holds a
different one — or none — and rejects the leaves it signs.

That does not surface as an error. The bridge falls back to tunnelling, so traffic keeps
flowing and the parsers just stop seeing it, with nothing on the client side to notice.
Diagnosing it took the proxy log, the CA's `NotBefore`, and a process listing.

## This is not an upgrade problem — verified

```
install #1 (fresh)        CA AE:8E:84:A7…   "generated self-signed CA" x1
install #2 (upgrade)      CA AE:8E:84:A7…   x0        <- preserved, silent
rm -rf ~/.cortex; start   CA 3E:57:70:E0…             <- new
```

`EnsureFileSource` mints when **any** of `tls.crt`, `tls.key`, `ca.crt` is missing (an earlier version of this body said "all absent" — wrong, and it produced a real false negative in the gate, since fixed),
and `install.sh` never deletes `~/.cortex` (its `rm -rf` calls are the download tempdir
and the bootstrapped script).

It happens on a **first install with agents already running**, and after `~/.cortex` is
deleted and recreated — which **our own uninstall instructions prescribe**.

## Three places now say it

Chosen so the fact appears where the reader already is:

| Where | What |
|---|---|
| the proxy, as it mints | `restart_clients=` on the existing warning |
| `install.sh` closing summary | only when a CA was actually created just now |
| `abctl service status` | the CA's `NotBefore` plus the `lsof` command to find older clients |

`ca_existed` is sampled **before** the service starts anything — the proxy mints on
first start, so afterwards it is too late to tell.

Plus the uninstall docs, where `rm -rf ~/.cortex` is prescribed, connecting the `tunnel`
/ `client-rejected-ca` rows #929 surfaces back to "restart your agents".

"Installed and healthy" is not the same as "seeing anything", and this was the only such
fact with nowhere to read it but the proxy log.

## Scope correction: no process inspection in Go

I had proposed `abctl` compare the CA's `NotBefore` against running clients' start times.
Doing it by hand showed that needs an `lsof` equivalent — `/proc` on Linux, libproc on
macOS, socket-to-pid per lookup — which would give a diagnostics-only change its own real
risk. Printing the cutoff and the one command gets the same answer for none of that.

## Verification

End to end in a sandbox on shifted ports:

```
fresh install    -> notice printed, CA minted
second install   -> silent, CA fingerprint unchanged
proxy minting    -> restart_clients="agents already running trust a different CA …"
```

Unit tests cover the `status` line failing silently on a missing config, a bridgeless
config, and a configured bridge whose `ca.crt` does not exist yet — that last one would
otherwise report a cutoff of the zero time and make every client look stale.

`shellcheck` clean at `--severity=error` and `-s sh`; 42 install tests pass; `go vet` and
both Go suites clean; `gofmt` clean on every file touched. No conflict with #929
(`git merge-tree` reports zero markers) despite both touching `laptop-service.md`.

## Relationship to the other two

- **#929** (open) makes the failure legible once it happens. This one stops it happening.
- **Problem 2** — the skip set is keyed by host, so one stale client suppresses
  observability for every client for 10 minutes, repeatedly — is **not** here. It changes
  bridging behaviour, its `bridgeServe` edit lands in the hunk #929 rewrites, and it
  carries a tradeoff worth its own discussion. It also matters much less once this merges,
  since most stale clients exist only because nothing told anyone to restart them.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Service status now shows when the bridge certificate authority was created.
  - When applicable, it provides a command to help identify client connections that started before the certificate authority was renewed.
  - Installation now detects certificate authority changes and alerts you when running agents need to be restarted.

- **Bug Fixes**
  - Improved handling when certificate authority information is unavailable or incomplete.

- **Documentation**
  - Added guidance explaining why agents may need restarting after reinstalling the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->