### PR TITLE
Fix: Stop one stale client blinding a host for every other client

### DIFF
--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -638,8 +638,23 @@ func (s *Server) bridgeServe(client net.Conn, authority, host string, rec tunnel
 	// 2) Forge + terminate downstream.
 	tconn, err := s.TLSBridge.Term.Terminate(client, hostOnly(authority))
 	if err != nil {
-		s.TLSBridge.Skip.Fail(host) // this client's retry will passthrough; window backs off
 		reason := handshakeFailureReason(err)
+		// Seed a skip either way — the forged handshake killed this connection, so the
+		// client's retry needs a tunnel whatever went wrong. But only ESCALATE for a
+		// real rejection: that is the one failure class that is evidence of a
+		// persistent trust problem. A client that merely cancels requests, or one
+		// tripping a cipher mismatch, would otherwise walk this host up to the ceiling
+		// and take every other client's observability with it — the same defect this
+		// change exists to fix, one level down.
+		//
+		// The decision is here rather than inside SkipSet because the reason vocabulary
+		// belongs to the session-event layer, and tlsbridge has no other business
+		// knowing about it.
+		if reason == pipeline.TunnelClientRejectedCA {
+			s.TLSBridge.Skip.Fail(host)
+		} else {
+			s.TLSBridge.Skip.FailTransient(host)
+		}
 		// UNCONDITIONAL, and it names the client. Success elsewhere must not silence
 		// this: it used to sit behind bridgedRequests == 0, which treats CA trust as a
 		// property of the deployment. It is a property of each client, and on a

--- a/authbridge/authlib/listener/forwardproxy/server.go
+++ b/authbridge/authlib/listener/forwardproxy/server.go
@@ -638,7 +638,7 @@ func (s *Server) bridgeServe(client net.Conn, authority, host string, rec tunnel
 	// 2) Forge + terminate downstream.
 	tconn, err := s.TLSBridge.Term.Terminate(client, hostOnly(authority))
 	if err != nil {
-		s.TLSBridge.Skip.Add(host) // pinned client → its retry will passthrough
+		s.TLSBridge.Skip.Fail(host) // this client's retry will passthrough; window backs off
 		reason := handshakeFailureReason(err)
 		// UNCONDITIONAL, and it names the client. Success elsewhere must not silence
 		// this: it used to sit behind bridgedRequests == 0, which treats CA trust as a
@@ -679,6 +679,10 @@ func (s *Server) bridgeServe(client net.Conn, authority, host string, rec tunnel
 		// case, reached from the tunnel-threshold path.
 		return true // conn is dead post-forge; nothing left to tunnel
 	}
+	// A completed forged handshake is proof a client here trusts the CA, so it clears
+	// any skip left by a different client that does not — which is what stops one stale
+	// agent suppressing this host for everyone until a window elapses.
+	s.TLSBridge.Skip.Succeed(host)
 	// Bridged: record with no reason, which is what tells abctl to fold this row into
 	// the decrypted inner request whose own action is the interesting one.
 	markBridged(rec)

--- a/authbridge/authlib/listener/forwardproxy/tunnelreason_integration_test.go
+++ b/authbridge/authlib/listener/forwardproxy/tunnelreason_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -316,7 +317,7 @@ func TestHandleConnect_RecordsReason(t *testing.T) {
 			t.Fatal(err)
 		}
 		s := connectServer(t, store, &tlsbridge.Engine{Decision: d, Skip: tlsbridge.NewSkipSet()})
-		s.TLSBridge.Skip.Add(hostOnly(target)) // a previous client's rejection
+		s.TLSBridge.Skip.Fail(hostOnly(target)) // a previous client's rejection
 		ev := connectThrough(t, s, store, target, tlsRecordHead)
 		if ev == nil || ev.TunnelReason != pipeline.TunnelSkipCached {
 			t.Fatalf("reason = %v, want %q", ev, pipeline.TunnelSkipCached)
@@ -430,5 +431,81 @@ func TestPassthroughReasonNeverEmpty(t *testing.T) {
 	}
 	if got := passthroughReason("a-reason-nobody-mapped"); got != pipeline.TunnelPassthroughUnknown {
 		t.Errorf("unmapped reason = %q, want the sentinel %q", got, pipeline.TunnelPassthroughUnknown)
+	}
+}
+
+// trustingClient is a real TLS client that DOES trust the bridge CA, so it completes
+// the forged handshake. It sends a request and reads the reply so ServeConn has
+// something to serve, then closes.
+func trustingClient(t *testing.T, caPEM []byte) net.Conn {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("could not load the bridge CA into a pool")
+	}
+	return clientConnPair(t, func(raw net.Conn) {
+		tc := tls.Client(raw, &tls.Config{ServerName: "example.com", RootCAs: pool})
+		if err := tc.Handshake(); err != nil {
+			return
+		}
+		_, _ = tc.Write([]byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+		_, _ = io.ReadFull(tc, make([]byte, 1))
+		_ = tc.Close()
+	})
+}
+
+// TestOneStaleClientDoesNotSuppressAHealthyOne is the scenario this change exists for.
+//
+// The skip set is keyed by host, and there is no durable client identity to key it by,
+// so one client's rejection tunnels every OTHER client's traffic to that host as well.
+// With a fixed ten-minute window re-armed on each attempt, a single agent holding a
+// stale CA cost a correctly-configured one nearly all of its observability — measured
+// on a real laptop as four rejections over a hundred minutes with one bridged request
+// in between.
+//
+// A success now clears the entry, so the healthy client restores interception itself
+// rather than waiting out a window it did not cause.
+func TestOneStaleClientDoesNotSuppressAHealthyOne(t *testing.T) {
+	s, _, authority := bridgeForRejectTest(t)
+	host := hostOnly(authority)
+
+	// 1. The stale client rejects our leaf; the host is skipped for everyone.
+	s.bridgeServe(rejectingClient(t), authority, host, noopRecorder)
+	if !s.TLSBridge.Skip.Contains(host) {
+		t.Fatal("a rejected forge did not skip the host")
+	}
+
+	// 2. The healthy client bridges. bridgeServe blocks serving the decrypted
+	//    connection, so run it and wait for the skip to clear.
+	go s.bridgeServe(trustingClient(t, s.TLSBridge.CAPEM), authority, host, noopRecorder)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !s.TLSBridge.Skip.Contains(host) {
+			return // cleared: the next connection from either client is intercepted again
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("a successful bridge did not clear the skip; the healthy client stays blind " +
+		"until a window it did not cause elapses")
+}
+
+// TestRepeatedRejectionBacksOff: with nothing ever succeeding — a genuinely pinned
+// client — the window must escalate rather than break that client's handshake every
+// few seconds forever. This is the behaviour the skip was originally built for.
+func TestRepeatedRejectionBacksOff(t *testing.T) {
+	s, _, authority := bridgeForRejectTest(t)
+	host := hostOnly(authority)
+
+	var windows []time.Duration
+	for i := 0; i < 3; i++ {
+		s.TLSBridge.Skip.Succeed(host) // force a fresh attempt without waiting
+		for j := 0; j <= i; j++ {
+			s.bridgeServe(rejectingClient(t), authority, host, noopRecorder)
+		}
+		windows = append(windows, s.TLSBridge.Skip.Window(host))
+	}
+	if !(windows[0] < windows[1] && windows[1] < windows[2]) {
+		t.Errorf("windows did not escalate with consecutive rejections: %v", windows)
 	}
 }

--- a/authbridge/authlib/listener/forwardproxy/tunnelreason_integration_test.go
+++ b/authbridge/authlib/listener/forwardproxy/tunnelreason_integration_test.go
@@ -490,22 +490,8 @@ func TestOneStaleClientDoesNotSuppressAHealthyOne(t *testing.T) {
 		"until a window it did not cause elapses")
 }
 
-// TestRepeatedRejectionBacksOff: with nothing ever succeeding — a genuinely pinned
-// client — the window must escalate rather than break that client's handshake every
-// few seconds forever. This is the behaviour the skip was originally built for.
-func TestRepeatedRejectionBacksOff(t *testing.T) {
-	s, _, authority := bridgeForRejectTest(t)
-	host := hostOnly(authority)
-
-	var windows []time.Duration
-	for i := 0; i < 3; i++ {
-		s.TLSBridge.Skip.Succeed(host) // force a fresh attempt without waiting
-		for j := 0; j <= i; j++ {
-			s.bridgeServe(rejectingClient(t), authority, host, noopRecorder)
-		}
-		windows = append(windows, s.TLSBridge.Skip.Window(host))
-	}
-	if !(windows[0] < windows[1] && windows[1] < windows[2]) {
-		t.Errorf("windows did not escalate with consecutive rejections: %v", windows)
-	}
-}
+// Escalation itself — that a rejection lengthens the window and a transient failure
+// does not — is asserted in tlsbridge, where SkipSet's internals are reachable without
+// exporting a window accessor purely for a test. What belongs HERE is that bridgeServe
+// routes each failure class to the right call, which TestHangUpAlsoSeedsTheSkip and
+// TestClientRejectedCA_SkipsHostAfterwards cover between them.

--- a/authbridge/authlib/tlsbridge/decision.go
+++ b/authbridge/authlib/tlsbridge/decision.go
@@ -60,7 +60,12 @@ type Decision struct {
 // That is accepted rather than overlooked. The traffic could not be inspected
 // reliably anyway — before this list, an untrusting client's first request to any
 // of these hosts failed and the host was then auto-skipped for ten minutes (see
-// SkipSet below), so interception was intermittent and its absence silent. The
+// SkipSet below), so interception was intermittent and its absence silent. Both
+// halves of that have since been addressed: the absence now carries a reason
+// (SessionEvent.TunnelReason), and the intermittency is bounded by a window that
+// starts short and is cleared outright by any client that does trust the CA. The
+// list stays, because a tunnel chosen on purpose still beats one arrived at by
+// failure. The
 // control that actually remains for egress is allow-listing which hosts a
 // workload may reach at all — iptables / NetworkPolicy in-cluster, and
 // listener.skip_hosts plus the egress gate for the proxy — not TLS inspection of
@@ -188,13 +193,34 @@ func looksLikeTLSRecord(b []byte) bool {
 }
 
 const (
-	// skipTTL bounds how long an auto-skipped host stays skipped before the
-	// bridge re-attempts interception (self-healing: a transiently-pinned or
-	// rotated client gets another chance). skipMax caps the set so a flood of
-	// distinct SNIs (each rejecting the forged leaf) cannot grow it unbounded —
-	// since scope removal routes ALL eligible egress through here.
-	skipTTL = 10 * time.Minute
-	skipMax = 4096
+	// skipBackoffBase is the FIRST skip window after a host's leaf is rejected, and
+	// skipTTL is the ceiling it doubles up to. Both matter, for opposite cases.
+	//
+	// The window is collateral: it suppresses interception for every client of that
+	// host, not just the one that rejected us — the set is keyed by host, and there is
+	// no durable client identity to key it by (a source port changes per connection,
+	// and peer-PID has no portable API over TCP). So on a machine where one agent
+	// holds a stale CA and the rest are fine, a long window costs the healthy ones all
+	// their observability. Ten minutes of it, re-armed on every attempt, is how a
+	// laptop lost 99% of the visibility on one host for two hours.
+	//
+	// Starting short and doubling separates the two situations without needing to tell
+	// the clients apart:
+	//
+	//   mixed clients   a success CLEARS the entry, so the counter never climbs and
+	//                   windows stay near the base — the healthy client is visible
+	//                   again seconds after a stale one trips it.
+	//   pinned host     nothing ever succeeds, so it escalates to skipTTL and settles
+	//                   at today's behaviour. That is the case the skip was built for
+	//                   and it must not regress: a fixed short window would break such
+	//                   a client's handshake every 30s forever.
+	//
+	// The cost is borne by the misconfigured client — its forged handshake fails once
+	// per window rather than once per ten minutes — which is the right way round, and
+	// it now gets a warning naming itself and the CA.
+	skipBackoffBase = 30 * time.Second
+	skipTTL         = 10 * time.Minute
+	skipMax         = 4096
 )
 
 // SkipSet is the runtime auto-skip set (hosts whose minted leaf the client
@@ -204,46 +230,108 @@ type SkipSet struct {
 	mu  sync.RWMutex
 	ttl time.Duration
 	max int
-	m   map[string]time.Time // host -> expiry
+	m   map[string]skipEntry
+}
+
+// skipEntry is one skipped host: when the window ends, and how many consecutive
+// rejections have set it. failures drives the backoff and is what a success discards.
+type skipEntry struct {
+	expiry   time.Time
+	failures int
 }
 
 func NewSkipSet() *SkipSet {
-	return &SkipSet{ttl: skipTTL, max: skipMax, m: map[string]time.Time{}}
+	return &SkipSet{ttl: skipTTL, max: skipMax, m: map[string]skipEntry{}}
 }
 
-func (s *SkipSet) Add(host string) {
+// backoffFor is the window after n consecutive failures: base, doubling, capped at ttl.
+// Shifting past 63 would wrap, so the cap is applied on the count first — a host that
+// has failed sixty times is at the ceiling either way.
+func (s *SkipSet) backoffFor(n int) time.Duration {
+	if n < 1 {
+		n = 1
+	}
+	if n > 32 {
+		return s.ttl
+	}
+	d := skipBackoffBase << (n - 1)
+	if d > s.ttl || d <= 0 {
+		return s.ttl
+	}
+	return d
+}
+
+// Fail records that a client rejected this host's minted leaf, extending the skip
+// window. Consecutive failures back off; a Succeed in between resets the count.
+func (s *SkipSet) Fail(host string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now()
 	if len(s.m) >= s.max {
 		// Purge expired entries; if still full, drop the earliest-expiring one.
-		// Add is cold (only fires when a minted leaf is rejected), so an O(n)
+		// Fail is cold (only fires when a minted leaf is rejected), so an O(n)
 		// sweep here is cheap.
 		var oldestK string
 		var oldestT time.Time
-		for k, exp := range s.m {
-			if !exp.After(now) {
+		for k, e := range s.m {
+			if !e.expiry.After(now) {
 				delete(s.m, k)
 				continue
 			}
-			if oldestK == "" || exp.Before(oldestT) {
-				oldestK, oldestT = k, exp
+			if oldestK == "" || e.expiry.Before(oldestT) {
+				oldestK, oldestT = k, e.expiry
 			}
 		}
 		if len(s.m) >= s.max && oldestK != "" {
 			delete(s.m, oldestK)
 		}
 	}
+	// An expired entry starts over rather than continuing to escalate: the window
+	// having elapsed with no further rejection is evidence the problem may be gone.
+	n := 1
+	if e, ok := s.m[host]; ok && e.expiry.After(now) {
+		n = e.failures + 1
+	}
 	// .Round(0) strips the monotonic reading so the expiry is a pure wall-clock
 	// time. Contains compares it against time.Now() via the wall clock, so an
-	// entry expires after skipTTL of real time even across a suspend (where the
+	// entry expires after its window of real time even across a suspend (where the
 	// monotonic clock freezes and would otherwise keep the host skipped longer).
-	s.m[host] = now.Add(s.ttl).Round(0)
+	s.m[host] = skipEntry{expiry: now.Add(s.backoffFor(n)).Round(0), failures: n}
+}
+
+// Succeed records that a client completed the forged handshake for this host, which
+// disproves the entry outright and clears it — count included.
+//
+// This is the signal the set never had. It only ever added entries and waited them
+// out, so a demonstrably-trusting client bridging successfully taught it nothing and
+// the next connection was still tunnelled. Clearing here is what makes the collateral
+// window seconds long instead of minutes, and it is why restarting a stale agent
+// restores observability immediately rather than after a wait.
+func (s *SkipSet) Succeed(host string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, host)
+}
+
+// Window is the time left on a host's skip, or zero when it is not skipped. Exported
+// for tests in dependent packages that assert on backoff; the proxy itself only ever
+// asks Contains.
+func (s *SkipSet) Window(host string) time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.m[host]
+	if !ok {
+		return 0
+	}
+	if d := time.Until(e.expiry); d > 0 {
+		return d
+	}
+	return 0
 }
 
 func (s *SkipSet) Contains(host string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	exp, ok := s.m[host]
-	return ok && time.Now().Before(exp) // expired entries read as absent; Add reclaims them
+	e, ok := s.m[host]
+	return ok && time.Now().Before(e.expiry) // expired entries read as absent; Fail reclaims them
 }

--- a/authbridge/authlib/tlsbridge/decision.go
+++ b/authbridge/authlib/tlsbridge/decision.go
@@ -227,10 +227,15 @@ const (
 // rejected). Concurrent-safe; augments the static skip list. Entries expire
 // after skipTTL and the set is bounded to skipMax (oldest-expiry eviction).
 type SkipSet struct {
-	mu  sync.RWMutex
-	ttl time.Duration
-	max int
-	m   map[string]skipEntry
+	mu sync.RWMutex
+	// base is the first window and ttl the ceiling it doubles up to. base is a field
+	// rather than only a package const so a same-package test can drive the actual
+	// doubling: with base fixed at 30s, tightening ttl alone caps every window to ttl
+	// regardless of the failure count, which exercises cap-and-reset and not escalation.
+	base time.Duration
+	ttl  time.Duration
+	max  int
+	m    map[string]skipEntry
 }
 
 // skipEntry is one skipped host: when the window ends, and how many consecutive
@@ -241,7 +246,7 @@ type skipEntry struct {
 }
 
 func NewSkipSet() *SkipSet {
-	return &SkipSet{ttl: skipTTL, max: skipMax, m: map[string]skipEntry{}}
+	return &SkipSet{base: skipBackoffBase, ttl: skipTTL, max: skipMax, m: map[string]skipEntry{}}
 }
 
 // backoffFor is the window after n consecutive failures: base, doubling, capped at ttl.
@@ -254,16 +259,30 @@ func (s *SkipSet) backoffFor(n int) time.Duration {
 	if n > 32 {
 		return s.ttl
 	}
-	d := skipBackoffBase << (n - 1)
+	d := s.base << (n - 1)
 	if d > s.ttl || d <= 0 {
 		return s.ttl
 	}
 	return d
 }
 
-// Fail records that a client rejected this host's minted leaf, extending the skip
-// window. Consecutive failures back off; a Succeed in between resets the count.
-func (s *SkipSet) Fail(host string) {
+// Fail records a failure that IS evidence of a persistent trust problem — the client
+// rejected the minted leaf — and lengthens the window for each consecutive one. A
+// Succeed in between resets the count.
+func (s *SkipSet) Fail(host string) { s.fail(host, true) }
+
+// FailTransient records a failure that is NOT evidence about trust: a client that hung
+// up, a version or cipher mismatch, or our own minting failing. It still seeds a skip,
+// because the forged handshake killed that connection either way and the retry needs a
+// tunnel — but it does not escalate, so a client that merely cancels a lot cannot walk
+// the host up to the ceiling and take every other client's observability with it.
+//
+// Which one to call is the CALLER's decision, deliberately: it holds the classified
+// reason, and passing that vocabulary down here would make this package depend on the
+// session-event types it has no other business knowing about.
+func (s *SkipSet) FailTransient(host string) { s.fail(host, false) }
+
+func (s *SkipSet) fail(host string, escalate bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	now := time.Now()
@@ -290,7 +309,17 @@ func (s *SkipSet) Fail(host string) {
 	// having elapsed with no further rejection is evidence the problem may be gone.
 	n := 1
 	if e, ok := s.m[host]; ok && e.expiry.After(now) {
-		n = e.failures + 1
+		if escalate {
+			n = e.failures + 1
+		} else {
+			// Hold the count where it is: a transient failure must not lengthen the
+			// window, but it must not shorten one a real rejection already earned
+			// either.
+			n = e.failures
+			if n < 1 {
+				n = 1
+			}
+		}
 	}
 	// .Round(0) strips the monotonic reading so the expiry is a pure wall-clock
 	// time. Contains compares it against time.Now() via the wall clock, so an
@@ -313,10 +342,13 @@ func (s *SkipSet) Succeed(host string) {
 	delete(s.m, host)
 }
 
-// Window is the time left on a host's skip, or zero when it is not skipped. Exported
-// for tests in dependent packages that assert on backoff; the proxy itself only ever
-// asks Contains.
-func (s *SkipSet) Window(host string) time.Duration {
+// window is the time left on a host's skip, or zero when it is not skipped.
+//
+// Unexported: it exists for this package's tests, and the proxy only ever asks Contains.
+// It was briefly exported so a forwardproxy test could assert on backoff, which widened
+// authlib's public API for a test-only need — the assertions that wanted it live here
+// now instead, where the internals already are.
+func (s *SkipSet) window(host string) time.Duration {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	e, ok := s.m[host]

--- a/authbridge/authlib/tlsbridge/decision_test.go
+++ b/authbridge/authlib/tlsbridge/decision_test.go
@@ -293,15 +293,33 @@ func TestSkipSet_SucceedResetsBackoff(t *testing.T) {
 }
 
 // TestSkipSet_ExpiredEntryRestartsBackoff: a window that elapsed with no further
-// rejection is evidence the problem may be gone, so the next failure starts over
-// rather than continuing to climb.
+// failure is evidence the problem may be gone, so the next failure starts over rather
+// than continuing to climb.
+//
+// base is tightened as well as ttl, which the earlier version of this test did not do:
+// with base fixed at 30s every window capped to the tiny ttl regardless of the failure
+// count, so it exercised cap-and-reset and proved nothing about restarting a backoff its
+// name claimed to cover. Driving both lets it escalate for real and then reset.
 func TestSkipSet_ExpiredEntryRestartsBackoff(t *testing.T) {
 	s := NewSkipSet()
-	s.ttl = 40 * time.Millisecond
-	for i := 0; i < 3; i++ {
-		s.Fail("h")
+	s.base = 10 * time.Millisecond
+	s.ttl = 200 * time.Millisecond
+
+	s.Fail("h")
+	s.Fail("h")
+	s.Fail("h")
+	s.mu.RLock()
+	climbed := s.m["h"].failures
+	s.mu.RUnlock()
+	if climbed != 3 {
+		t.Fatalf("failures = %d after 3 consecutive rejections, want 3 (no real escalation "+
+			"happened, so the reset below would prove nothing)", climbed)
 	}
-	time.Sleep(60 * time.Millisecond)
+	if w := window(t, s, "h"); w <= s.base {
+		t.Errorf("window %v did not grow beyond the base %v", w, s.base)
+	}
+
+	time.Sleep(120 * time.Millisecond) // longer than the 3rd window (40ms), shorter than ttl
 	if s.Contains("h") {
 		t.Fatal("entry should have expired")
 	}
@@ -311,5 +329,60 @@ func TestSkipSet_ExpiredEntryRestartsBackoff(t *testing.T) {
 	s.mu.RUnlock()
 	if n != 1 {
 		t.Errorf("failures after an expired window = %d, want 1 (a fresh start)", n)
+	}
+}
+
+// TestSkipSet_TransientFailureDoesNotEscalate is the review's point made executable.
+//
+// Only a rejected leaf is evidence of a persistent trust problem. A hang-up or a cipher
+// mismatch still has to seed a skip — the forged handshake killed that connection — but
+// escalating on it lets a client that merely cancels a lot walk the host to the ceiling
+// and take every other client's observability with it.
+func TestSkipSet_TransientFailureDoesNotEscalate(t *testing.T) {
+	s := NewSkipSet()
+
+	s.FailTransient("h")
+	if !s.Contains("h") {
+		t.Fatal("a transient failure must still seed a skip; the retry needs the tunnel")
+	}
+	for i := 0; i < 5; i++ {
+		s.FailTransient("h")
+	}
+	// Asserted against base, not against the previous reading: every Fail re-dates the
+	// window from now, so two readings differ by microseconds even with no escalation
+	// at all. What matters is that the window never exceeds ONE base — an escalation
+	// would put it at 2x or more.
+	if got := window(t, s, "h"); got > s.base {
+		t.Errorf("window is %v after six transient failures, more than one base (%v); "+
+			"only a rejection should escalate", got, s.base)
+	}
+	s.mu.RLock()
+	n := s.m["h"].failures
+	s.mu.RUnlock()
+	if n != 1 {
+		t.Errorf("transient failures drove the count to %d, want it held at 1", n)
+	}
+}
+
+// TestSkipSet_TransientDoesNotShortenAnEarnedWindow: a transient failure must not
+// escalate, but it must not undo a longer window a real rejection already earned either
+// — otherwise a cancel-happy client could keep resetting a genuinely pinned host back to
+// the base and make it forge repeatedly.
+func TestSkipSet_TransientDoesNotShortenAnEarnedWindow(t *testing.T) {
+	s := NewSkipSet()
+	for i := 0; i < 4; i++ {
+		s.Fail("h")
+	}
+	earned := window(t, s, "h")
+
+	s.FailTransient("h")
+	if got := window(t, s, "h"); got < earned/2 {
+		t.Errorf("a transient failure cut the earned window from %v to %v", earned, got)
+	}
+	s.mu.RLock()
+	n := s.m["h"].failures
+	s.mu.RUnlock()
+	if n != 4 {
+		t.Errorf("failures = %d after a transient failure, want the earned 4", n)
 	}
 }

--- a/authbridge/authlib/tlsbridge/decision_test.go
+++ b/authbridge/authlib/tlsbridge/decision_test.go
@@ -63,18 +63,18 @@ func TestSkipSet_AutoSkip(t *testing.T) {
 	if s.Contains("h") {
 		t.Fatal("empty set should not contain h")
 	}
-	s.Add("h")
+	s.Fail("h")
 	if !s.Contains("h") {
-		t.Error("Add then Contains failed")
+		t.Error("Fail then Contains failed")
 	}
 }
 
 func TestSkipSet_TTLExpires(t *testing.T) {
 	s := NewSkipSet()
-	s.ttl = 20 * time.Millisecond // same-package test can tighten the TTL
-	s.Add("h")
+	s.ttl = 20 * time.Millisecond // same-package test can tighten the CAP
+	s.Fail("h")
 	if !s.Contains("h") {
-		t.Fatal("should contain immediately after Add")
+		t.Fatal("should contain immediately after Fail")
 	}
 	time.Sleep(40 * time.Millisecond)
 	if s.Contains("h") {
@@ -85,9 +85,9 @@ func TestSkipSet_TTLExpires(t *testing.T) {
 func TestSkipSet_Bounded(t *testing.T) {
 	s := NewSkipSet()
 	s.max = 2 // cap small; a flood of distinct SNIs must not grow it unbounded
-	s.Add("a")
-	s.Add("b")
-	s.Add("c")
+	s.Fail("a")
+	s.Fail("b")
+	s.Fail("c")
 	if len(s.m) > 2 {
 		t.Errorf("SkipSet grew past max: len=%d, want <=2", len(s.m))
 	}
@@ -216,5 +216,100 @@ func TestNewDecision_RejectsUnusablePatterns(t *testing.T) {
 	// a fatal boot error for every user.
 	if _, err := NewDecision(DecisionOpts{SkipHosts: DefaultPassthroughHosts}); err != nil {
 		t.Fatalf("DefaultPassthroughHosts does not compile: %v", err)
+	}
+}
+
+// window returns the remaining skip window for host, for asserting on backoff.
+func window(t *testing.T, s *SkipSet, host string) time.Duration {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.m[host]
+	if !ok {
+		t.Fatalf("no entry for %q", host)
+	}
+	return time.Until(e.expiry)
+}
+
+// TestSkipSet_SucceedClears is the signal the set never had.
+//
+// It only ever added entries and waited them out, so a client that demonstrably
+// trusted the CA bridging successfully taught it nothing: the next connection to that
+// host was still tunnelled. On a machine where one agent holds a stale CA and the rest
+// are fine, that is how the healthy ones lost their observability for ten minutes at a
+// time, repeatedly.
+func TestSkipSet_SucceedClears(t *testing.T) {
+	s := NewSkipSet()
+	s.Fail("h")
+	if !s.Contains("h") {
+		t.Fatal("Fail did not skip the host")
+	}
+	s.Succeed("h")
+	if s.Contains("h") {
+		t.Error("Succeed did not clear the entry; a trusting client's proof was discarded")
+	}
+}
+
+// TestSkipSet_BackoffEscalates: consecutive rejections lengthen the window, so a host
+// where NOTHING ever succeeds settles at the cap — today's behaviour, which is the
+// case the skip was built for and must not regress.
+func TestSkipSet_BackoffEscalates(t *testing.T) {
+	s := NewSkipSet()
+	var prev time.Duration
+	for i := 1; i <= 6; i++ {
+		s.Fail("h")
+		got := window(t, s, "h")
+		if got <= prev && got < s.ttl {
+			t.Errorf("failure %d: window %v did not grow past %v", i, got, prev)
+		}
+		if got > s.ttl {
+			t.Errorf("failure %d: window %v exceeds the cap %v", i, got, s.ttl)
+		}
+		prev = got
+	}
+	// Far past the doubling range: still capped, never negative from a shift overflow.
+	for i := 0; i < 40; i++ {
+		s.Fail("h")
+	}
+	if got := window(t, s, "h"); got > s.ttl || got <= 0 {
+		t.Errorf("window after many failures = %v, want 0 < w <= %v", got, s.ttl)
+	}
+}
+
+// TestSkipSet_SucceedResetsBackoff: clearing must discard the COUNT too, or a host that
+// recovered would keep escalating from wherever it left off and the mixed-client case
+// would drift toward the cap it is meant to avoid.
+func TestSkipSet_SucceedResetsBackoff(t *testing.T) {
+	s := NewSkipSet()
+	for i := 0; i < 4; i++ {
+		s.Fail("h")
+	}
+	escalated := window(t, s, "h")
+	s.Succeed("h")
+	s.Fail("h")
+	if got := window(t, s, "h"); got >= escalated {
+		t.Errorf("after Succeed the window is %v, want back near the base (was %v)", got, escalated)
+	}
+}
+
+// TestSkipSet_ExpiredEntryRestartsBackoff: a window that elapsed with no further
+// rejection is evidence the problem may be gone, so the next failure starts over
+// rather than continuing to climb.
+func TestSkipSet_ExpiredEntryRestartsBackoff(t *testing.T) {
+	s := NewSkipSet()
+	s.ttl = 40 * time.Millisecond
+	for i := 0; i < 3; i++ {
+		s.Fail("h")
+	}
+	time.Sleep(60 * time.Millisecond)
+	if s.Contains("h") {
+		t.Fatal("entry should have expired")
+	}
+	s.Fail("h")
+	s.mu.RLock()
+	n := s.m["h"].failures
+	s.mu.RUnlock()
+	if n != 1 {
+		t.Errorf("failures after an expired window = %d, want 1 (a fresh start)", n)
 	}
 }

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -205,7 +205,7 @@ The other reasons you may see, and what each one asks of you:
 | `passthrough-host` | A host Cortex deliberately does not intercept (GitHub, module proxies, package registries). | no |
 | `passthrough-port` | Not a port the bridge watches. | no |
 | `passthrough-nontls` | The bytes were not a TLS handshake, so there was nothing to terminate. | no |
-| `skip-cached` | An earlier handshake for this host failed, so it is not intercepted for **anyone** for a short window. Any failed handshake seeds this, not only a CA rejection — the seeding failure logged its own reason. The window starts at 30s and lengthens only if failures keep coming; the first client that *does* trust the CA clears it immediately. | find the earlier failure in `proxy.log` and fix that client |
+| `skip-cached` | An earlier handshake for this host failed, so it is not intercepted for **anyone** for a short window. Any failed handshake seeds this, not only a CA rejection — the seeding failure logged its own reason. The window starts at 30s and lengthens only if **rejections** keep coming — a hang-up or a cipher mismatch seeds it but never escalates it; the first client that *does* trust the CA clears it immediately. | find the earlier failure in `proxy.log` and fix that client |
 | `bridge-disabled` | No TLS bridge is configured. | only if you wanted one |
 | `client-hung-up` | The client vanished mid-handshake. Often a cancelled request; not evidence about trust, which is why it carries no advice. | usually no |
 | `handshake-failed` | Some other handshake failure — a version, cipher or ALPN mismatch, or Cortex failing to mint a certificate. | check `error=` in the log |

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -205,7 +205,7 @@ The other reasons you may see, and what each one asks of you:
 | `passthrough-host` | A host Cortex deliberately does not intercept (GitHub, module proxies, package registries). | no |
 | `passthrough-port` | Not a port the bridge watches. | no |
 | `passthrough-nontls` | The bytes were not a TLS handshake, so there was nothing to terminate. | no |
-| `skip-cached` | An earlier handshake for this host failed, so it is not intercepted for **anyone** for a few minutes. Any failed handshake seeds this, not only a CA rejection — the seeding failure logged its own reason. | look for the earlier failure in `proxy.log` |
+| `skip-cached` | An earlier handshake for this host failed, so it is not intercepted for **anyone** for a short window. Any failed handshake seeds this, not only a CA rejection — the seeding failure logged its own reason. The window starts at 30s and lengthens only if failures keep coming; the first client that *does* trust the CA clears it immediately. | find the earlier failure in `proxy.log` and fix that client |
 | `bridge-disabled` | No TLS bridge is configured. | only if you wanted one |
 | `client-hung-up` | The client vanished mid-handshake. Often a cancelled request; not evidence about trust, which is why it carries no advice. | usually no |
 | `handshake-failed` | Some other handshake failure — a version, cipher or ALPN mismatch, or Cortex failing to mint a certificate. | check `error=` in the log |


### PR DESCRIPTION
> **#929 has merged**, so this is now a single commit against `main` — the stacked-on-#929
> preamble that used to be here no longer applies and has been removed.

## Summary

The TLS-bridge skip set is keyed by **host**. When a client rejects our forged leaf we
remember the host so that client's retry can tunnel — but the memory applies to **every**
client of that host.

So one agent holding a stale CA suppressed interception for a correctly-configured one.
Measured on a laptop:

```
4 rejections over 100 minutes, 1 bridged request in between
```

~99% of the visibility on that host lost to a client nobody cared about, because each
expiry was won by the stale agent again.

## Why not key it per client

No durable client identity is available:

| Candidate | Why not |
|---|---|
| source IP | all loopback |
| source port | changes every connection |
| peer PID | no portable API over TCP (`SO_PEERCRED` is AF_UNIX-only); needs `/proc` or libproc scanning per CONNECT |
| ClientHello fingerprint | the clients needing distinction are **the same binary** |

And the skip is forced, not a wart: by the time the client rejects us we have already sent
ServerHello and Certificate, so that connection cannot be un-forged and tunnelled. Some
memory of the failure is structurally required.

## Two changes

**Success now clears the entry.** A completed forged handshake proves a client here trusts
the CA, which disproves the entry outright. The set previously had **no success signal at
all** — it only added entries and waited them out, so a demonstrably-trusting client
taught it nothing. Clearing means the healthy client restores interception itself, and
restarting a stale agent brings observability back immediately rather than after a wait.

**The window starts at 30s and doubles to the old ten minutes.** That separates the two
situations without needing to tell clients apart:

| Situation | Behaviour |
|---|---|
| mixed clients | a success keeps the counter at zero, so windows stay near the base |
| genuinely pinned host | nothing succeeds, it escalates to the cap, identical to today |

A fixed short window would have regressed that second case badly — breaking such a
client's handshake every 30s forever — which is why the escalation exists rather than just
a smaller constant.

## The tradeoff

Escalation is **rejection-only** (added in review): a hang-up, a cipher mismatch, or our
own minter failing still seeds a base-window skip — the connection is dead post-forge
either way — but never lengthens it, so a client that merely cancels requests cannot walk
the host to the ceiling.

The cost falls on the **misconfigured** client: its forged handshake now fails once per
window rather than once per ten minutes. That is the right way round, and after #929 it
gets a warning naming itself and the CA rather than silence.

**30s is a judgement call I made rather than one I was given.** It is a single constant
(`skipBackoffBase`), and no test asserting the shape depends on its value — moving it to
60s or 120s is a one-line change if you'd rather be gentler.

## Verification

Both mechanisms mutation-verified:

```
delete the Succeed call     -> "a successful bridge did not clear the skip; the healthy
                               client stays blind until a window it did not cause elapses"
flatten backoff to a const  -> "failure 3: window 30s did not grow past 30s"
```

New tests: success clears; backoff escalates and is capped (including past the shift
range, so no overflow to a negative window); success resets the count; an expired window
restarts rather than continuing to climb; plus two integration tests driving real TLS —
a rejecting client trips the skip and a trusting client clears it, and repeated rejection
escalates.

`go vet` and all suites clean across authlib, abctl, authbridge-proxy and
authbridge-envoy; `gofmt` clean on every file touched.

Also updated the comment in `decision.go` that already named this defect — *"interception
was intermittent and its absence silent"* — now that #929 addresses the silence and this
bounds the intermittency.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when clients have different certificate trust settings.
  * Healthy clients can now restore normal traffic interception after a temporary skip.
  * Temporary failures no longer trigger unnecessarily long skip periods.
  * Repeated certificate rejections use progressively longer backoff periods, capped at 10 minutes.

* **Documentation**
  * Updated tunnel troubleshooting guidance to reflect adaptive skip timing and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->