### PR TITLE
test: :white_check_mark: Parity tests

### DIFF
--- a/authbridge/authlib/listener/parity/drivers_test.go
+++ b/authbridge/authlib/listener/parity/drivers_test.go
@@ -1,0 +1,393 @@
+package parity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"testing"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/extproc"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/forwardproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/listener/reverseproxy"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+	"github.com/rossoctl/cortex/authbridge/authlib/session"
+)
+
+// fixture describes one parity scenario. Direction selects the listener
+// pair to compare — Inbound (extproc + reverseproxy) or Outbound
+// (extproc + forwardproxy). Entries flow through plugins.BuildWithDeps
+// so Requires / RequiresLater / RequiresAny fire at build time.
+type fixture struct {
+	name      string
+	direction pipeline.Direction
+	entries   []config.PluginEntry
+	method    string
+	path      string
+	reqBody   []byte
+
+	// upstreamStatus / upstreamBody are what the httptest backend serves
+	// on the proxy path, and what the parity harness synthesizes into the
+	// extproc ResponseHeaders/ResponseBody messages. Zero status skips
+	// the response phase entirely (deny-at-request scenarios).
+	upstreamStatus int
+	upstreamBody   []byte
+}
+
+// buildSpyPipeline constructs the pipeline every driver runs against,
+// routing through plugins.BuildWithDeps so the RequiresLater / Requires
+// gate fires at construction time on every listener path.
+//
+// Returned error is the build error verbatim so parity assertions on the
+// negative case ("both listeners refuse this pipeline the same way")
+// can compare error strings across drivers.
+func buildSpyPipeline(entries []config.PluginEntry) (*pipeline.Pipeline, error) {
+	return plugins.BuildWithDeps(entries, plugins.Deps{})
+}
+
+// spyEntry builds a config.PluginEntry for spyPluginA/B with the given
+// knobs. Marshals spyConfig once so fixture literals stay compact.
+func spyEntry(name string, cfg spyConfig) config.PluginEntry {
+	raw, _ := json.Marshal(cfg)
+	return config.PluginEntry{Name: name, Config: raw}
+}
+
+// observation is the parity-comparable snapshot of what each listener
+// wrote to the session store. Includes only fields the framework
+// promises stay stable across listeners; Host casing, timestamps, and
+// RequestID are omitted since each listener sets them independently.
+type observation struct {
+	Phase       string
+	StatusCode  int
+	Invocations []invocationSummary
+	PluginKeys  []string
+	// PluginEventJSON pins the raw JSON per plugin key so a snapshot
+	// difference between listeners surfaces as a value diff.
+	PluginEventJSON map[string]string
+}
+
+type invocationSummary struct {
+	Plugin  string
+	Action  string
+	Reason  string
+	Details map[string]string
+}
+
+// observe returns the first event matching (direction, phase) in the
+// DefaultSessionID bucket, folded into the parity-comparable shape.
+// Returns nil when the bucket is empty or the phase is absent.
+func observe(t *testing.T, store *session.Store, wantDir pipeline.Direction, wantPhase pipeline.SessionPhase) *observation {
+	t.Helper()
+	v := store.View(session.DefaultSessionID)
+	if v == nil || len(v.Events) == 0 {
+		return nil
+	}
+	var ev *pipeline.SessionEvent
+	for i := range v.Events {
+		if v.Events[i].Phase == wantPhase && v.Events[i].Direction == wantDir {
+			ev = &v.Events[i]
+			break
+		}
+	}
+	if ev == nil {
+		return nil
+	}
+
+	obs := &observation{
+		Phase:           ev.Phase.String(),
+		StatusCode:      ev.StatusCode,
+		PluginEventJSON: map[string]string{},
+	}
+	if ev.Invocations != nil {
+		invs := ev.Invocations.Inbound
+		if wantDir == pipeline.Outbound {
+			invs = ev.Invocations.Outbound
+		}
+		for _, inv := range invs {
+			obs.Invocations = append(obs.Invocations, invocationSummary{
+				Plugin:  inv.Plugin,
+				Action:  string(inv.Action),
+				Reason:  inv.Reason,
+				Details: inv.Details,
+			})
+		}
+	}
+	for k, raw := range ev.Plugins {
+		obs.PluginKeys = append(obs.PluginKeys, k)
+		obs.PluginEventJSON[k] = string(raw)
+	}
+	sort.Strings(obs.PluginKeys)
+	return obs
+}
+
+// --- extproc driver ------------------------------------------------------
+
+// mockStream is a minimal ExternalProcessor_ProcessServer that pre-seeds
+// requests and captures responses. Same shape as the mockStream in
+// extproc/server_test.go:29; copied because that file is _test.go.
+//
+// TODO(parity): promote to plugintesting/ or listener/testutil/ once a
+// third caller appears, per the shared-testing-utils audit follow-up.
+type mockStream struct {
+	extprocv3.ExternalProcessor_ProcessServer
+	ctx       context.Context
+	requests  []*extprocv3.ProcessingRequest
+	responses []*extprocv3.ProcessingResponse
+	recvIdx   int
+}
+
+func (m *mockStream) Context() context.Context { return m.ctx }
+func (m *mockStream) Send(resp *extprocv3.ProcessingResponse) error {
+	m.responses = append(m.responses, resp)
+	return nil
+}
+func (m *mockStream) Recv() (*extprocv3.ProcessingRequest, error) {
+	if m.recvIdx >= len(m.requests) {
+		return nil, fmt.Errorf("EOF")
+	}
+	req := m.requests[m.recvIdx]
+	m.recvIdx++
+	return req, nil
+}
+func (m *mockStream) SetHeader(metadata.MD) error  { return nil }
+func (m *mockStream) SendHeader(metadata.MD) error { return nil }
+func (m *mockStream) SetTrailer(metadata.MD)       {}
+func (m *mockStream) SendMsg(any) error            { return nil }
+func (m *mockStream) RecvMsg(any) error            { return nil }
+
+func makeHeaders(kvs ...string) *corev3.HeaderMap {
+	hm := &corev3.HeaderMap{}
+	for i := 0; i < len(kvs); i += 2 {
+		hm.Headers = append(hm.Headers, &corev3.HeaderValue{
+			Key:      kvs[i],
+			RawValue: []byte(kvs[i+1]),
+		})
+	}
+	return hm
+}
+
+// runExtproc drives the fixture through the extproc listener in-process
+// (no gRPC, no Envoy binary — Server.Process is called directly).
+// Puts the spy pipeline on the slot matching fixture.direction; the
+// other slot gets an empty pipeline.
+func runExtproc(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *observation {
+	t.Helper()
+
+	spyPipe, err := buildSpyPipeline(f.entries)
+	if err != nil {
+		t.Fatalf("extproc: BuildWithDeps: %v", err)
+	}
+	emptyPipe, err := plugins.BuildWithDeps(nil, plugins.Deps{})
+	if err != nil {
+		t.Fatalf("extproc: BuildWithDeps(nil): %v", err)
+	}
+
+	store := session.New(0, 100, 100)
+	t.Cleanup(func() { store.Close() })
+
+	srv := &extproc.Server{Sessions: store}
+	dirHeader := "inbound"
+	if f.direction == pipeline.Outbound {
+		srv.OutboundPipeline = pipeline.NewHolder(spyPipe)
+		srv.InboundPipeline = pipeline.NewHolder(emptyPipe)
+		dirHeader = "outbound"
+	} else {
+		srv.InboundPipeline = pipeline.NewHolder(spyPipe)
+		srv.OutboundPipeline = pipeline.NewHolder(emptyPipe)
+	}
+
+	reqs := []*extprocv3.ProcessingRequest{
+		{
+			Request: &extprocv3.ProcessingRequest_RequestHeaders{
+				RequestHeaders: &extprocv3.HttpHeaders{
+					Headers: makeHeaders(
+						"x-authbridge-direction", dirHeader,
+						":method", f.method,
+						":path", f.path,
+						":authority", "parity.local",
+						"content-length", fmt.Sprintf("%d", len(f.reqBody)),
+					),
+				},
+			},
+		},
+	}
+	// Send RequestBody only when the plugin declared ReadsBody, matching
+	// what Envoy does at the ext_proc filter (server.go:113).
+	if len(f.reqBody) > 0 && spyPipe.NeedsBody() {
+		reqs = append(reqs, &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_RequestBody{
+				RequestBody: &extprocv3.HttpBody{Body: f.reqBody, EndOfStream: true},
+			},
+		})
+	}
+	if f.upstreamStatus > 0 {
+		reqs = append(reqs, &extprocv3.ProcessingRequest{
+			Request: &extprocv3.ProcessingRequest_ResponseHeaders{
+				ResponseHeaders: &extprocv3.HttpHeaders{
+					Headers: makeHeaders(
+						":status", fmt.Sprintf("%d", f.upstreamStatus),
+						"content-type", "application/json",
+						"content-length", fmt.Sprintf("%d", len(f.upstreamBody)),
+					),
+				},
+			},
+		})
+		// Send ResponseBody only when the plugin asked for body buffering.
+		// The header-only path runs RunResponse and records on its own.
+		if spyPipe.NeedsBody() {
+			reqs = append(reqs, &extprocv3.ProcessingRequest{
+				Request: &extprocv3.ProcessingRequest_ResponseBody{
+					ResponseBody: &extprocv3.HttpBody{Body: f.upstreamBody, EndOfStream: true},
+				},
+			})
+		}
+	}
+
+	stream := &mockStream{ctx: context.Background(), requests: reqs}
+	_ = srv.Process(stream)
+
+	return observe(t, store, f.direction, wantPhase)
+}
+
+// --- reverseproxy driver -------------------------------------------------
+
+// runReverseProxy drives the fixture through the reverse-proxy listener
+// against an httptest.Server upstream. The upstream stub fails loudly
+// when a deny fixture reaches it, guarding OnRequest deny correctness.
+func runReverseProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *observation {
+	t.Helper()
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit = true
+		if f.upstreamStatus == 0 {
+			t.Errorf("reverseproxy: upstream unexpectedly reached on deny fixture %q", f.name)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.upstreamStatus)
+		_, _ = w.Write(f.upstreamBody)
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, err := buildSpyPipeline(f.entries)
+	if err != nil {
+		t.Fatalf("reverseproxy: BuildWithDeps: %v", err)
+	}
+
+	store := session.New(0, 100, 100)
+	t.Cleanup(func() { store.Close() })
+
+	srv, err := reverseproxy.NewServer(pipeline.NewHolder(p), store, upstream.URL, nil)
+	if err != nil {
+		t.Fatalf("reverseproxy: NewServer: %v", err)
+	}
+	proxy := httptest.NewServer(srv.Handler())
+	t.Cleanup(proxy.Close)
+
+	var bodyReader io.Reader
+	if len(f.reqBody) > 0 {
+		bodyReader = bytes.NewReader(f.reqBody)
+	}
+	req, err := http.NewRequest(f.method, proxy.URL+f.path, bodyReader)
+	if err != nil {
+		t.Fatalf("reverseproxy: NewRequest: %v", err)
+	}
+	if len(f.reqBody) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("reverseproxy: Do: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Deny-fixture sanity: the upstream stub must stay untouched.
+	if f.upstreamStatus == 0 && upstreamHit {
+		t.Errorf("reverseproxy: fixture %q asked for deny but upstream was reached", f.name)
+	}
+
+	return observe(t, store, pipeline.Inbound, wantPhase)
+}
+
+// --- forwardproxy driver -------------------------------------------------
+
+// runForwardProxy drives the fixture through the forward-proxy listener
+// via a proxy-configured http.Client. Outbound-only; this is the
+// listener agents egress through in the laptop (proxy-sidecar) shape.
+func runForwardProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *observation {
+	t.Helper()
+
+	var upstreamHit bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit = true
+		if f.upstreamStatus == 0 {
+			t.Errorf("forwardproxy: upstream unexpectedly reached on deny fixture %q", f.name)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.upstreamStatus)
+		_, _ = w.Write(f.upstreamBody)
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, err := buildSpyPipeline(f.entries)
+	if err != nil {
+		t.Fatalf("forwardproxy: BuildWithDeps: %v", err)
+	}
+
+	store := session.New(0, 100, 100)
+	t.Cleanup(func() { store.Close() })
+
+	srv, err := forwardproxy.NewServer(pipeline.NewHolder(p), store, nil)
+	if err != nil {
+		t.Fatalf("forwardproxy: NewServer: %v", err)
+	}
+	proxy := httptest.NewServer(srv.Handler())
+	t.Cleanup(proxy.Close)
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("forwardproxy: parse proxy URL: %v", err)
+	}
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+
+	var bodyReader io.Reader
+	if len(f.reqBody) > 0 {
+		bodyReader = bytes.NewReader(f.reqBody)
+	}
+	req, err := http.NewRequest(f.method, upstream.URL+f.path, bodyReader)
+	if err != nil {
+		t.Fatalf("forwardproxy: NewRequest: %v", err)
+	}
+	if len(f.reqBody) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("forwardproxy: Do: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if f.upstreamStatus == 0 && upstreamHit {
+		t.Errorf("forwardproxy: fixture %q asked for deny but upstream was reached", f.name)
+	}
+
+	return observe(t, store, pipeline.Outbound, wantPhase)
+}
+

--- a/authbridge/authlib/listener/parity/drivers_test.go
+++ b/authbridge/authlib/listener/parity/drivers_test.go
@@ -84,21 +84,29 @@ type invocationSummary struct {
 	Details map[string]string
 }
 
-// observe returns the first event matching (direction, phase) in the
+// observe returns the sole event matching (direction, phase) in the
 // DefaultSessionID bucket, folded into the parity-comparable shape.
-// Returns nil when the bucket is empty or the phase is absent.
+// Returns nil when the bucket is empty or the phase is absent. Fails
+// on more than one match so duplicate-record drift surfaces here
+// instead of passing through as equal counts on both listeners.
 func observe(t *testing.T, store *session.Store, wantDir pipeline.Direction, wantPhase pipeline.SessionPhase) *observation {
 	t.Helper()
 	v := store.View(session.DefaultSessionID)
 	if v == nil || len(v.Events) == 0 {
 		return nil
 	}
-	var ev *pipeline.SessionEvent
+	var (
+		ev      *pipeline.SessionEvent
+		matches int
+	)
 	for i := range v.Events {
 		if v.Events[i].Phase == wantPhase && v.Events[i].Direction == wantDir {
 			ev = &v.Events[i]
-			break
+			matches++
 		}
+	}
+	if matches > 1 {
+		t.Fatalf("observe: %d events matched (direction=%v phase=%v); listener must record exactly once", matches, wantDir, wantPhase)
 	}
 	if ev == nil {
 		return nil
@@ -301,7 +309,7 @@ func runReverseProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *
 	if len(f.reqBody) > 0 {
 		bodyReader = bytes.NewReader(f.reqBody)
 	}
-	req, err := http.NewRequest(f.method, proxy.URL+f.path, bodyReader)
+	req, err := http.NewRequestWithContext(context.Background(), f.method, proxy.URL+f.path, bodyReader)
 	if err != nil {
 		t.Fatalf("reverseproxy: NewRequest: %v", err)
 	}
@@ -313,7 +321,9 @@ func runReverseProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *
 		t.Fatalf("reverseproxy: Do: %v", err)
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("reverseproxy: Body.Close: %v", err)
+	}
 
 	// Deny-fixture sanity: the upstream stub must stay untouched.
 	if f.upstreamStatus == 0 && upstreamHit {
@@ -370,7 +380,7 @@ func runForwardProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *
 	if len(f.reqBody) > 0 {
 		bodyReader = bytes.NewReader(f.reqBody)
 	}
-	req, err := http.NewRequest(f.method, upstream.URL+f.path, bodyReader)
+	req, err := http.NewRequestWithContext(context.Background(), f.method, upstream.URL+f.path, bodyReader)
 	if err != nil {
 		t.Fatalf("forwardproxy: NewRequest: %v", err)
 	}
@@ -382,7 +392,9 @@ func runForwardProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *
 		t.Fatalf("forwardproxy: Do: %v", err)
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("forwardproxy: Body.Close: %v", err)
+	}
 
 	if f.upstreamStatus == 0 && upstreamHit {
 		t.Errorf("forwardproxy: fixture %q asked for deny but upstream was reached", f.name)

--- a/authbridge/authlib/listener/parity/drivers_test.go
+++ b/authbridge/authlib/listener/parity/drivers_test.go
@@ -45,13 +45,8 @@ type fixture struct {
 	upstreamBody   []byte
 }
 
-// buildSpyPipeline constructs the pipeline every driver runs against,
-// routing through plugins.BuildWithDeps so the RequiresLater / Requires
-// gate fires at construction time on every listener path.
-//
-// Returned error is the build error verbatim so parity assertions on the
-// negative case ("both listeners refuse this pipeline the same way")
-// can compare error strings across drivers.
+// buildSpyPipeline routes construction through plugins.BuildWithDeps
+// so Requires / RequiresLater fire at build time on every driver.
 func buildSpyPipeline(entries []config.PluginEntry) (*pipeline.Pipeline, error) {
 	return plugins.BuildWithDeps(entries, plugins.Deps{})
 }
@@ -63,18 +58,27 @@ func spyEntry(name string, cfg spyConfig) config.PluginEntry {
 	return config.PluginEntry{Name: name, Config: raw}
 }
 
-// observation is the parity-comparable snapshot of what each listener
-// wrote to the session store. Includes only fields the framework
-// promises stay stable across listeners; Host casing, timestamps, and
-// RequestID are omitted since each listener sets them independently.
+// observation is the parity-comparable snapshot of a listener's session
+// event. Covers the operator-facing wire surface; per-listener locals
+// (Host casing, timestamps, RequestID, Duration, TLS, Identity) are
+// excluded — expanding coverage there is a follow-up fixture pass.
 type observation struct {
 	Phase       string
 	StatusCode  int
+	Error       *errorSummary
 	Invocations []invocationSummary
 	PluginKeys  []string
 	// PluginEventJSON pins the raw JSON per plugin key so a snapshot
 	// difference between listeners surfaces as a value diff.
 	PluginEventJSON map[string]string
+}
+
+// errorSummary mirrors pipeline.EventError so listener drift in the
+// deny reason fails parity instead of remaining invisible.
+type errorSummary struct {
+	Kind    string
+	Code    string
+	Message string
 }
 
 type invocationSummary struct {
@@ -87,8 +91,7 @@ type invocationSummary struct {
 // observe returns the sole event matching (direction, phase) in the
 // DefaultSessionID bucket, folded into the parity-comparable shape.
 // Returns nil when the bucket is empty or the phase is absent. Fails
-// on more than one match so duplicate-record drift surfaces here
-// instead of passing through as equal counts on both listeners.
+// on more than one match so duplicate-record drift surfaces here.
 func observe(t *testing.T, store *session.Store, wantDir pipeline.Direction, wantPhase pipeline.SessionPhase) *observation {
 	t.Helper()
 	v := store.View(session.DefaultSessionID)
@@ -116,6 +119,9 @@ func observe(t *testing.T, store *session.Store, wantDir pipeline.Direction, wan
 		Phase:           ev.Phase.String(),
 		StatusCode:      ev.StatusCode,
 		PluginEventJSON: map[string]string{},
+	}
+	if ev.Error != nil {
+		obs.Error = &errorSummary{Kind: ev.Error.Kind, Code: ev.Error.Code, Message: ev.Error.Message}
 	}
 	if ev.Invocations != nil {
 		invs := ev.Invocations.Inbound
@@ -162,7 +168,7 @@ func (m *mockStream) Send(resp *extprocv3.ProcessingResponse) error {
 }
 func (m *mockStream) Recv() (*extprocv3.ProcessingRequest, error) {
 	if m.recvIdx >= len(m.requests) {
-		return nil, fmt.Errorf("EOF")
+		return nil, io.EOF
 	}
 	req := m.requests[m.recvIdx]
 	m.recvIdx++
@@ -265,6 +271,19 @@ func runExtproc(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *obser
 	stream := &mockStream{ctx: context.Background(), requests: reqs}
 	_ = srv.Process(stream)
 
+	// Wire guards matching the HTTP drivers' upstreamHit check: consume
+	// every message, and reject fixtures must send an ImmediateResponse.
+	if stream.recvIdx != len(reqs) {
+		t.Errorf("extproc: consumed %d of %d messages; listener bailed", stream.recvIdx, len(reqs))
+	}
+	if f.upstreamStatus == 0 {
+		if n := len(stream.responses); n == 0 {
+			t.Errorf("extproc: fixture %q asked for deny but no response was sent", f.name)
+		} else if last := stream.responses[n-1]; last.GetImmediateResponse() == nil {
+			t.Errorf("extproc: fixture %q asked for deny but last response was %T, want ImmediateResponse", f.name, last.Response)
+		}
+	}
+
 	return observe(t, store, f.direction, wantPhase)
 }
 
@@ -275,6 +294,9 @@ func runExtproc(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *obser
 // when a deny fixture reaches it, guarding OnRequest deny correctness.
 func runReverseProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *observation {
 	t.Helper()
+	if f.direction != pipeline.Inbound {
+		t.Fatalf("reverseproxy handles Inbound only, got fixture %q direction=%v", f.name, f.direction)
+	}
 
 	var upstreamHit bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -340,6 +362,9 @@ func runReverseProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *
 // listener agents egress through in the laptop (proxy-sidecar) shape.
 func runForwardProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *observation {
 	t.Helper()
+	if f.direction != pipeline.Outbound {
+		t.Fatalf("forwardproxy handles Outbound only, got fixture %q direction=%v", f.name, f.direction)
+	}
 
 	var upstreamHit bool
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -403,3 +428,41 @@ func runForwardProxy(t *testing.T, f fixture, wantPhase pipeline.SessionPhase) *
 	return observe(t, store, pipeline.Outbound, wantPhase)
 }
 
+// --- construction-only helpers -------------------------------------------
+
+// tryBuild* replay each driver's construction (pipeline + listener
+// NewServer / Server init) and return the first error.
+
+func tryBuildExtproc(entries []config.PluginEntry) error {
+	spyPipe, err := buildSpyPipeline(entries)
+	if err != nil {
+		return err
+	}
+	emptyPipe, err := plugins.BuildWithDeps(nil, plugins.Deps{})
+	if err != nil {
+		return err
+	}
+	_ = &extproc.Server{
+		InboundPipeline:  pipeline.NewHolder(spyPipe),
+		OutboundPipeline: pipeline.NewHolder(emptyPipe),
+	}
+	return nil
+}
+
+func tryBuildReverseProxy(entries []config.PluginEntry) error {
+	p, err := buildSpyPipeline(entries)
+	if err != nil {
+		return err
+	}
+	_, err = reverseproxy.NewServer(pipeline.NewHolder(p), nil, "http://parity.local", nil)
+	return err
+}
+
+func tryBuildForwardProxy(entries []config.PluginEntry) error {
+	p, err := buildSpyPipeline(entries)
+	if err != nil {
+		return err
+	}
+	_, err = forwardproxy.NewServer(pipeline.NewHolder(p), nil, nil)
+	return err
+}

--- a/authbridge/authlib/listener/parity/parity_test.go
+++ b/authbridge/authlib/listener/parity/parity_test.go
@@ -1,0 +1,242 @@
+// Package parity runs the same fixture through both the extproc and
+// HTTP-proxy listeners and asserts the resulting session event is
+// identical, catching silent drift between the two deployment shapes.
+package parity
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/config"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+)
+
+// listenerRun pairs a driver with a name so failure messages point at
+// the listener that drifted.
+type listenerRun struct {
+	name string
+	run  func(*testing.T, fixture, pipeline.SessionPhase) *observation
+}
+
+var inboundListeners = []listenerRun{
+	{name: "extproc", run: runExtproc},
+	{name: "reverseproxy", run: runReverseProxy},
+}
+
+var outboundListeners = []listenerRun{
+	{name: "extproc", run: runExtproc},
+	{name: "forwardproxy", run: runForwardProxy},
+}
+
+// TestParity_DenyOnRequest: pctx.Record before Reject must produce the
+// same phase:"denied" event on both listeners.
+func TestParity_DenyOnRequest(t *testing.T) {
+	f := fixture{
+		name:      "deny-on-request",
+		direction: pipeline.Inbound,
+		entries: []config.PluginEntry{spyEntry(spyPluginA, spyConfig{
+			DenyOnRequest: true,
+			DenyStatus:    429,
+			DenyReason:    "spy.denied",
+			DenyDetails:   map[string]string{"cutoff_reason": "quota"},
+		})},
+		method: "GET",
+		path:   "/parity/deny",
+	}
+	assertParity(t, f, pipeline.SessionDenied, inboundListeners)
+}
+
+// TestParity_ResponseEventEmission: an OnResponse emit to Extensions.
+// Custom must surface identically on SessionEvent.Plugins from both
+// listeners.
+func TestParity_ResponseEventEmission(t *testing.T) {
+	f := fixture{
+		name:      "priced-response-headers-only",
+		direction: pipeline.Inbound,
+		entries: []config.PluginEntry{spyEntry(spyPluginA, spyConfig{
+			EmitOnResponse: true,
+			ResponseEvent:  &spyEvent{Marker: "priced", Count: 3},
+		})},
+		method:         "GET",
+		path:           "/parity/priced",
+		upstreamStatus: 200,
+		upstreamBody:   []byte(`{"reply":"ok"}`),
+	}
+	assertParity(t, f, pipeline.SessionResponse, inboundListeners)
+}
+
+// TestParity_OutboundDenyOnRequest: same deny-on-request contract on the
+// outbound side — extproc and forwardproxy must record the same
+// phase:"denied" event when a plugin rejects at OnRequest.
+func TestParity_OutboundDenyOnRequest(t *testing.T) {
+	f := fixture{
+		name:      "outbound-deny-on-request",
+		direction: pipeline.Outbound,
+		entries: []config.PluginEntry{spyEntry(spyPluginA, spyConfig{
+			DenyOnRequest: true,
+			DenyStatus:    403,
+			DenyReason:    "spy.blocked",
+			DenyDetails:   map[string]string{"cutoff_reason": "egress-policy"},
+		})},
+		method: "GET",
+		path:   "/parity/egress",
+	}
+	assertParity(t, f, pipeline.SessionDenied, outboundListeners)
+}
+
+// TestParity_RequiresLaterOrderingRejected: a RequiresLater violation
+// must fail at plugins.BuildWithDeps, the single construction call
+// every listener consumes. This locks the wrong-order refusal for
+// every listener path at once.
+//
+// Wrong order: the RequiresLater dependency at a LOWER index than
+// the plugin that names it. Contract says HIGHER.
+//
+// Complements the unit tests in plugins/deps_test.go, which cover the
+// gate itself; this test asserts the parity property — that every
+// listener funnels through the same construction call — which is a
+// listener-package concern and belongs here.
+func TestParity_RequiresLaterOrderingRejected(t *testing.T) {
+	entriesWrong := []config.PluginEntry{
+		spyEntry(spyPluginB, spyConfig{}),
+		spyEntry(spyPluginA, spyConfig{RequiresLater: []string{spyPluginB}}),
+	}
+	if _, err := buildSpyPipeline(entriesWrong); err == nil {
+		t.Fatal("BuildWithDeps accepted a wrong-order pipeline; RequiresLater is not enforced")
+	}
+	// Well-ordered: dependency at HIGHER index than the plugin that names it.
+	entriesOK := []config.PluginEntry{
+		spyEntry(spyPluginA, spyConfig{RequiresLater: []string{spyPluginB}}),
+		spyEntry(spyPluginB, spyConfig{}),
+	}
+	if _, err := buildSpyPipeline(entriesOK); err != nil {
+		t.Fatalf("BuildWithDeps rejected a well-ordered pipeline: %v", err)
+	}
+}
+
+// assertParity runs the fixture through every listener and fails on
+// any observation mismatch, naming both listeners in the diff. A
+// listener that produced no event when others did is itself parity
+// drift ("presence" is the first field consumers compare), so that
+// case is reported at the parent-test level even when a subtest fails.
+func assertParity(t *testing.T, f fixture, wantPhase pipeline.SessionPhase, listeners []listenerRun) {
+	t.Helper()
+
+	type namedObs struct {
+		listener string
+		observed *observation
+	}
+	got := make([]namedObs, 0, len(listeners))
+	for _, l := range listeners {
+		t.Run(f.name+"/"+l.name, func(t *testing.T) {
+			obs := l.run(t, f, wantPhase)
+			if obs == nil {
+				t.Fatalf("listener %q produced no matching event for fixture %q (phase=%v)", l.name, f.name, wantPhase)
+			}
+			got = append(got, namedObs{listener: l.name, observed: obs})
+		})
+	}
+
+	// Partial-presence drift: some listeners produced an event, others
+	// didn't. Report at the parent level so a failing subtest doesn't
+	// mask the parity gap.
+	if len(got) > 0 && len(got) < len(listeners) {
+		present := make([]string, 0, len(got))
+		for _, g := range got {
+			present = append(present, g.listener)
+		}
+		t.Errorf("parity presence drift on fixture %q: only these listeners produced an event: %v", f.name, present)
+	}
+	if len(got) < 2 {
+		return // fewer than two observations to compare against each other.
+	}
+
+	// Pairwise compare against the first listener. All observations must
+	// agree; a diff names both sides so operators see which drifted.
+	base := got[0]
+	for _, other := range got[1:] {
+		if diff := observationDiff(base.observed, other.observed); diff != "" {
+			t.Errorf("parity drift on fixture %q between %s and %s:\n%s",
+				f.name, base.listener, other.listener, diff)
+		}
+	}
+}
+
+// observationDiff returns the first field-level disagreement, or ""
+// when both agree on every parity-comparable field.
+func observationDiff(a, b *observation) string {
+	if a.Phase != b.Phase {
+		return "Phase: " + a.Phase + " vs " + b.Phase
+	}
+	if a.StatusCode != b.StatusCode {
+		return fmt.Sprintf("StatusCode: %d vs %d", a.StatusCode, b.StatusCode)
+	}
+	if !invocationsEqual(a.Invocations, b.Invocations) {
+		return "Invocations differ:\n  a=" + jsonPretty(a.Invocations) + "\n  b=" + jsonPretty(b.Invocations)
+	}
+	if !reflect.DeepEqual(a.PluginKeys, b.PluginKeys) {
+		return "PluginKeys: " + jsonPretty(a.PluginKeys) + " vs " + jsonPretty(b.PluginKeys)
+	}
+	// Compare per-plugin JSON payloads structurally to tolerate
+	// whitespace and map-order differences between listeners.
+	keys := make([]string, 0, len(a.PluginEventJSON))
+	for k := range a.PluginEventJSON {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if !jsonEqual(a.PluginEventJSON[k], b.PluginEventJSON[k]) {
+			return "PluginEventJSON[" + k + "]: " + a.PluginEventJSON[k] + " vs " + b.PluginEventJSON[k]
+		}
+	}
+	return ""
+}
+
+// invocationsEqual compares two slices as sets so multi-plugin
+// fixtures tolerate independent-gate ordering.
+func invocationsEqual(a, b []invocationSummary) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	byKey := func(s []invocationSummary) {
+		sort.Slice(s, func(i, j int) bool {
+			if s[i].Plugin != s[j].Plugin {
+				return s[i].Plugin < s[j].Plugin
+			}
+			if s[i].Action != s[j].Action {
+				return s[i].Action < s[j].Action
+			}
+			return s[i].Reason < s[j].Reason
+		})
+	}
+	as := append([]invocationSummary(nil), a...)
+	bs := append([]invocationSummary(nil), b...)
+	byKey(as)
+	byKey(bs)
+	return reflect.DeepEqual(as, bs)
+}
+
+func jsonPretty(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "<unmarshalable>"
+	}
+	return string(b)
+}
+
+// jsonEqual compares two raw JSON strings structurally so map-order
+// and whitespace differences between listeners register as equal.
+func jsonEqual(a, b string) bool {
+	var av, bv any
+	if err := json.Unmarshal([]byte(a), &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(b), &bv); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}
+

--- a/authbridge/authlib/listener/parity/parity_test.go
+++ b/authbridge/authlib/listener/parity/parity_test.go
@@ -87,43 +87,49 @@ func TestParity_OutboundDenyOnRequest(t *testing.T) {
 	assertParity(t, f, pipeline.SessionDenied, outboundListeners)
 }
 
-// TestParity_RequiresLaterOrderingRejected: a RequiresLater violation
-// must fail at plugins.BuildWithDeps, the single construction call
-// every listener consumes. This locks the wrong-order refusal for
-// every listener path at once.
-//
-// Wrong order: the RequiresLater dependency at a LOWER index than
-// the plugin that names it. Contract says HIGHER.
-//
-// Complements the unit tests in plugins/deps_test.go, which cover the
-// gate itself; this test asserts the parity property — that every
-// listener funnels through the same construction call — which is a
-// listener-package concern and belongs here.
+// TestParity_RequiresLaterOrderingRejected: each listener's
+// construction must reject a RequiresLater violation (dependency at a
+// LOWER index than the plugin naming it; contract requires HIGHER).
 func TestParity_RequiresLaterOrderingRejected(t *testing.T) {
 	entriesWrong := []config.PluginEntry{
 		spyEntry(spyPluginB, spyConfig{}),
 		spyEntry(spyPluginA, spyConfig{RequiresLater: []string{spyPluginB}}),
 	}
-	if _, err := buildSpyPipeline(entriesWrong); err == nil {
-		t.Fatal("BuildWithDeps accepted a wrong-order pipeline; RequiresLater is not enforced")
-	}
-	// Well-ordered: dependency at HIGHER index than the plugin that names it.
 	entriesOK := []config.PluginEntry{
 		spyEntry(spyPluginA, spyConfig{RequiresLater: []string{spyPluginB}}),
 		spyEntry(spyPluginB, spyConfig{}),
 	}
-	if _, err := buildSpyPipeline(entriesOK); err != nil {
-		t.Fatalf("BuildWithDeps rejected a well-ordered pipeline: %v", err)
+
+	builders := []struct {
+		name string
+		fn   func([]config.PluginEntry) error
+	}{
+		{"extproc", tryBuildExtproc},
+		{"reverseproxy", tryBuildReverseProxy},
+		{"forwardproxy", tryBuildForwardProxy},
+	}
+	for _, b := range builders {
+		t.Run(b.name, func(t *testing.T) {
+			if err := b.fn(entriesWrong); err == nil {
+				t.Errorf("%s accepted a wrong-order pipeline; RequiresLater is not enforced", b.name)
+			}
+			if err := b.fn(entriesOK); err != nil {
+				t.Errorf("%s rejected a well-ordered pipeline: %v", b.name, err)
+			}
+		})
 	}
 }
 
 // assertParity runs the fixture through every listener and fails on
-// any observation mismatch, naming both listeners in the diff. A
-// listener that produced no event when others did is itself parity
-// drift ("presence" is the first field consumers compare), so that
-// case is reported at the parent-test level even when a subtest fails.
+// any observation mismatch. Partial presence (one listener records, the
+// others don't) is itself drift and reported at the parent-test level.
 func assertParity(t *testing.T, f fixture, wantPhase pipeline.SessionPhase, listeners []listenerRun) {
 	t.Helper()
+
+	// A single-listener call would pass vacuously with nothing to compare.
+	if len(listeners) < 2 {
+		t.Fatalf("assertParity: fixture %q was given %d listener(s); need at least 2", f.name, len(listeners))
+	}
 
 	type namedObs struct {
 		listener string
@@ -151,7 +157,7 @@ func assertParity(t *testing.T, f fixture, wantPhase pipeline.SessionPhase, list
 		t.Errorf("parity presence drift on fixture %q: only these listeners produced an event: %v", f.name, present)
 	}
 	if len(got) < 2 {
-		return // fewer than two observations to compare against each other.
+		return // one or more legs failed in the subtest; presence drift already reported.
 	}
 
 	// Pairwise compare against the first listener. All observations must
@@ -173,6 +179,9 @@ func observationDiff(a, b *observation) string {
 	}
 	if a.StatusCode != b.StatusCode {
 		return fmt.Sprintf("StatusCode: %d vs %d", a.StatusCode, b.StatusCode)
+	}
+	if !reflect.DeepEqual(a.Error, b.Error) {
+		return "Error: " + jsonPretty(a.Error) + " vs " + jsonPretty(b.Error)
 	}
 	if !invocationsEqual(a.Invocations, b.Invocations) {
 		return "Invocations differ:\n  a=" + jsonPretty(a.Invocations) + "\n  b=" + jsonPretty(b.Invocations)
@@ -239,4 +248,3 @@ func jsonEqual(a, b string) bool {
 	}
 	return reflect.DeepEqual(av, bv)
 }
-

--- a/authbridge/authlib/listener/parity/spy_test.go
+++ b/authbridge/authlib/listener/parity/spy_test.go
@@ -1,0 +1,97 @@
+package parity
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
+)
+
+// spyPlugin is the single fixture-mate for parity tests. Knobs (deny at
+// OnRequest, emit at OnResponse, declare RequiresLater on another spy)
+// arrive via Configure so BuildWithDeps can construct one through the
+// registry like any other plugin.
+type spyPlugin struct {
+	name string
+	cfg  spyConfig
+}
+
+// spyConfig is the wire-shape the registry factory decodes from Configure.
+// Keep JSON tags stable — fixture builders in parity_test.go marshal this.
+type spyConfig struct {
+	DenyOnRequest bool              `json:"deny_on_request"`
+	DenyStatus    int               `json:"deny_status"`
+	DenyReason    string            `json:"deny_reason"`
+	DenyDetails   map[string]string `json:"deny_details"`
+
+	EmitOnResponse bool      `json:"emit_on_response"`
+	ResponseEvent  *spyEvent `json:"response_event"`
+
+	// RequiresLater names peer plugins that must appear at a HIGHER
+	// index in the same pipeline. Populates PluginCapabilities so the
+	// registry's dependency validator can reject wrong-order pipelines.
+	RequiresLater []string `json:"requires_later"`
+}
+
+// spyEvent is the payload emitted at OnResponse. Trivial and JSON-
+// stable so parity assertions compare raw JSON directly.
+type spyEvent struct {
+	Marker string `json:"marker"`
+	Count  int    `json:"count"`
+}
+
+func (s *spyPlugin) Name() string { return s.name }
+
+func (s *spyPlugin) Capabilities() pipeline.PluginCapabilities {
+	return pipeline.PluginCapabilities{RequiresLater: s.cfg.RequiresLater}
+}
+
+func (s *spyPlugin) Configure(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, &s.cfg)
+}
+
+func (s *spyPlugin) OnRequest(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	if !s.cfg.DenyOnRequest {
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+	pctx.Record(pipeline.Invocation{
+		Action:  pipeline.ActionDeny,
+		Reason:  s.cfg.DenyReason,
+		Details: s.cfg.DenyDetails,
+	})
+	return pipeline.DenyStatus(s.cfg.DenyStatus, s.cfg.DenyReason, s.cfg.DenyReason)
+}
+
+func (s *spyPlugin) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
+	if !s.cfg.EmitOnResponse || s.cfg.ResponseEvent == nil {
+		return pipeline.Action{Type: pipeline.Continue}
+	}
+	if pctx.Extensions.Custom == nil {
+		pctx.Extensions.Custom = map[string]any{}
+	}
+	pctx.Extensions.Custom[s.name+pipeline.PluginEventSuffix] = *s.cfg.ResponseEvent
+	return pipeline.Action{Type: pipeline.Continue}
+}
+
+// Compile-time interface checks.
+var (
+	_ pipeline.Plugin       = (*spyPlugin)(nil)
+	_ pipeline.Configurable = (*spyPlugin)(nil)
+)
+
+// Register two spy factories so RequiresLater fixtures can pair two
+// distinct plugins in one pipeline. Names are scoped to avoid clashing
+// with any real plugin registered in the same process.
+const (
+	spyPluginA = "parity-spy-a"
+	spyPluginB = "parity-spy-b"
+)
+
+func init() {
+	plugins.RegisterPlugin(spyPluginA, func() pipeline.Plugin { return &spyPlugin{name: spyPluginA} })
+	plugins.RegisterPlugin(spyPluginB, func() pipeline.Plugin { return &spyPlugin{name: spyPluginB} })
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Adds an integration test package that runs the same fixture through both listener implementations (gRPC ext_proc and HTTP proxies) and asserts they produce identical session events. Catches the silent-drift class of bug where a plugin change tested against one listener quietly misbehaves on the other — the failure mode behind streaming exact-once guards, deny-path recording gaps, and cross-listener plugin-event snapshot inconsistencies. Extends the invariant to construction-layer parity by locking wrong-ordered pipelines with dependency requirements to a single build-refusal contract every listener consumes.

Follow-ups:
- Add fixtures for SSE streaming (buffered vs frame-by-frame divergence), request body mutation, and multi-plugin pipelines — each is one fixture in the same package, without new drivers.
- Per-listener construction validation for `RequiresLater` — needs a listener-framework surface that accepts entries rather than a pre-built pipeline.
-  Extend fixtures with a body-reading spy so parity covers extproc's two-phase body handshake versus the proxies' in-process buffering 

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Expanded parity coverage across extproc, reverse-proxy, and forward-proxy listeners.
- Added scenarios for inbound and outbound request denials, response events, and dependency ordering.
- Added configurable test fixtures for comparing listener behavior and outputs.
- Improved validation of event observations, error details, proxy responses, and message handling.
- Added checks for invalid listener direction and incomplete or inconsistent deny responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->