### PR TITLE
Fix: Remove a dead SkipSet.window method

### DIFF
--- a/authbridge/authlib/tlsbridge/decision.go
+++ b/authbridge/authlib/tlsbridge/decision.go
@@ -342,25 +342,6 @@ func (s *SkipSet) Succeed(host string) {
 	delete(s.m, host)
 }
 
-// window is the time left on a host's skip, or zero when it is not skipped.
-//
-// Unexported: it exists for this package's tests, and the proxy only ever asks Contains.
-// It was briefly exported so a forwardproxy test could assert on backoff, which widened
-// authlib's public API for a test-only need — the assertions that wanted it live here
-// now instead, where the internals already are.
-func (s *SkipSet) window(host string) time.Duration {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	e, ok := s.m[host]
-	if !ok {
-		return 0
-	}
-	if d := time.Until(e.expiry); d > 0 {
-		return d
-	}
-	return 0
-}
-
 func (s *SkipSet) Contains(host string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/authbridge/authlib/tlsbridge/decision_test.go
+++ b/authbridge/authlib/tlsbridge/decision_test.go
@@ -220,6 +220,12 @@ func TestNewDecision_RejectsUnusablePatterns(t *testing.T) {
 }
 
 // window returns the remaining skip window for host, for asserting on backoff.
+//
+// A test helper rather than a method on SkipSet: nothing in the proxy needs to read a
+// window — it only ever asks Contains — so a method would be non-test code that nothing
+// calls. There WAS such a method briefly, left behind when an exported accessor was
+// unexported instead of deleted; it sat dead until review caught it, because no linter
+// here reports unused methods.
 func window(t *testing.T, s *SkipSet, host string) time.Duration {
 	t.Helper()
 	s.mu.RLock()


### PR DESCRIPTION
## Summary

Removes a dead `(*SkipSet).window` method. Caught by review on #932 after it merged, so it
lands here.

When an exported `Window()` accessor was unexported rather than deleted, the method stayed
behind — and the test that had wanted it uses a package-level `window(t, s, host)` helper
that reads `s.m` directly. Two things named `window` doing the same job, one called by
nothing.

Deleted the method rather than pointing the helper at it: nothing in the proxy needs to
read a window — it only ever asks `Contains` — so the method would be non-test code with
no callers. The helper also `t.Fatalf`s on a missing entry, which a plain accessor cannot.

## The more useful finding

This survived a green CI, and it would survive it again:

| Check | Reports unused methods? |
| --- | --- |
| `go vet` | no |
| `staticcheck` / `golangci-lint` / `revive` / `unused` | **not run in this repo** — I grepped the workflows |

`staticcheck` also cannot be run locally against these modules today: it is built against
go1.24 and `authlib` requires go1.26.5, so it refuses to compile the package.

So an unused unexported method is currently invisible to every automated check here. That
is worth knowing independently of this one method — if you want it closed, adding
`staticcheck` (or `golangci-lint` with `unused`) to `ci.yaml` is the lever, and it would
want its own PR since a first run on an existing codebase usually surfaces a batch.

I checked the rest of `SkipSet` while here: `backoffFor` (1 call site) and `fail` (2) are
both live.

## Verification

`gofmt` clean, `go vet` clean, 57 authlib packages pass, `authbridge-proxy` builds.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an unused internal helper and its time-remaining calculation.
  - Clarified the role of the remaining test-only helper through updated internal documentation.
  - No changes to connection handling, skip-set behavior, or other end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->