### PR TITLE
Feat: Gateway discount as a multiplier, plus pricing inspection and drift detection

### DIFF
--- a/authbridge/authlib/observe/statserver.go
+++ b/authbridge/authlib/observe/statserver.go
@@ -36,6 +36,7 @@ type Option func(*statServerOpts)
 
 type statServerOpts struct {
 	reloadStatus http.Handler
+	pricingTable http.Handler
 }
 
 // WithReloadStatus registers a /reload/status handler (typically the
@@ -43,6 +44,16 @@ type statServerOpts struct {
 // reload isn't wired up — the endpoint simply won't exist.
 func WithReloadStatus(h http.Handler) Option {
 	return func(o *statServerOpts) { o.reloadStatus = h }
+}
+
+// WithPricingTable registers a /pricing/table handler (typically the Handler returned
+// by an authlib/pricing.Registry). Omit when pricing isn't wired up.
+//
+// It answers what a config file cannot: the rates in effect come from the operator's
+// `pricing:` section PLUS a table compiled into the binary PLUS any shipped gateway
+// discount, so reading the config describes only the part the operator wrote.
+func WithPricingTable(h http.Handler) Option {
+	return func(o *statServerOpts) { o.pricingTable = h }
 }
 
 // NewStatServer builds the stat HTTP server. configProvider is
@@ -62,6 +73,9 @@ func NewStatServer(addr string, configProvider ConfigProvider, statsProvider Sta
 	if o.reloadStatus != nil {
 		mux.Handle("/reload/status", o.reloadStatus)
 	}
+	if o.pricingTable != nil {
+		mux.Handle("/pricing/table", o.pricingTable)
+	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -73,6 +87,7 @@ func NewStatServer(addr string, configProvider ConfigProvider, statsProvider Sta
     <li><a href="/config">Rossoctl AuthBridge configuration</a></li>
     <li><a href="/stats">Rossoctl AuthBridge statistics</a></li>
     <li><a href="/reload/status">Config reload status</a></li>
+    <li><a href="/pricing/table">Pricing table</a> (add <code>?host=&lt;gateway&gt;</code> for the rates that endpoint is actually charged)</li>
     </ul>
   </body>
 </html>`)

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift.go
@@ -3,6 +3,8 @@ package litellm_budgettrack
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
@@ -89,11 +91,26 @@ func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) 
 	}
 	modelled := float64(micros) / 1e6
 	ratio := modelled / authoritative
-	if ratio > 1-driftTolerance && ratio < 1+driftTolerance {
+	// Inclusive bounds: the contract above says "more than 5%", and a strict compare
+	// warned AT exactly 5%.
+	if ratio >= 1-driftTolerance && ratio <= 1+driftTolerance {
+		return
+	}
+	// Only compare figures that mean the same thing. See the header block in plugin.go:
+	// the "-original" fallback is the charged cost on a gateway that runs no LiteLLM
+	// discount/margin layer, but where one IS configured it is the figure BEFORE that
+	// layer, and comparing a modelled cost against it would report drift that is really
+	// the operator's own gateway-side adjustment. Skipped rather than guessed at,
+	// because the arithmetic relating the two is not something this code can verify.
+	if !driftComparable(pctx) {
 		return
 	}
 
-	key := pctx.Host + "\x00" + inf.Model
+	// Normalized the SAME way resolution normalizes, via the pricing package rather
+	// than a local copy. Keying on the raw Host gave "GW.internal:443" and "gw.internal"
+	// separate entries for one endpoint, so the same drift could warn repeatedly and the
+	// key budget drained faster than the cap implies.
+	key := pricing.EndpointKey(pctx.Host) + "\x00" + strings.ToLower(inf.Model)
 	p.drift.mu.Lock()
 	if p.drift.seen == nil {
 		p.drift.seen = map[string]struct{}{}
@@ -133,4 +150,40 @@ func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) 
 		"effect", direction+"stating every request this table prices, including streamed ones where no gateway figure exists",
 		"rates_from", prov.String(),
 		"fix", "set pricing.endpoints[].multiplier for this endpoint (a fraction of list), or per-model rates; `abctl pricing --host <endpoint>` shows what is in effect")
+}
+
+// driftComparable reports whether the gateway's figure can be compared against a modelled
+// one at all.
+//
+// False when the bare header is absent AND LiteLLM's own discount/margin layer is active:
+// the fallback figure is then pre-adjustment while the modelled figure is what the caller
+// pays, so any comparison measures the gateway's adjustment rather than the rate table.
+func driftComparable(pctx *pipeline.Context) bool {
+	if pctx.ResponseHeaders.Get(responseCostHeader) != "" {
+		return true // the effective figure itself; nothing to reconcile
+	}
+	for _, h := range []string{costDiscountAmountHeader, costMarginAmountHeader} {
+		v := pctx.ResponseHeaders.Get(h)
+		if v == "" {
+			continue
+		}
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// resetDrift clears the dedup set and the cap.
+//
+// Called on Configure, which is also the hot-reload path: a reload is an operator having
+// changed something, quite possibly the multiplier this check told them to set, so the
+// old "already warned about that" state is stale. It is also the only way out of the cap
+// short of a restart, which answers the note that a capped reporter otherwise stays off
+// for the life of the process.
+func (p *BudgetTrack) resetDrift() {
+	p.drift.mu.Lock()
+	p.drift.seen = nil
+	p.drift.capped = false
+	p.drift.mu.Unlock()
 }

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift.go
@@ -1,0 +1,109 @@
+package litellm_budgettrack
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// driftTolerance is how far the modelled cost may sit from the gateway's own figure
+// before it is worth saying so.
+//
+// 5% absorbs rounding and the micro quantization while still catching every mistake
+// that matters: a forgotten gateway discount is 32% off, a missing multiplier or a
+// decimal-place slip is a factor of ten or a hundred. Anything inside 5% is not
+// actionable and would train an operator to ignore the line.
+const driftTolerance = 0.05
+
+// driftReporter warns, once per endpoint and model, when the rate table disagrees with
+// what the gateway actually charged.
+//
+// This exists because the information was already on the wire and nobody looked. A
+// non-streamed response carries BOTH the gateway's settled cost and the token counts,
+// so the modelled figure can be checked against the real one for free — and for months
+// a gateway billing 0.76x vendor list was reported at list, with the discrepancy
+// visible in every such response and no signal anywhere.
+//
+// Once per (endpoint, model), not per request: an agent makes thousands of calls, and a
+// per-request warning would bury every other line in the log and get filtered out.
+type driftReporter struct {
+	mu   sync.Mutex
+	seen map[string]struct{}
+	log  *slog.Logger
+}
+
+func (d *driftReporter) logger() *slog.Logger {
+	if d.log != nil {
+		return d.log
+	}
+	return slog.Default()
+}
+
+// SetDriftLogger overrides the logger used for drift warnings. For tests.
+func (p *BudgetTrack) SetDriftLogger(l *slog.Logger) {
+	p.drift.mu.Lock()
+	p.drift.log = l
+	p.drift.mu.Unlock()
+}
+
+// checkDrift compares an authoritative cost against what the rate table would have
+// modelled, and warns on a material divergence.
+//
+// Called only where an authoritative figure exists — a non-streamed response with a
+// usable cost header. A streamed response reports 0 there by design, so there is
+// nothing to compare and silence is correct.
+//
+// The ledger keeps using the authoritative figure regardless: drift is a diagnostic
+// about the rate TABLE, never a reason to distrust the gateway's own number.
+func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) {
+	if authoritative <= 0 || p.rates == nil {
+		return
+	}
+	inf := pctx.Extensions.Inference
+	if inf == nil || inf.Model == "" {
+		return
+	}
+	u := pricing.UsageFromInference(inf)
+	if u == (pricing.Usage{}) {
+		return
+	}
+	micros, prov, ok := p.costOf(pctx.Host, inf.Model, u)
+	if !ok {
+		return // unpriced is already reported as a coverage gap; not drift
+	}
+	modelled := float64(micros) / 1e6
+	ratio := modelled / authoritative
+	if ratio > 1-driftTolerance && ratio < 1+driftTolerance {
+		return
+	}
+
+	key := pctx.Host + "\x00" + inf.Model
+	p.drift.mu.Lock()
+	if p.drift.seen == nil {
+		p.drift.seen = map[string]struct{}{}
+	}
+	if _, dup := p.drift.seen[key]; dup {
+		p.drift.mu.Unlock()
+		return
+	}
+	p.drift.seen[key] = struct{}{}
+	log := p.drift.logger()
+	p.drift.mu.Unlock()
+
+	direction := "over"
+	if ratio < 1 {
+		direction = "under"
+	}
+	log.Warn("pricing: the rate table disagrees with what the gateway charged",
+		"endpoint", pctx.Host,
+		"model", inf.Model,
+		"modelled_usd", fmt.Sprintf("%.6f", modelled),
+		"gateway_usd", fmt.Sprintf("%.6f", authoritative),
+		"ratio", fmt.Sprintf("%.3fx", ratio),
+		"effect", direction+"stating every request this table prices, including streamed ones where no gateway figure exists",
+		"rates_from", prov.String(),
+		"fix", "set pricing.endpoints[].multiplier for this endpoint (a fraction of list), or per-model rates; `abctl pricing --host <endpoint>` shows what is in effect")
+}

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift.go
@@ -18,6 +18,18 @@ import (
 // actionable and would train an operator to ignore the line.
 const driftTolerance = 0.05
 
+// maxDriftKeys bounds the dedup set.
+//
+// Both halves of the key come off the request — Host is a client-supplied header, the
+// model is a body field — so an unbounded map grows for as long as a caller varies them,
+// in a process designed to run for weeks, to serve a diagnostic. 256 distinct
+// endpoint/model pairs is far past any real deployment and long past the point where the
+// operator has been told their rate table is wrong.
+//
+// At the cap reporting STOPS rather than dropping the dedup: continuing to warn without
+// dedup would turn a bounded-memory problem into an unbounded-log one.
+const maxDriftKeys = 256
+
 // driftReporter warns, once per endpoint and model, when the rate table disagrees with
 // what the gateway actually charged.
 //
@@ -30,9 +42,10 @@ const driftTolerance = 0.05
 // Once per (endpoint, model), not per request: an agent makes thousands of calls, and a
 // per-request warning would bury every other line in the log and get filtered out.
 type driftReporter struct {
-	mu   sync.Mutex
-	seen map[string]struct{}
-	log  *slog.Logger
+	mu     sync.Mutex
+	seen   map[string]struct{}
+	capped bool
+	log    *slog.Logger
 }
 
 func (d *driftReporter) logger() *slog.Logger {
@@ -87,6 +100,20 @@ func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) 
 	}
 	if _, dup := p.drift.seen[key]; dup {
 		p.drift.mu.Unlock()
+		return
+	}
+	if len(p.drift.seen) >= maxDriftKeys {
+		alreadyCapped := p.drift.capped
+		p.drift.capped = true
+		log := p.drift.logger()
+		p.drift.mu.Unlock()
+		if !alreadyCapped {
+			// Said once, because going quiet without a word would read as "the drift
+			// stopped" — the opposite of what happened.
+			log.Warn("pricing: no longer reporting rate-table drift",
+				"reason", fmt.Sprintf("hit the %d endpoint/model limit", maxDriftKeys),
+				"fix", "`abctl pricing --host <endpoint>` still shows the rates in effect")
+		}
 		return
 	}
 	p.drift.seen[key] = struct{}{}

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
@@ -3,6 +3,7 @@ package litellm_budgettrack
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -112,5 +113,38 @@ func TestDrift_SilentOnStreamedResponses(t *testing.T) {
 
 	if got := buf.String(); got != "" {
 		t.Errorf("warned on a streamed response, which has no authoritative cost: %s", got)
+	}
+}
+
+// The dedup key is (endpoint, model), and BOTH halves come off the request: Host is a
+// client-supplied header and the model is a body field. An unbounded map keyed on those
+// grows for as long as a caller varies them, in a long-lived sidecar, for a diagnostic.
+func TestDrift_SeenMapIsBounded(t *testing.T) {
+	p := configurePriced(t, 1e9, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	for i := 0; i < maxDriftKeys*3; i++ {
+		h := http.Header{}
+		h.Set("Content-Type", "application/json")
+		h.Set(responseCostHeader, "0.002")
+		pctx := &pipeline.Context{Host: fmt.Sprintf("gw-%d.internal", i), ResponseHeaders: h}
+		pricedInference(pctx, 1000, 0, 0, 1000)
+		p.OnResponseFrame(context.Background(), pctx, nil, true)
+	}
+
+	p.drift.mu.Lock()
+	n := len(p.drift.seen)
+	p.drift.mu.Unlock()
+	if n > maxDriftKeys {
+		t.Errorf("seen holds %d keys, cap is %d", n, maxDriftKeys)
+	}
+	// And it must say it stopped, exactly once — silently going quiet would read as
+	// "the drift was fixed".
+	if c := strings.Count(buf.String(), "no longer reporting"); c != 1 {
+		t.Errorf("cap notice appeared %d times, want exactly 1", c)
 	}
 }

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
@@ -1,0 +1,116 @@
+package litellm_budgettrack
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// A non-streamed response carries BOTH the gateway's own settled cost and the token
+// counts, so the modelled figure can be checked against the real one for free. Nothing
+// did that, which is how a gateway billing 0.76x vendor list was reported at list for
+// months with no signal.
+func TestDrift_WarnsWhenModelledDivergesFromAuthoritative(t *testing.T) {
+	// Rates deliberately 2x what the gateway will report, so the modelled figure is
+	// double the authoritative one.
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	// 1000 in + 1000 out at 2e-6 = 0.004 modelled; gateway says 0.002.
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set(responseCostHeader, "0.002")
+	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+	pricedInference(pctx, 1000, 0, 0, 1000)
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	got := buf.String()
+	if got == "" {
+		t.Fatal("no drift warning for a 2x divergence")
+	}
+	for _, want := range []string{"gw.internal", "claude-opus-5", "pricing"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning omits %q: %s", want, got)
+		}
+	}
+	// The ledger must still use the AUTHORITATIVE figure — drift is a diagnostic, not
+	// a reason to distrust the gateway's own number.
+	if p.ledger.TotalSpend != 0.002 {
+		t.Errorf("TotalSpend = %v, want the gateway's 0.002", p.ledger.TotalSpend)
+	}
+}
+
+func TestDrift_SilentWhenTheyAgree(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  1e-6,
+		pricing.TierOutput: 1e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set(responseCostHeader, "0.002") // 1000+1000 at 1e-6 = exactly 0.002
+	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+	pricedInference(pctx, 1000, 0, 0, 1000)
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("warned on agreement: %s", got)
+	}
+}
+
+// Warned once per (endpoint, model), not per request: an agent makes thousands of calls
+// and a per-request warning would bury every other line in the log.
+func TestDrift_WarnsOncePerEndpointModel(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	for i := 0; i < 5; i++ {
+		h := http.Header{}
+		h.Set("Content-Type", "application/json")
+		h.Set(responseCostHeader, "0.002")
+		pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+		pricedInference(pctx, 1000, 0, 0, 1000)
+		p.OnResponseFrame(context.Background(), pctx, nil, true)
+	}
+	if n := strings.Count(buf.String(), "gw.internal"); n != 1 {
+		t.Errorf("warned %d times, want exactly 1 per endpoint/model", n)
+	}
+}
+
+// A streamed response has no authoritative figure (the header is 0 by design), so there
+// is nothing to compare and no warning to give.
+func TestDrift_SilentOnStreamedResponses(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	h := http.Header{}
+	h.Set("Content-Type", "text/event-stream")
+	h.Set(responseCostHeader, "0")
+	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+	pricedInference(pctx, 1000, 0, 0, 1000)
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("warned on a streamed response, which has no authoritative cost: %s", got)
+	}
+}

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
@@ -148,3 +148,142 @@ func TestDrift_SeenMapIsBounded(t *testing.T) {
 		t.Errorf("cap notice appeared %d times, want exactly 1", c)
 	}
 }
+
+// Every other drift test sets the bare header, so the "-original" fallback — the ONLY
+// header the Anthropic /v1/messages path emits, which is the shape Claude Code sends —
+// had no drift coverage at all. Measured against the real gateway: both paths report the
+// same post-discount figure, so a correct table must stay silent on the fallback too.
+func TestDrift_SilentOnTheOriginalHeaderFallback(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  1e-6,
+		pricing.TierOutput: 1e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	// No bare header, exactly as /v1/messages replies.
+	h.Set(responseCostOriginalHeader, "0.002")
+	h.Set(costDiscountAmountHeader, "0.0")
+	h.Set(costMarginAmountHeader, "0.0")
+	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+	pricedInference(pctx, 1000, 0, 0, 1000)
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("warned on the fallback path where the figures agree: %s", got)
+	}
+	if p.ledger.TotalSpend != 0.002 {
+		t.Errorf("TotalSpend = %v, want the fallback figure 0.002", p.ledger.TotalSpend)
+	}
+}
+
+// Where LiteLLM's own discount layer IS active, the fallback figure is pre-adjustment and
+// the modelled one is what the caller pays. Comparing them measures the gateway's
+// adjustment, not the rate table, so drift must decline to speak rather than blame the
+// multiplier.
+func TestDrift_SilentWhenTheFallbackFigureIsPreAdjustment(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set(responseCostOriginalHeader, "0.002") // modelled would be 0.004 → 2x, normally a warning
+	h.Set(costDiscountAmountHeader, "0.0005")  // but the gateway adjusts its own figure
+	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+	pricedInference(pctx, 1000, 0, 0, 1000)
+	p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+	if got := buf.String(); got != "" {
+		t.Errorf("blamed the rate table for the gateway's own discount layer: %s", got)
+	}
+}
+
+// Exactly 5% is silent: the contract says "more than 5%".
+func TestDrift_TolerancePeriodIsInclusive(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		authorativ string
+		warn       bool
+	}{
+		{"exactly +5%", "0.0019047619047619048", false}, // modelled 0.002 = authoritative x 1.05
+		{"exactly -5%", "0.002105263157894737", false},  // modelled 0.002 = authoritative x 0.95
+		{"just past +5%", "0.0018", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := configurePriced(t, 100, map[pricing.Tier]float64{
+				pricing.TierInput:  1e-6,
+				pricing.TierOutput: 1e-6,
+			})
+			var buf bytes.Buffer
+			p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+			h := http.Header{}
+			h.Set("Content-Type", "application/json")
+			h.Set(responseCostHeader, tc.authorativ)
+			pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+			pricedInference(pctx, 1000, 0, 0, 1000) // modelled 0.002
+			p.OnResponseFrame(context.Background(), pctx, nil, true)
+
+			if warned := buf.String() != ""; warned != tc.warn {
+				t.Errorf("warned = %v, want %v (%s)", warned, tc.warn, buf.String())
+			}
+		})
+	}
+}
+
+// Case and port variants are ONE endpoint, so they share a dedup entry.
+func TestDrift_DedupKeyNormalizesTheHost(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	var buf bytes.Buffer
+	p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	for _, host := range []string{"gw.internal", "GW.internal", "gw.internal:443"} {
+		h := http.Header{}
+		h.Set("Content-Type", "application/json")
+		h.Set(responseCostHeader, "0.002")
+		pctx := &pipeline.Context{Host: host, ResponseHeaders: h}
+		pricedInference(pctx, 1000, 0, 0, 1000)
+		p.OnResponseFrame(context.Background(), pctx, nil, true)
+	}
+	if n := strings.Count(buf.String(), "\n"); n != 1 {
+		t.Errorf("warned %d times for one endpoint spelled three ways:\n%s", n, buf.String())
+	}
+}
+
+// A reload is the way out of the cap, and the way a fixed multiplier gets a clean slate.
+func TestDrift_ConfigureResetsTheReporter(t *testing.T) {
+	p := configurePriced(t, 100, map[pricing.Tier]float64{
+		pricing.TierInput:  2e-6,
+		pricing.TierOutput: 2e-6,
+	})
+	warn := func() string {
+		var buf bytes.Buffer
+		p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+		h := http.Header{}
+		h.Set("Content-Type", "application/json")
+		h.Set(responseCostHeader, "0.002")
+		pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
+		pricedInference(pctx, 1000, 0, 0, 1000)
+		p.OnResponseFrame(context.Background(), pctx, nil, true)
+		return buf.String()
+	}
+	if warn() == "" {
+		t.Fatal("no first warning")
+	}
+	if warn() != "" {
+		t.Fatal("warned twice without a reload")
+	}
+	p.resetDrift()
+	if warn() == "" {
+		t.Error("still silent after a reset; a reload must give a fixed config a clean slate")
+	}
+}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -97,6 +97,9 @@ type BudgetTrack struct {
 	// rates is the process rate table, injected before Configure. Read only
 	// through costOf, which guards the nil interface.
 	rates pricing.Resolver
+
+	// drift reports when the table disagrees with the gateway's own figure.
+	drift driftReporter
 }
 
 // SetPricingResolver implements pricing.ResolverConsumer.
@@ -269,6 +272,11 @@ func (p *BudgetTrack) OnResponseFrame(_ context.Context, pctx *pipeline.Context,
 	}
 	switch {
 	case cost > 0:
+		if source == costevent.SourceGatewayHeader {
+			// Only a header cost is authoritative. Comparing a modelled figure against
+			// itself would always agree and say nothing.
+			p.checkDrift(pctx, cost)
+		}
 		if total, ok := p.accumulate(cost); ok {
 			p.emitCost(pctx, cost, source, total, provenance)
 		}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -41,15 +41,33 @@ import (
 
 // Response cost headers emitted by LiteLLM.
 //
-// responseCostHeader is the effective (post-discount) cost and is present on
-// OpenAI-style /v1/chat/completions responses. Newer LiteLLM releases — and the
-// Anthropic /v1/messages endpoint that Claude Code uses — do not emit it, only
-// the pre-discount "-original" variant, so we fall back to that when the bare
-// header is absent. Without the fallback, budget tracking silently records $0
-// for Anthropic-format traffic.
+// MEASURED 2026-09-11 against ete-litellm (LiteLLM 1.85.5), because an earlier version of
+// this comment had the semantics backwards and a reviewer reasonably concluded from it
+// that drift detection would false-positive on every Anthropic-format request:
+//
+//	/v1/chat/completions  both headers present, IDENTICAL values
+//	/v1/messages          only "-original", same value the other path reports
+//
+// For 16 input + 4 output tokens of claude-opus-5 both paths reported
+// 0.00013680000000000002, which is 0.76 x vendor list (16x$5 + 4x$25 per Mtok = 0.00018).
+// So "-original" is the cost the gateway ACTUALLY CHARGED, not a pre-discount list price,
+// and falling back to it compares like with like.
+//
+// "Original" refers to LiteLLM's OWN discount/margin layer, reported alongside in
+// X-Litellm-Response-Cost-{Discount,Margin}-Amount: original is the figure before that
+// layer is applied. This gateway runs neither (both report 0.0), so the two agree. A
+// gateway that DOES configure them would see them diverge, which is why checkDrift
+// checks those headers before comparing — see driftComparable.
+//
+// The fallback itself is load-bearing: without it, budget tracking silently records $0
+// for every Anthropic-format request, which is the shape Claude Code sends.
 const (
 	responseCostHeader         = "X-Litellm-Response-Cost"
 	responseCostOriginalHeader = "X-Litellm-Response-Cost-Original"
+
+	// LiteLLM's own adjustment layer, non-zero only where an operator configured it.
+	costDiscountAmountHeader = "X-Litellm-Response-Cost-Discount-Amount"
+	costMarginAmountHeader   = "X-Litellm-Response-Cost-Margin-Amount"
 )
 
 type budgetTrackConfig struct {
@@ -166,6 +184,9 @@ func (p *BudgetTrack) Configure(raw json.RawMessage) error {
 		return fmt.Errorf("litellm-budget-track: max_budget must be > 0")
 	}
 	p.loadLedger()
+	// Configure is also the hot-reload path, so drift's "already said that" state is
+	// cleared here: the reload may well BE the operator acting on a drift warning.
+	p.resetDrift()
 	return nil
 }
 

--- a/authbridge/authlib/pricing/bundled_multipliers.go
+++ b/authbridge/authlib/pricing/bundled_multipliers.go
@@ -21,11 +21,16 @@ func bundledMultipliers() []MultiplierRule {
 	return []MultiplierRule{{
 		// WHAT THIS NUMBER IS, so that nobody edits it thinking it is a rounding
 		// constant: it is the fraction of vendor list that IBM's internal LiteLLM
-		// gateways bill, and shipping it here states that in a public repository. That
-		// was a deliberate call by the maintainers, not an oversight — but it is still a
-		// statement about one organisation's pricing, so treat a change to this line as
-		// a disclosure decision and not a data refresh, and do not widen the host
-		// pattern to gateways whose terms have not been cleared the same way.
+		// gateways bill, and shipping it here states that in a public repository.
+		//
+		// Cleared for publication by @huang195, as maintainer, in the "Disclosure of the
+		// shipped factor" section of cortex#968 — the PR that added this rule. Cited
+		// rather than merely asserted, because a comment vouching for its own line is
+		// the one thing this comment must not be.
+		//
+		// It is still a statement about one organisation's pricing, so treat a change to
+		// this line as a disclosure decision and not a data refresh, and do not widen
+		// the host pattern to gateways whose terms have not been cleared the same way.
 		//
 		// Another gateway's factor belongs in `pricing.endpoints[].multiplier`, or in a
 		// rule of its own. Do not repurpose this one.

--- a/authbridge/authlib/pricing/bundled_multipliers.go
+++ b/authbridge/authlib/pricing/bundled_multipliers.go
@@ -2,9 +2,9 @@ package pricing
 
 // bundledMultipliers are the gateway discounts shipped with the binary.
 //
-// HAND-MAINTAINED, deliberately not generated. bundled.go comes from LiteLLM's public
-// price map; these come from a commercial agreement, and `make pricing-table` must
-// never be able to clobber them.
+// HAND-MAINTAINED, deliberately not generated. bundled.go is derived from LiteLLM's
+// public price map; these factors are measured against a live gateway, so
+// `make pricing-table` must never be able to clobber them.
 //
 // Why ship a discount at all, when the bundled rates are vendor list: most Cortex
 // installs run through one of these gateways, so list overstates them by a third. The
@@ -19,12 +19,15 @@ package pricing
 // operator with different terms overrides with one line, which outranks this.
 func bundledMultipliers() []MultiplierRule {
 	return []MultiplierRule{{
-		// Measured 2026-09-10 against ete-litellm.ai-models.vpc-int.res.ibm.com by
-		// differencing x-litellm-response-cost-original across paired non-streamed
-		// calls: input, cache-write, cache-read and output for opus-5, sonnet-5 and
-		// haiku-4-5 all came to exactly 0.7600 of the then-current vendor list. A
-		// uniform scalar across twelve independent figures, which is what makes one
-		// number the honest representation.
+		// Measured 2026-09-10 by differencing x-litellm-response-cost-original across
+		// paired non-streamed calls: input, cache-write, cache-read and output, for
+		// opus-5, sonnet-5 and haiku-4-5, all came to exactly 0.7600 of the
+		// then-current vendor list. A uniform scalar across twelve independent
+		// figures, which is what makes one number the honest representation rather
+		// than a convenient approximation.
+		//
+		// Re-measure with the method in docs/plugin-catalog.md if the figures ever
+		// look wrong; the drift check in litellm-budget-track will say so first.
 		//
 		// Streamed responses report a cost of 0 in that header, so this cannot be
 		// re-derived from live agent traffic — which is precisely why it is shipped

--- a/authbridge/authlib/pricing/bundled_multipliers.go
+++ b/authbridge/authlib/pricing/bundled_multipliers.go
@@ -19,6 +19,17 @@ package pricing
 // operator with different terms overrides with one line, which outranks this.
 func bundledMultipliers() []MultiplierRule {
 	return []MultiplierRule{{
+		// WHAT THIS NUMBER IS, so that nobody edits it thinking it is a rounding
+		// constant: it is the fraction of vendor list that IBM's internal LiteLLM
+		// gateways bill, and shipping it here states that in a public repository. That
+		// was a deliberate call by the maintainers, not an oversight — but it is still a
+		// statement about one organisation's pricing, so treat a change to this line as
+		// a disclosure decision and not a data refresh, and do not widen the host
+		// pattern to gateways whose terms have not been cleared the same way.
+		//
+		// Another gateway's factor belongs in `pricing.endpoints[].multiplier`, or in a
+		// rule of its own. Do not repurpose this one.
+		//
 		// Measured 2026-09-10 by differencing x-litellm-response-cost-original across
 		// paired non-streamed calls: input, cache-write, cache-read and output, for
 		// opus-5, sonnet-5 and haiku-4-5, all came to exactly 0.7600 of the

--- a/authbridge/authlib/pricing/bundled_multipliers.go
+++ b/authbridge/authlib/pricing/bundled_multipliers.go
@@ -1,0 +1,36 @@
+package pricing
+
+// bundledMultipliers are the gateway discounts shipped with the binary.
+//
+// HAND-MAINTAINED, deliberately not generated. bundled.go comes from LiteLLM's public
+// price map; these come from a commercial agreement, and `make pricing-table` must
+// never be able to clobber them.
+//
+// Why ship a discount at all, when the bundled rates are vendor list: most Cortex
+// installs run through one of these gateways, so list overstates them by a third. The
+// alternative was every operator copying twelve rates by hand, which is both more work
+// and more fragile — see MultiplierRule for why a scalar survives a repricing and a
+// copied rate card does not.
+//
+// Why SCOPED to a host pattern rather than applied globally: a global default would
+// silently understate anyone going straight to api.anthropic.com by 24%, and
+// understating hides spend. Scoping means both audiences are right with no
+// configuration — the gateways get the discount, everything else gets list — and an
+// operator with different terms overrides with one line, which outranks this.
+func bundledMultipliers() []MultiplierRule {
+	return []MultiplierRule{{
+		// Measured 2026-09-10 against ete-litellm.ai-models.vpc-int.res.ibm.com by
+		// differencing x-litellm-response-cost-original across paired non-streamed
+		// calls: input, cache-write, cache-read and output for opus-5, sonnet-5 and
+		// haiku-4-5 all came to exactly 0.7600 of the then-current vendor list. A
+		// uniform scalar across twelve independent figures, which is what makes one
+		// number the honest representation.
+		//
+		// Streamed responses report a cost of 0 in that header, so this cannot be
+		// re-derived from live agent traffic — which is precisely why it is shipped
+		// rather than learned.
+		Host:   "*.res.ibm.com",
+		Factor: 0.76,
+		Prov:   ProvBundled,
+	}}
+}

--- a/authbridge/authlib/pricing/config.go
+++ b/authbridge/authlib/pricing/config.go
@@ -39,6 +39,17 @@ type EndpointConfig struct {
 	// Models maps a model glob to its rates. Keys are matched
 	// case-insensitively, and an exact key beats a glob.
 	Models map[string]ModelConfig `yaml:"models" json:"models,omitempty"`
+
+	// Multiplier scales every rate that resolves for these hosts. Absent means 1.0.
+	//
+	// A FRACTION of the resolved rate, so a 24% discount is 0.76. This is the whole
+	// configuration most deployments need: a gateway discount is one scalar, and
+	// stating it once tracks upstream repricing instead of freezing last quarter's
+	// numbers into a copied rate card. See MultiplierRule.
+	//
+	// An endpoint with a multiplier needs no models block — it scales what already
+	// resolves, including models no entry names.
+	Multiplier *float64 `yaml:"multiplier" json:"multiplier,omitempty"`
 }
 
 // ModelConfig is one model pattern's rates, optionally with long-context
@@ -105,8 +116,14 @@ func (c *Config) BundledEnabled() bool {
 // at equal specificity: an override is an override.
 func Build(cfg *Config) (*Table, error) {
 	var entries []Entry
+	var mults []MultiplierRule
 	if cfg.BundledEnabled() {
 		entries = append(entries, Bundled()...)
+		// Shipped gateway discounts travel with the shipped rates: the rates are
+		// vendor list, and for the gateways named here list is a third too high.
+		// Disabling the bundled table disables both, which is the right pairing —
+		// a multiplier on rates you did not ship scales somebody else's numbers.
+		mults = append(mults, bundledMultipliers()...)
 	}
 	if cfg != nil {
 		configured, err := cfg.entries()
@@ -114,8 +131,30 @@ func Build(cfg *Config) (*Table, error) {
 			return nil, err
 		}
 		entries = append(entries, configured...)
+		mults = append(mults, cfg.multipliers()...)
 	}
-	return NewTable(entries)
+	return NewTable(entries, mults...)
+}
+
+// multipliers converts the config's endpoint blocks into multiplier rules.
+func (c *Config) multipliers() []MultiplierRule {
+	if c == nil {
+		return nil
+	}
+	var out []MultiplierRule
+	for _, ep := range c.Endpoints {
+		if ep.Multiplier == nil {
+			continue
+		}
+		hosts := ep.Hosts
+		if len(hosts) == 0 {
+			hosts = []string{""}
+		}
+		for _, h := range hosts {
+			out = append(out, MultiplierRule{Host: h, Factor: *ep.Multiplier, Prov: ProvConfigured})
+		}
+	}
+	return out
 }
 
 // entries converts the config's endpoint/model blocks into table rows.
@@ -137,7 +176,12 @@ func (c *Config) entries() ([]Entry, error) {
 			}
 		}
 		if len(ep.Models) == 0 {
-			return nil, fmt.Errorf("%s: no models configured; an endpoint block with no rates prices nothing", where)
+			if ep.Multiplier != nil {
+				// A multiplier-only block scales what already resolves, so demanding
+				// rates here would defeat the point of expressing a discount once.
+				continue
+			}
+			return nil, fmt.Errorf("%s: no models or multiplier configured; an endpoint block with neither prices nothing", where)
 		}
 		// Sorted so a config with several faults reports the same one across
 		// restarts, instead of whichever map iteration reached first.
@@ -265,7 +309,8 @@ func (c *Config) WarnIfUnpinned(log *slog.Logger) {
 		return // the operator has pinned something
 	}
 	log.Warn("pricing: every endpoint will price from the bundled table, which ships VENDOR LIST rates",
-		"effect", "a gateway that bills below list is OVERSTATED (the reference gateway differs by 1.32x)",
-		"fix", "add a pricing.endpoints entry for your gateway; see docs/plugin-catalog.md",
+		"effect", "a gateway that bills below list is OVERSTATED — measured at 0.76x list on the shipped gateways, so ~1.32x high without a multiplier",
+		"fix", "set pricing.endpoints[].multiplier for your gateway (one scalar; 0.76 means a 24% discount), or per-model rates; see docs/plugin-catalog.md",
+		"note", "gateways matching the shipped rules already have a multiplier applied and need nothing",
 		"check", "abctl annotates the cost total [bundled] rather than [configured]")
 }

--- a/authbridge/authlib/pricing/describe.go
+++ b/authbridge/authlib/pricing/describe.go
@@ -1,9 +1,6 @@
 package pricing
 
-import (
-	"sort"
-	"strings"
-)
+import "sort"
 
 // This file exists because a config file cannot answer the question operators
 // actually have.
@@ -214,23 +211,12 @@ func (r *Registry) EffectiveFor(host string) Effective {
 // lowestThresholdFor reports the smallest long-context breakpoint on the row that would
 // win for this endpoint and model, or 0 if it has none.
 //
-// Resolves the row the same way Resolve does, then reads its thresholds before
-// flattening — which is the only place they survive.
+// Selects through Table.bestRow — the same ranking Resolve uses, not a copy of it — then
+// reads the thresholds off the row, which is the only place they survive: Resolve
+// flattens with At(promptTotal) before returning, so by then the applicable one has been
+// folded into Base and the rest are gone.
 func (t *Table) lowestThresholdFor(endpoint, model string) int {
-	if t == nil {
-		return 0
-	}
-	forms := modelNameForms(strings.ToLower(strings.TrimSpace(model)))
-	var best *row
-	for i := range t.rows {
-		r := &t.rows[i]
-		if !matchHost(r.host, endpoint) || !r.model.match(forms) {
-			continue
-		}
-		if best == nil || r.prov > best.prov || (r.prov == best.prov && r.spec.beats(best.spec)) {
-			best = r
-		}
-	}
+	best := t.bestRow(endpoint, model)
 	if best == nil {
 		return 0
 	}

--- a/authbridge/authlib/pricing/describe.go
+++ b/authbridge/authlib/pricing/describe.go
@@ -73,6 +73,18 @@ type EffectiveRates struct {
 	// the tool built to inspect it. The bundled table ships four such models.
 	LongContextAbove int `json:"longContextAbove,omitempty"`
 
+	// Above* are the rates once LongContextAbove is exceeded, resolved the same way and
+	// with the same multiplier applied. Present only when LongContextAbove is.
+	//
+	// Naming the breakpoint without its prices told an operator that their long sessions
+	// cost something other than the figures above, and left them to find out what by
+	// reading the raw table and applying the discount by hand — which is the arithmetic
+	// this endpoint exists to do for them.
+	AboveInputPerMillion      float64 `json:"aboveInputPerMillion,omitempty"`
+	AboveCacheWritePerMillion float64 `json:"aboveCacheWritePerMillion,omitempty"`
+	AboveCacheReadPerMillion  float64 `json:"aboveCacheReadPerMillion,omitempty"`
+	AboveOutputPerMillion     float64 `json:"aboveOutputPerMillion,omitempty"`
+
 	InputPerMillion      float64 `json:"inputPerMillion,omitempty"`
 	CacheWritePerMillion float64 `json:"cacheWritePerMillion,omitempty"`
 	CacheReadPerMillion  float64 `json:"cacheReadPerMillion,omitempty"`
@@ -179,6 +191,15 @@ func (t *Table) EffectiveFor(host string) Effective {
 		// threshold into Base, so the thresholds are only visible on the row itself.
 		if lo := t.lowestThresholdFor(host, m); lo > 0 {
 			e.LongContextAbove = lo
+			// lo+1 because a threshold applies to prompts that EXCEED it — a request of
+			// exactly lo tokens pays base, per Rates.At.
+			above, aprov := t.Resolve(host, m, lo+1)
+			if aprov != ProvNone {
+				e.AboveInputPerMillion = perM(above, TierInput)
+				e.AboveCacheWritePerMillion = perM(above, TierCacheWrite)
+				e.AboveCacheReadPerMillion = perM(above, TierCacheRead)
+				e.AboveOutputPerMillion = perM(above, TierOutput)
+			}
 		}
 		if prov != ProvNone {
 			e.InputPerMillion = perM(rates, TierInput)

--- a/authbridge/authlib/pricing/describe.go
+++ b/authbridge/authlib/pricing/describe.go
@@ -1,0 +1,194 @@
+package pricing
+
+import "sort"
+
+// This file exists because a config file cannot answer the question operators
+// actually have.
+//
+// `pricing:` shows what the operator WROTE. The figures a request is charged come from
+// that plus a rate table compiled into the binary plus any shipped gateway discount —
+// so reading the config tells you nothing about the two thirds you did not write. And
+// storing the table in the config instead would freeze every install at the rates
+// current on its install date, silently, because the config is written once and never
+// refreshed: exactly the staleness this package was built to remove.
+//
+// So the table is not stored, it is made inspectable.
+
+// RowView is one rate-table row, in the unit providers publish.
+//
+// A zero rate means UNSET, not free: config rejects a zero and the generator drops it,
+// so nothing legitimate produces one. Rendered with omitempty so an absent tier reads
+// as absent rather than as a price of nothing.
+type RowView struct {
+	Host       string `json:"host,omitempty"`
+	Model      string `json:"model"`
+	Provenance string `json:"provenance"`
+
+	InputPerMillion      float64 `json:"inputPerMillion,omitempty"`
+	CacheWritePerMillion float64 `json:"cacheWritePerMillion,omitempty"`
+	CacheReadPerMillion  float64 `json:"cacheReadPerMillion,omitempty"`
+	OutputPerMillion     float64 `json:"outputPerMillion,omitempty"`
+
+	Thresholds []ThresholdView `json:"thresholds,omitempty"`
+}
+
+// ThresholdView is one long-context override.
+type ThresholdView struct {
+	AbovePromptTokens    int     `json:"abovePromptTokens"`
+	InputPerMillion      float64 `json:"inputPerMillion,omitempty"`
+	CacheWritePerMillion float64 `json:"cacheWritePerMillion,omitempty"`
+	CacheReadPerMillion  float64 `json:"cacheReadPerMillion,omitempty"`
+	OutputPerMillion     float64 `json:"outputPerMillion,omitempty"`
+}
+
+// MultiplierView is one endpoint discount rule.
+type MultiplierView struct {
+	Host       string  `json:"host,omitempty"`
+	Factor     float64 `json:"factor"`
+	Provenance string  `json:"provenance"`
+}
+
+// Description is the whole table, unresolved.
+type Description struct {
+	// UpstreamCommit is the LiteLLM commit the bundled rates were generated from, so a
+	// figure can be traced to its source without reading the binary.
+	UpstreamCommit string           `json:"upstreamCommit,omitempty"`
+	Rows           []RowView        `json:"rows"`
+	Multipliers    []MultiplierView `json:"multipliers,omitempty"`
+}
+
+// EffectiveRates is what one model actually costs at one endpoint, multiplier included.
+type EffectiveRates struct {
+	Model      string `json:"model"`
+	Provenance string `json:"provenance"`
+	Unpriced   bool   `json:"unpriced,omitempty"`
+
+	InputPerMillion      float64 `json:"inputPerMillion,omitempty"`
+	CacheWritePerMillion float64 `json:"cacheWritePerMillion,omitempty"`
+	CacheReadPerMillion  float64 `json:"cacheReadPerMillion,omitempty"`
+	OutputPerMillion     float64 `json:"outputPerMillion,omitempty"`
+}
+
+// Effective is the resolved answer for one endpoint.
+type Effective struct {
+	Host string `json:"host"`
+	// Multiplier and MultiplierFrom are surfaced separately from the scaled rates so an
+	// operator can see WHY their figures differ from vendor list, rather than being
+	// handed numbers that match no published price list.
+	Multiplier     float64          `json:"multiplier"`
+	MultiplierFrom string           `json:"multiplierFrom,omitempty"`
+	Models         []EffectiveRates `json:"models"`
+}
+
+func perM(r Rates, t Tier) float64 {
+	v, ok := r.For(t)
+	if !ok {
+		return 0
+	}
+	return v * tokensPerMillion
+}
+
+// Describe renders the raw table: every row as configured or shipped, unscaled.
+func (t *Table) Describe() Description {
+	out := Description{UpstreamCommit: BundledUpstreamCommit}
+	if t == nil {
+		return out
+	}
+	for i := range t.rows {
+		r := &t.rows[i]
+		row := RowView{
+			Host:                 r.host,
+			Model:                r.model.pattern,
+			Provenance:           r.prov.String(),
+			InputPerMillion:      perM(r.rates, TierInput),
+			CacheWritePerMillion: perM(r.rates, TierCacheWrite),
+			CacheReadPerMillion:  perM(r.rates, TierCacheRead),
+			OutputPerMillion:     perM(r.rates, TierOutput),
+		}
+		for _, th := range r.rates.Thresholds {
+			tv := ThresholdView{AbovePromptTokens: th.AbovePromptTokens}
+			for tier, dst := range map[Tier]*float64{
+				TierInput:      &tv.InputPerMillion,
+				TierCacheWrite: &tv.CacheWritePerMillion,
+				TierCacheRead:  &tv.CacheReadPerMillion,
+				TierOutput:     &tv.OutputPerMillion,
+			} {
+				if th.Set[tier] {
+					*dst = th.Rate[tier] * tokensPerMillion
+				}
+			}
+			row.Thresholds = append(row.Thresholds, tv)
+		}
+		out.Rows = append(out.Rows, row)
+	}
+	for i := range t.mults {
+		m := &t.mults[i]
+		out.Multipliers = append(out.Multipliers, MultiplierView{
+			Host: m.host, Factor: m.factor, Provenance: m.prov.String(),
+		})
+	}
+	return out
+}
+
+// EffectiveFor resolves every model the table names, for one endpoint.
+//
+// This is the question worth answering: not "what rows exist" but "what will this
+// gateway charge me". Resolution applies host scoping, specificity, provenance
+// precedence and the multiplier — none of which a reader can carry out by eye.
+//
+// Glob rows are resolved under their own pattern, which is the honest rendering: a
+// pattern's rate is what any model matching it gets, and inventing a concrete model
+// name to stand for it would imply a row that does not exist.
+func (t *Table) EffectiveFor(host string) Effective {
+	out := Effective{Host: host, Multiplier: 1}
+	if t == nil {
+		return out
+	}
+	f, fprov := t.multiplierFor(host)
+	out.Multiplier = f
+	if fprov != ProvNone {
+		out.MultiplierFrom = fprov.String()
+	}
+
+	seen := map[string]struct{}{}
+	var models []string
+	for i := range t.rows {
+		m := t.rows[i].model.pattern
+		if _, dup := seen[m]; dup {
+			continue
+		}
+		seen[m] = struct{}{}
+		models = append(models, m)
+	}
+	sort.Strings(models)
+
+	for _, m := range models {
+		rates, prov := t.Resolve(host, m, 0)
+		e := EffectiveRates{Model: m, Provenance: prov.String(), Unpriced: prov == ProvNone}
+		if prov != ProvNone {
+			e.InputPerMillion = perM(rates, TierInput)
+			e.CacheWritePerMillion = perM(rates, TierCacheWrite)
+			e.CacheReadPerMillion = perM(rates, TierCacheRead)
+			e.OutputPerMillion = perM(rates, TierOutput)
+		}
+		out.Models = append(out.Models, e)
+	}
+	return out
+}
+
+// Describe on the Registry reads the live table. Nil-safe, matching Resolve: a binary
+// with no pricing wired reports an empty table rather than crashing a status handler.
+func (r *Registry) Describe() Description {
+	if r == nil {
+		return Description{UpstreamCommit: BundledUpstreamCommit}
+	}
+	return r.tab.Load().Describe()
+}
+
+// EffectiveFor on the Registry reads the live table.
+func (r *Registry) EffectiveFor(host string) Effective {
+	if r == nil {
+		return Effective{Host: host, Multiplier: 1}
+	}
+	return r.tab.Load().EffectiveFor(host)
+}

--- a/authbridge/authlib/pricing/describe.go
+++ b/authbridge/authlib/pricing/describe.go
@@ -1,6 +1,9 @@
 package pricing
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // This file exists because a config file cannot answer the question operators
 // actually have.
@@ -62,6 +65,16 @@ type EffectiveRates struct {
 	Model      string `json:"model"`
 	Provenance string `json:"provenance"`
 	Unpriced   bool   `json:"unpriced,omitempty"`
+
+	// LongContextAbove is the prompt-token count past which DIFFERENT rates apply, or
+	// 0 when this model has none.
+	//
+	// The rates below are the below-threshold ones, because that is what a request of
+	// unknown size is charged and EffectiveFor resolves at prompt size 0. Without this
+	// field the view quotes a figure a long-context request will not be charged — the
+	// same silent-wrong-number failure this package exists to remove, reintroduced by
+	// the tool built to inspect it. The bundled table ships four such models.
+	LongContextAbove int `json:"longContextAbove,omitempty"`
 
 	InputPerMillion      float64 `json:"inputPerMillion,omitempty"`
 	CacheWritePerMillion float64 `json:"cacheWritePerMillion,omitempty"`
@@ -165,6 +178,11 @@ func (t *Table) EffectiveFor(host string) Effective {
 	for _, m := range models {
 		rates, prov := t.Resolve(host, m, 0)
 		e := EffectiveRates{Model: m, Provenance: prov.String(), Unpriced: prov == ProvNone}
+		// Read from the UNFLATTENED row: Resolve has already folded the applicable
+		// threshold into Base, so the thresholds are only visible on the row itself.
+		if lo := t.lowestThresholdFor(host, m); lo > 0 {
+			e.LongContextAbove = lo
+		}
 		if prov != ProvNone {
 			e.InputPerMillion = perM(rates, TierInput)
 			e.CacheWritePerMillion = perM(rates, TierCacheWrite)
@@ -191,4 +209,36 @@ func (r *Registry) EffectiveFor(host string) Effective {
 		return Effective{Host: host, Multiplier: 1}
 	}
 	return r.tab.Load().EffectiveFor(host)
+}
+
+// lowestThresholdFor reports the smallest long-context breakpoint on the row that would
+// win for this endpoint and model, or 0 if it has none.
+//
+// Resolves the row the same way Resolve does, then reads its thresholds before
+// flattening — which is the only place they survive.
+func (t *Table) lowestThresholdFor(endpoint, model string) int {
+	if t == nil {
+		return 0
+	}
+	forms := modelNameForms(strings.ToLower(strings.TrimSpace(model)))
+	var best *row
+	for i := range t.rows {
+		r := &t.rows[i]
+		if !matchHost(r.host, endpoint) || !r.model.match(forms) {
+			continue
+		}
+		if best == nil || r.prov > best.prov || (r.prov == best.prov && r.spec.beats(best.spec)) {
+			best = r
+		}
+	}
+	if best == nil {
+		return 0
+	}
+	lowest := 0
+	for _, th := range best.rates.Thresholds {
+		if th.AbovePromptTokens > 0 && (lowest == 0 || th.AbovePromptTokens < lowest) {
+			lowest = th.AbovePromptTokens
+		}
+	}
+	return lowest
 }

--- a/authbridge/authlib/pricing/describe_test.go
+++ b/authbridge/authlib/pricing/describe_test.go
@@ -1,0 +1,120 @@
+package pricing
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Describe answers "what rates is this process actually using", which no config file
+// can: the config shows what the operator wrote, not what the binary contributed.
+func TestDescribe_ShowsBundledRowsAndMultipliers(t *testing.T) {
+	reg := NewRegistry(mustBuild(t, nil))
+	d := reg.Describe()
+
+	if len(d.Rows) == 0 {
+		t.Fatal("no rows described")
+	}
+	var sawOpus5 bool
+	for _, r := range d.Rows {
+		if r.Model == "claude-opus-5" {
+			sawOpus5 = true
+			if r.InputPerMillion != 5.00 {
+				t.Errorf("opus-5 input = %v, want 5.00 (list, undscaled in the raw table)", r.InputPerMillion)
+			}
+			if r.Provenance != "bundled" {
+				t.Errorf("opus-5 provenance = %q, want bundled", r.Provenance)
+			}
+		}
+	}
+	if !sawOpus5 {
+		t.Error("claude-opus-5 missing from the described table")
+	}
+
+	// The shipped gateway discount has to be visible, or an operator cannot tell why
+	// their figures differ from vendor list.
+	var sawIBM bool
+	for _, m := range d.Multipliers {
+		if strings.Contains(m.Host, "res.ibm.com") {
+			sawIBM = true
+			if m.Factor != 0.76 || m.Provenance != "bundled" {
+				t.Errorf("ibm multiplier = %+v, want 0.76 bundled", m)
+			}
+		}
+	}
+	if !sawIBM {
+		t.Error("the shipped *.res.ibm.com multiplier is not described")
+	}
+}
+
+// The question an operator actually asks is per-endpoint: what will THIS gateway charge?
+// That needs resolution, including the multiplier, which a raw table dump cannot show.
+func TestDescribe_EffectiveForHostAppliesTheMultiplier(t *testing.T) {
+	reg := NewRegistry(mustBuild(t, nil))
+
+	eff := reg.EffectiveFor("ete-litellm.ai-models.vpc-int.res.ibm.com")
+	if eff.Multiplier != 0.76 {
+		t.Errorf("Multiplier = %v, want 0.76", eff.Multiplier)
+	}
+	if eff.MultiplierFrom != "bundled" {
+		t.Errorf("MultiplierFrom = %q, want bundled", eff.MultiplierFrom)
+	}
+	byModel := map[string]EffectiveRates{}
+	for _, m := range eff.Models {
+		byModel[m.Model] = m
+	}
+	// Measured on that gateway: 3.80 / 4.75 / 0.38 / 19.00.
+	got, ok := byModel["claude-opus-5"]
+	if !ok {
+		t.Fatalf("claude-opus-5 absent; got %d models", len(eff.Models))
+	}
+	for name, pair := range map[string][2]float64{
+		"input":       {got.InputPerMillion, 3.80},
+		"cache-write": {got.CacheWritePerMillion, 4.75},
+		"cache-read":  {got.CacheReadPerMillion, 0.38},
+		"output":      {got.OutputPerMillion, 19.00},
+	} {
+		if pair[0] < pair[1]-1e-9 || pair[0] > pair[1]+1e-9 {
+			t.Errorf("opus-5 %s = %v, want %v (list scaled by the gateway discount)", name, pair[0], pair[1])
+		}
+	}
+
+	// The vendor endpoint is unscaled, which is the whole reason the rule is scoped.
+	direct := reg.EffectiveFor("api.anthropic.com")
+	if direct.Multiplier != 1 {
+		t.Errorf("api.anthropic.com multiplier = %v, want 1", direct.Multiplier)
+	}
+}
+
+func TestDescribe_JSONRoundTrips(t *testing.T) {
+	// This is served over HTTP, so it has to survive encoding.
+	reg := NewRegistry(mustBuild(t, nil))
+	for name, v := range map[string]any{"table": reg.Describe(), "effective": reg.EffectiveFor("x.res.ibm.com")} {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(b) < 10 {
+			t.Errorf("%s encoded to %q", name, b)
+		}
+	}
+}
+
+func TestDescribe_NilRegistryIsEmptyNotAPanic(t *testing.T) {
+	var reg *Registry
+	if d := reg.Describe(); len(d.Rows) != 0 || len(d.Multipliers) != 0 {
+		t.Errorf("nil registry described %+v", d)
+	}
+	if e := reg.EffectiveFor("h"); e.Multiplier != 1 || len(e.Models) != 0 {
+		t.Errorf("nil registry effective = %+v", e)
+	}
+}
+
+func mustBuild(t *testing.T, c *Config) *Table {
+	t.Helper()
+	tab, err := Build(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tab
+}

--- a/authbridge/authlib/pricing/describe_test.go
+++ b/authbridge/authlib/pricing/describe_test.go
@@ -20,7 +20,7 @@ func TestDescribe_ShowsBundledRowsAndMultipliers(t *testing.T) {
 		if r.Model == "claude-opus-5" {
 			sawOpus5 = true
 			if r.InputPerMillion != 5.00 {
-				t.Errorf("opus-5 input = %v, want 5.00 (list, undscaled in the raw table)", r.InputPerMillion)
+				t.Errorf("opus-5 input = %v, want 5.00 (list, unscaled in the raw table)", r.InputPerMillion)
 			}
 			if r.Provenance != "bundled" {
 				t.Errorf("opus-5 provenance = %q, want bundled", r.Provenance)
@@ -117,4 +117,39 @@ func mustBuild(t *testing.T, c *Config) *Table {
 		t.Fatal(err)
 	}
 	return tab
+}
+
+// The bundled table ships long-context thresholds (four sonnet models at 200k), and
+// EffectiveFor resolves at prompt size 0 — so without a marker the host view quotes a
+// rate a long-context request will not be charged. That is precisely the failure this
+// package exists to remove, so it must not be reintroduced by the tool built to inspect
+// it.
+func TestDescribe_EffectiveFlagsLongContextTiers(t *testing.T) {
+	reg := NewRegistry(mustBuild(t, nil))
+	eff := reg.EffectiveFor("api.anthropic.com")
+
+	var withThresholds, checked int
+	for _, m := range eff.Models {
+		if m.LongContextAbove > 0 {
+			withThresholds++
+			if m.Model == "claude-sonnet-4-5" {
+				checked++
+				if m.LongContextAbove != 200_000 {
+					t.Errorf("sonnet-4-5 LongContextAbove = %d, want 200000", m.LongContextAbove)
+				}
+			}
+		}
+	}
+	if withThresholds == 0 {
+		t.Error("no model reports a long-context tier, but the bundled table ships four")
+	}
+	if checked == 0 {
+		t.Error("claude-sonnet-4-5 does not report its 200k tier")
+	}
+	// A model without thresholds must not claim one.
+	for _, m := range eff.Models {
+		if m.Model == "claude-opus-5" && m.LongContextAbove != 0 {
+			t.Errorf("opus-5 reports a long-context tier at %d; it has none", m.LongContextAbove)
+		}
+	}
 }

--- a/authbridge/authlib/pricing/handler.go
+++ b/authbridge/authlib/pricing/handler.go
@@ -1,0 +1,37 @@
+package pricing
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// Handler serves the pricing table for inspection on the diagnostic listener, beside
+// /config and /reload/status.
+//
+//	GET /pricing/table          the raw table: every row and multiplier, unscaled
+//	GET /pricing/table?host=H   what H actually charges, multiplier applied
+//
+// The host form is the one worth having. "Which rows exist" is answerable from the
+// source; "what will this gateway charge me" requires host scoping, specificity,
+// provenance precedence and the discount to be applied together, which is not
+// something a reader can carry out by eye — and is exactly the gap that let a 0.76x
+// gateway be reported at vendor list for months.
+func (r *Registry) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var body any
+		if host := req.URL.Query().Get("host"); host != "" {
+			body = r.EffectiveFor(host)
+		} else {
+			body = r.Describe()
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(body); err != nil {
+			// Matching the reloader's status handler: a broken pipe on a diagnostic
+			// endpoint is not worth an ERROR line.
+			slog.Debug("pricing: table encode failed", "error", err)
+		}
+	}
+}

--- a/authbridge/authlib/pricing/host.go
+++ b/authbridge/authlib/pricing/host.go
@@ -101,3 +101,14 @@ func validHostPattern(pattern string) error {
 	_, err := path.Match(pattern, "probe")
 	return err
 }
+
+// EndpointKey normalizes a request's target host the way rate resolution normalizes it:
+// lower-cased, port stripped.
+//
+// Exported so callers that key their own state on an endpoint — the drift reporter's
+// dedup set, for one — agree with matchHost about what counts as the same endpoint.
+// Keeping a private copy of this rule is how "GW.internal:443" and "gw.internal" came to
+// occupy two entries for one gateway.
+func EndpointKey(endpoint string) string {
+	return strings.ToLower(hostKey(endpoint))
+}

--- a/authbridge/authlib/pricing/multiplier.go
+++ b/authbridge/authlib/pricing/multiplier.go
@@ -59,26 +59,35 @@ func (m MultiplierRule) validate(what string) error {
 	return nil
 }
 
-// scale returns r with every set rate multiplied.
+// scale returns r with every set rate multiplied — Base and any long-context override.
 //
-// Long-context premiums scale too, and the ORDERING is what makes that true rather than
-// anything in this function: Resolve flattens with At(promptTotal) first, so whichever
-// threshold applies has already been folded into Base by the time scale runs. Missing
-// that would leave a discounted gateway correct below its breakpoint and wrong above it,
-// which shows up as an unexplained jump in reported cost on long sessions.
+// Resolve calls this on ALREADY-FLATTENED rates, so in that path Thresholds is empty and
+// the loop below does nothing. It is still written to scale them, because the alternative
+// readings are both wrong for any other caller: passing thresholds through unscaled
+// leaves one Rates value carrying two different scales, so a later At() would fold a
+// list-price premium onto a discounted base; dropping them loses the premium entirely and
+// silently underprices long requests. A discounted gateway discounts its long-context
+// tier too.
 //
-// An earlier version also walked r.Thresholds here. That branch was unreachable —
-// proven by putting a panic in it and watching the whole suite pass, including the test
-// that appeared to cover it — so it was removed rather than left to imply a guarantee it
-// never provided. If a caller ever scales UNFLATTENED rates, it needs adding back with a
-// test that reaches it.
+// Unreachable from Resolve is not the same as untested — TestRates_ScaleScalesThresholds
+// calls it directly, so the branch has coverage independent of its caller.
 func (r Rates) scale(f float64) Rates {
 	if f == 1 {
 		return r
 	}
-	out := Rates{Set: r.Set, Thresholds: r.Thresholds}
+	out := Rates{Set: r.Set}
 	for i := range r.Base {
 		out.Base[i] = r.Base[i] * f
+	}
+	if len(r.Thresholds) > 0 {
+		out.Thresholds = make([]ContextThreshold, len(r.Thresholds))
+		for i, th := range r.Thresholds {
+			scaled := ContextThreshold{AbovePromptTokens: th.AbovePromptTokens, Set: th.Set}
+			for tier := range th.Rate {
+				scaled.Rate[tier] = th.Rate[tier] * f
+			}
+			out.Thresholds[i] = scaled
+		}
 	}
 	return out
 }

--- a/authbridge/authlib/pricing/multiplier.go
+++ b/authbridge/authlib/pricing/multiplier.go
@@ -1,0 +1,85 @@
+package pricing
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+// MultiplierRule scales every rate that resolves for an endpoint.
+//
+// It exists because a gateway discount is a SCALAR, not a rate card. The IBM LiteLLM
+// gateways bill a uniform fraction of vendor list — measured at exactly 0.7600 across
+// three models and all four tiers, twelve figures agreeing to four decimal places.
+// Expressing that as twelve copied numbers has two costs a multiplier does not:
+//
+//   - Twelve chances to fumble a decimal place, in a file nothing validates against
+//     the gateway.
+//   - It goes stale silently the moment Anthropic reprices. The gateway's price is
+//     DERIVED from list, so a multiplier tracks a repricing automatically once the
+//     bundled table is refreshed, while copied rates keep reporting last quarter's
+//     numbers with no indication they are wrong.
+type MultiplierRule struct {
+	// Host is a glob matched against the request's target host, port stripped. Empty
+	// or "*" scales every endpoint.
+	Host string
+	// Factor multiplies each resolved rate. 1.0 means list.
+	Factor float64
+	// Prov records where the factor came from, so a scaled figure reports the weaker
+	// of its two sources rather than claiming to be operator-verified.
+	Prov Provenance
+}
+
+// maxMultiplier bounds the factor.
+//
+// The typo this catches is `multiplier: 76` for 0.76, which inflates every figure a
+// hundredfold and reads as entirely plausible in a config file. Nothing legitimate
+// marks a gateway up tenfold over vendor list, so anything past 10 is a mistake and
+// worth refusing at startup rather than reporting as spend.
+const maxMultiplier = 10.0
+
+func (m MultiplierRule) validate(what string) error {
+	switch {
+	case math.IsNaN(m.Factor) || math.IsInf(m.Factor, 0):
+		return fmt.Errorf("%s: multiplier must be a finite number", what)
+	case m.Factor <= 0:
+		// Zero would price the endpoint's entire traffic at nothing, which reads as
+		// "this gateway is free" rather than as the misconfiguration it is.
+		return fmt.Errorf("%s: multiplier must be > 0 (got %v); omit it to mean 1.0", what, m.Factor)
+	case m.Factor > maxMultiplier:
+		return fmt.Errorf("%s: multiplier %v exceeds the sanity bound of %v — did you mean %v? (it is a FRACTION of list, so a 24%% discount is 0.76)",
+			what, m.Factor, maxMultiplier, m.Factor/100)
+	}
+	if !anyHost(m.Host) {
+		if err := validHostPattern(strings.ToLower(m.Host)); err != nil {
+			return fmt.Errorf("%s: multiplier host pattern %q: %w", what, m.Host, err)
+		}
+	}
+	return nil
+}
+
+// scale returns r with every set rate, and every threshold override, multiplied.
+//
+// Thresholds scale too. Missing that would make a discounted gateway correct below
+// its long-context breakpoint and wrong above it — the kind of split that shows up as
+// an unexplained jump in reported cost on long sessions.
+func (r Rates) scale(f float64) Rates {
+	if f == 1 {
+		return r
+	}
+	out := Rates{Set: r.Set}
+	for i := range r.Base {
+		out.Base[i] = r.Base[i] * f
+	}
+	if len(r.Thresholds) > 0 {
+		out.Thresholds = make([]ContextThreshold, len(r.Thresholds))
+		for i, th := range r.Thresholds {
+			scaled := ContextThreshold{AbovePromptTokens: th.AbovePromptTokens, Set: th.Set}
+			for j := range th.Rate {
+				scaled.Rate[j] = th.Rate[j] * f
+			}
+			out.Thresholds[i] = scaled
+		}
+	}
+	return out
+}

--- a/authbridge/authlib/pricing/multiplier.go
+++ b/authbridge/authlib/pricing/multiplier.go
@@ -8,9 +8,9 @@ import (
 
 // MultiplierRule scales every rate that resolves for an endpoint.
 //
-// It exists because a gateway discount is a SCALAR, not a rate card. The IBM LiteLLM
-// gateways bill a uniform fraction of vendor list — measured at exactly 0.7600 across
-// three models and all four tiers, twelve figures agreeing to four decimal places.
+// It exists because a gateway discount is a SCALAR, not a rate card. Some gateways bill a
+// uniform fraction of vendor list — one was measured at exactly 0.7600 across three
+// models and all four tiers, twelve figures agreeing to four decimal places.
 // Expressing that as twelve copied numbers has two costs a multiplier does not:
 //
 //   - Twelve chances to fumble a decimal place, in a file nothing validates against
@@ -25,8 +25,9 @@ type MultiplierRule struct {
 	Host string
 	// Factor multiplies each resolved rate. 1.0 means list.
 	Factor float64
-	// Prov records where the factor came from, so a scaled figure reports the weaker
-	// of its two sources rather than claiming to be operator-verified.
+	// Prov records where the factor came from. A scaled figure reports the STRONGER of
+	// its two sources, and it also ranks these rules against each other — an operator's
+	// factor for an endpoint beats the shipped one. See Resolve for why stronger.
 	Prov Provenance
 }
 
@@ -58,28 +59,26 @@ func (m MultiplierRule) validate(what string) error {
 	return nil
 }
 
-// scale returns r with every set rate, and every threshold override, multiplied.
+// scale returns r with every set rate multiplied.
 //
-// Thresholds scale too. Missing that would make a discounted gateway correct below
-// its long-context breakpoint and wrong above it — the kind of split that shows up as
-// an unexplained jump in reported cost on long sessions.
+// Long-context premiums scale too, and the ORDERING is what makes that true rather than
+// anything in this function: Resolve flattens with At(promptTotal) first, so whichever
+// threshold applies has already been folded into Base by the time scale runs. Missing
+// that would leave a discounted gateway correct below its breakpoint and wrong above it,
+// which shows up as an unexplained jump in reported cost on long sessions.
+//
+// An earlier version also walked r.Thresholds here. That branch was unreachable —
+// proven by putting a panic in it and watching the whole suite pass, including the test
+// that appeared to cover it — so it was removed rather than left to imply a guarantee it
+// never provided. If a caller ever scales UNFLATTENED rates, it needs adding back with a
+// test that reaches it.
 func (r Rates) scale(f float64) Rates {
 	if f == 1 {
 		return r
 	}
-	out := Rates{Set: r.Set}
+	out := Rates{Set: r.Set, Thresholds: r.Thresholds}
 	for i := range r.Base {
 		out.Base[i] = r.Base[i] * f
-	}
-	if len(r.Thresholds) > 0 {
-		out.Thresholds = make([]ContextThreshold, len(r.Thresholds))
-		for i, th := range r.Thresholds {
-			scaled := ContextThreshold{AbovePromptTokens: th.AbovePromptTokens, Set: th.Set}
-			for j := range th.Rate {
-				scaled.Rate[j] = th.Rate[j] * f
-			}
-			out.Thresholds[i] = scaled
-		}
 	}
 	return out
 }

--- a/authbridge/authlib/pricing/multiplier_test.go
+++ b/authbridge/authlib/pricing/multiplier_test.go
@@ -171,3 +171,38 @@ func TestMultiplier_EndpointNeedsNoModels(t *testing.T) {
 		t.Fatalf("rejected a multiplier-only endpoint: %v", err)
 	}
 }
+
+// Two behaviours the docs now promise, both surprising enough that they must be pinned:
+// a configured catch-all outranks a shipped host-specific rule (provenance decides before
+// specificity), and an explicit 1.0 is how an operator drops a shipped discount.
+func TestMultiplier_ConfiguredCatchAllOutranksShippedSpecific(t *testing.T) {
+	one := 1.0
+	nine := 0.9
+	shipped := "ete-litellm.ai-models.vpc-int.res.ibm.com"
+
+	// Control: shipped rule alone gives 0.76.
+	base := mustBuild(t, nil)
+	if f, prov := base.multiplierFor(shipped); f != 0.76 || prov != ProvBundled {
+		t.Fatalf("shipped rule = %v/%v, want 0.76/bundled", f, prov)
+	}
+
+	t.Run("catch-all replaces it", func(t *testing.T) {
+		tab := mustBuild(t, &Config{Endpoints: []EndpointConfig{{Hosts: []string{"*"}, Multiplier: &nine}}})
+		f, prov := tab.multiplierFor(shipped)
+		if f != 0.9 || prov != ProvConfigured {
+			t.Errorf("multiplierFor(%s) = %v/%v, want 0.9/configured — a configured catch-all must outrank the shipped specific rule", shipped, f, prov)
+		}
+	})
+
+	t.Run("explicit 1.0 drops the shipped discount", func(t *testing.T) {
+		tab := mustBuild(t, &Config{Endpoints: []EndpointConfig{{Hosts: []string{shipped}, Multiplier: &one}}})
+		if f, _ := tab.multiplierFor(shipped); f != 1 {
+			t.Errorf("multiplierFor = %v, want 1 — an explicit 1.0 must cancel the shipped factor", f)
+		}
+		// And the rates must come back at list, not scaled.
+		rates, prov := tab.Resolve(shipped, "claude-opus-5", 0)
+		if got := perM(rates, TierInput); got != 5 {
+			t.Errorf("input = %v/Mtok, want the unscaled 5 (prov %v)", got, prov)
+		}
+	})
+}

--- a/authbridge/authlib/pricing/multiplier_test.go
+++ b/authbridge/authlib/pricing/multiplier_test.go
@@ -255,3 +255,86 @@ func TestRates_ScaleScalesThresholds(t *testing.T) {
 		t.Errorf("above the threshold = %v, want the scaled premium 7.5e-6", b.Base[TierInput])
 	}
 }
+
+// An operator who measures their gateway and pins the real per-model rates must not have
+// those rates scaled again by a shipped multiplier. The pinned figures are already
+// post-discount; scaling them understates spend by the factor, and understating is the
+// direction that hides cost.
+func TestMultiplier_ShippedFactorDoesNotScaleConfiguredRates(t *testing.T) {
+	shipped := "ete-litellm.ai-models.vpc-int.res.ibm.com"
+	// The operator's own measurement: 3.80/Mtok input, i.e. list x 0.76 already.
+	var pinned Rates
+	pinned.Base[TierInput] = 3.8 / tokensPerMillion
+	pinned.Set[TierInput] = true
+
+	tab, err := NewTable(
+		[]Entry{{Host: shipped, Model: "claude-opus-5", Rates: pinned, Prov: ProvConfigured}},
+		bundledMultipliers()...,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rates, prov := tab.Resolve(shipped, "claude-opus-5", 0)
+	if got := perM(rates, TierInput); got != 3.8 {
+		t.Errorf("input = %v/Mtok, want the pinned 3.8 unscaled; 2.888 means the shipped 0.76 was applied on top", got)
+	}
+	if prov != ProvConfigured {
+		t.Errorf("provenance = %v, want configured", prov)
+	}
+	// A CONFIGURED multiplier still applies to configured rates — the operator asked
+	// for both, and the host view shows the factor.
+	half := 0.5
+	tab2, err := Build(&Config{Endpoints: []EndpointConfig{{
+		Hosts:      []string{shipped},
+		Multiplier: &half,
+		Models: map[string]ModelConfig{"claude-opus-5": {
+			TierRates: TierRates{InputCostPerMillion: 3.8},
+		}},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := perM(mustResolve(t, tab2, shipped, "claude-opus-5"), TierInput); got != 1.9 {
+		t.Errorf("configured x configured = %v/Mtok, want 1.9", got)
+	}
+}
+
+func mustResolve(t *testing.T, tab *Table, host, model string) Rates {
+	t.Helper()
+	r, prov := tab.Resolve(host, model, 0)
+	if prov == ProvNone {
+		t.Fatalf("%s/%s resolved unpriced", host, model)
+	}
+	return r
+}
+
+// Both checks the rate rows apply, applied to multiplier rules too. Each failure is
+// silent and in the same direction: the gateway stays at list, overstating a discount.
+func TestMultiplier_RejectsPortAndDuplicateRules(t *testing.T) {
+	t.Run("port in the pattern", func(t *testing.T) {
+		_, err := NewTable(nil, MultiplierRule{Host: "gw.internal:4000", Factor: 0.9, Prov: ProvConfigured})
+		if err == nil {
+			t.Fatal("accepted a host pattern with a port, which can never match")
+		}
+		if !strings.Contains(err.Error(), `use "gw.internal"`) {
+			t.Errorf("error does not name the fix: %v", err)
+		}
+	})
+	t.Run("duplicate host and provenance", func(t *testing.T) {
+		_, err := NewTable(nil,
+			MultiplierRule{Host: "gw.internal", Factor: 0.9, Prov: ProvConfigured},
+			MultiplierRule{Host: "gw.internal", Factor: 0.5, Prov: ProvConfigured},
+		)
+		if err == nil {
+			t.Fatal("accepted two factors for one host; one would be silently ignored")
+		}
+	})
+	t.Run("same host at different provenance is fine", func(t *testing.T) {
+		if _, err := NewTable(nil,
+			MultiplierRule{Host: "gw.internal", Factor: 0.9, Prov: ProvBundled},
+			MultiplierRule{Host: "gw.internal", Factor: 0.5, Prov: ProvConfigured},
+		); err != nil {
+			t.Fatalf("rejected a legitimate operator override of a shipped rule: %v", err)
+		}
+	})
+}

--- a/authbridge/authlib/pricing/multiplier_test.go
+++ b/authbridge/authlib/pricing/multiplier_test.go
@@ -204,5 +204,54 @@ func TestMultiplier_ConfiguredCatchAllOutranksShippedSpecific(t *testing.T) {
 		if got := perM(rates, TierInput); got != 5 {
 			t.Errorf("input = %v/Mtok, want the unscaled 5 (prov %v)", got, prov)
 		}
+		// Reported CONFIGURED, not bundled. Writing `multiplier: 1.0` is an operator
+		// telling us their endpoint bills at list — the same act as writing 0.76 — so
+		// reporting bundled would send them a WarnIfUnpinned line about the endpoint
+		// they just pinned.
+		if prov != ProvConfigured {
+			t.Errorf("provenance = %v, want configured for a deliberate 1.0 pin", prov)
+		}
 	})
+}
+
+// scale is unreachable from Resolve with thresholds present, because Resolve flattens
+// first. Tested directly anyway: "no caller reaches it today" is how the previous version
+// came to pass thresholds through unscaled without anything noticing.
+//
+// 0.5 is used deliberately — halving is exact in binary, so these are equalities rather
+// than tolerances.
+func TestRates_ScaleScalesThresholds(t *testing.T) {
+	var r Rates
+	r.Base[TierInput] = 10e-6
+	r.Set[TierInput] = true
+	r.Thresholds = []ContextThreshold{{AbovePromptTokens: 200_000}}
+	r.Thresholds[0].Rate[TierInput] = 15e-6
+	r.Thresholds[0].Set[TierInput] = true
+
+	got := r.scale(0.5)
+	if got.Base[TierInput] != 5e-6 {
+		t.Errorf("base = %v, want 5e-6", got.Base[TierInput])
+	}
+	if len(got.Thresholds) != 1 {
+		t.Fatalf("thresholds dropped: %+v", got.Thresholds)
+	}
+	if got.Thresholds[0].Rate[TierInput] != 7.5e-6 {
+		t.Errorf("threshold rate = %v, want 7.5e-6 — a discounted gateway discounts its long-context tier too",
+			got.Thresholds[0].Rate[TierInput])
+	}
+	if r.Thresholds[0].Rate[TierInput] != 15e-6 {
+		t.Errorf("scale mutated the receiver's thresholds: %v", r.Thresholds[0].Rate[TierInput])
+	}
+
+	// The property that makes the ordering safe: scaling and flattening COMMUTE. Resolve
+	// flattens then scales; any other caller may scale then flatten. Both must charge the
+	// same, which is exactly what passing thresholds through unscaled broke.
+	a := r.At(500_000).scale(0.5)
+	b := r.scale(0.5).At(500_000)
+	if a.Base != b.Base || a.Set != b.Set {
+		t.Errorf("scale and At do not commute:\n flatten-then-scale %v\n scale-then-flatten %v", a.Base, b.Base)
+	}
+	if b.Base[TierInput] != 7.5e-6 {
+		t.Errorf("above the threshold = %v, want the scaled premium 7.5e-6", b.Base[TierInput])
+	}
 }

--- a/authbridge/authlib/pricing/multiplier_test.go
+++ b/authbridge/authlib/pricing/multiplier_test.go
@@ -1,0 +1,173 @@
+package pricing
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The IBM LiteLLM gateways bill a uniform fraction of vendor list — measured at
+// exactly 0.7600 across three models and all four tiers. That is a scalar, not a rate
+// card, so it is expressed as a multiplier: one number instead of twelve, and it tracks
+// upstream repricing automatically because the gateway's price is DERIVED from list.
+func TestMultiplier_BundledDefaultCoversTheIBMGateways(t *testing.T) {
+	tab, err := Build(nil) // no operator config whatsoever
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputPerM := func(host, model string) (float64, Provenance) {
+		r, p := tab.Resolve(host, model, 0)
+		v, _ := r.For(TierInput)
+		return v * tokensPerMillion, p
+	}
+
+	// The real gateway, with and without a port.
+	for _, host := range []string{
+		"ete-litellm.ai-models.vpc-int.res.ibm.com",
+		"ete-litellm.ai-models.vpc-int.res.ibm.com:443",
+	} {
+		got, prov := inputPerM(host, "claude-opus-5")
+		if want := 5.00 * 0.76; got < want-1e-9 || got > want+1e-9 {
+			t.Errorf("%s opus-5 input = %.4f/Mtok, want %.4f (list x 0.76)", host, got, want)
+		}
+		if prov != ProvBundled {
+			t.Errorf("%s provenance = %s, want bundled (rate and multiplier both shipped)", host, prov)
+		}
+	}
+
+	// Direct to the vendor must stay at LIST. A global default would understate this
+	// by 24% — silently, which is the failure mode the whole package exists to avoid.
+	if got, _ := inputPerM("api.anthropic.com", "claude-opus-5"); got != 5.00 {
+		t.Errorf("api.anthropic.com opus-5 input = %.4f/Mtok, want 5.00 (list, unscaled)", got)
+	}
+	// And someone else's gateway is not covered by the IBM rule.
+	if got, _ := inputPerM("litellm.example.com", "claude-opus-5"); got != 5.00 {
+		t.Errorf("third-party gateway = %.4f/Mtok, want 5.00 (unscaled)", got)
+	}
+}
+
+// Every tier scales, not just input — the discount was measured as uniform.
+func TestMultiplier_AppliesToEveryTier(t *testing.T) {
+	tab, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const host = "ete-litellm.ai-models.vpc-int.res.ibm.com"
+	// Measured on the gateway: opus-5 3.80 / 4.75 / 0.38 / 19.00.
+	for _, tc := range []struct {
+		tier Tier
+		want float64
+	}{
+		{TierInput, 3.80}, {TierCacheWrite, 4.75}, {TierCacheRead, 0.38}, {TierOutput, 19.00},
+	} {
+		r, _ := tab.Resolve(host, "claude-opus-5", 0)
+		v, ok := r.For(tc.tier)
+		if !ok {
+			t.Errorf("tier %d unpriced", tc.tier)
+			continue
+		}
+		if got := v * tokensPerMillion; got < tc.want-1e-9 || got > tc.want+1e-9 {
+			t.Errorf("tier %d = %.4f/Mtok, want %.4f (measured on the gateway)", tc.tier, got, tc.want)
+		}
+	}
+	// Haiku included, cache tiers too, per the decision to apply it uniformly.
+	r, _ := tab.Resolve(host, "claude-haiku-4-5", 0)
+	if v, ok := r.For(TierCacheRead); !ok || v*tokensPerMillion < 0.076-1e-9 || v*tokensPerMillion > 0.076+1e-9 {
+		t.Errorf("haiku cache-read = %.5f/Mtok (ok=%v), want 0.076", v*tokensPerMillion, ok)
+	}
+}
+
+// Long-context thresholds must scale as well, or a discounted gateway would be
+// correct below 200k and wrong above it.
+func TestMultiplier_ScalesContextThresholds(t *testing.T) {
+	var r Rates
+	r.Base[TierInput], r.Set[TierInput] = 3.00/tokensPerMillion, true
+	r.Thresholds = []ContextThreshold{{
+		AbovePromptTokens: 200_000,
+		Rate:              [numTiers]float64{TierInput: 6.00 / tokensPerMillion},
+		Set:               [numTiers]bool{TierInput: true},
+	}}
+	half := 0.5
+	tab, err := NewTable([]Entry{{Host: "gw", Model: "*", Rates: r, Prov: ProvConfigured}},
+		MultiplierRule{Host: "gw", Factor: half, Prov: ProvConfigured})
+	if err != nil {
+		t.Fatal(err)
+	}
+	below, _ := tab.Resolve("gw", "m", 100_000)
+	above, _ := tab.Resolve("gw", "m", 300_000)
+	if v, _ := below.For(TierInput); v*tokensPerMillion != 1.50 {
+		t.Errorf("below threshold = %.2f/Mtok, want 1.50", v*tokensPerMillion)
+	}
+	if v, _ := above.For(TierInput); v*tokensPerMillion != 3.00 {
+		t.Errorf("above threshold = %.2f/Mtok, want 3.00 (the premium, halved)", v*tokensPerMillion)
+	}
+}
+
+func TestMultiplier_ConfiguredOverridesBundled(t *testing.T) {
+	var c Config
+	src := `
+endpoints:
+  - hosts: ["ete-litellm.ai-models.vpc-int.res.ibm.com"]
+    multiplier: 0.50
+`
+	if err := yaml.Unmarshal([]byte(src), &c); err != nil {
+		t.Fatal(err)
+	}
+	tab, err := Build(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An exact host beats the bundled *.res.ibm.com glob, and a configured multiplier
+	// outranks a bundled one — an operator whose deal changed says so once.
+	r, p := tab.Resolve("ete-litellm.ai-models.vpc-int.res.ibm.com", "claude-opus-5", 0)
+	v, _ := r.For(TierInput)
+	if got := v * tokensPerMillion; got != 2.50 {
+		t.Errorf("input = %.2f/Mtok, want 2.50 (list x 0.50)", got)
+	}
+	if p != ProvConfigured {
+		t.Errorf("provenance = %s, want configured — the operator supplied the multiplier", p)
+	}
+}
+
+func TestMultiplier_Validation(t *testing.T) {
+	for name, src := range map[string]string{
+		// 76 instead of 0.76 inflates every figure 100x and looks plausible in YAML.
+		"typo: whole number":         "endpoints:\n  - hosts: [gw]\n    multiplier: 76\n",
+		"zero would free everything": "endpoints:\n  - hosts: [gw]\n    multiplier: 0\n",
+		"negative":                   "endpoints:\n  - hosts: [gw]\n    multiplier: -1\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var c Config
+			if err := yaml.Unmarshal([]byte(src), &c); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Build(&c)
+			if err == nil {
+				t.Fatalf("accepted %s", name)
+			}
+			if !strings.Contains(err.Error(), "multiplier") {
+				t.Errorf("error %q does not name the field", err)
+			}
+		})
+	}
+	// 1.0 is legal and means "no discount", which is worth being able to state.
+	var c Config
+	if err := yaml.Unmarshal([]byte("endpoints:\n  - hosts: [gw]\n    multiplier: 1.0\n"), &c); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Build(&c); err != nil {
+		t.Errorf("rejected multiplier 1.0: %v", err)
+	}
+}
+
+// A multiplier-only endpoint needs no models block: it scales what already resolves.
+func TestMultiplier_EndpointNeedsNoModels(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("endpoints:\n  - hosts: [gw]\n    multiplier: 0.5\n"), &c); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Build(&c); err != nil {
+		t.Fatalf("rejected a multiplier-only endpoint: %v", err)
+	}
+}

--- a/authbridge/authlib/pricing/table.go
+++ b/authbridge/authlib/pricing/table.go
@@ -324,6 +324,10 @@ func NewTable(entries []Entry, mults ...MultiplierRule) (*Table, error) {
 			},
 		})
 	}
+	// Multiplier rules get the SAME two checks as rate rows above. They were skipped
+	// here, and both failures are silent in the same direction: a rule that never
+	// matches leaves its gateway at vendor list, which overstates a discounted gateway.
+	seenMult := make(map[string]struct{}, len(mults))
 	for i, m := range mults {
 		where := fmt.Sprintf("pricing multiplier[%d]", i)
 		if m.Host != "" {
@@ -338,6 +342,23 @@ func NewTable(entries []Entry, mults ...MultiplierRule) (*Table, error) {
 			return nil, fmt.Errorf("%s: provenance %d is not a table level", where, int(m.Prov))
 		}
 		host := strings.ToLower(m.Host)
+		// A port in the pattern can never match, because hostKey strips the port from
+		// the endpoint and never from the pattern. Copying an endpoint out of a URL is
+		// the likeliest way to write this field, so name the fix.
+		if !anyHost(host) {
+			if bare := hostKey(host); bare != host {
+				return nil, fmt.Errorf("%s: host pattern must not include a port (ports are stripped from the endpoint before matching, so this would never match); use %q", where, bare)
+			}
+		}
+		// Two rules with the same host and provenance rank equal, so multiplierFor keeps
+		// whichever came first and the other factor is silently ignored — and which one
+		// wins depends on config iteration order. Rejected, exactly as duplicate rate
+		// rows are.
+		dupKey := host + "\x00" + m.Prov.String()
+		if _, dup := seenMult[dupKey]; dup {
+			return nil, fmt.Errorf("%s: duplicate multiplier for this host at %s provenance; one of the two factors would be silently ignored", where, m.Prov)
+		}
+		seenMult[dupKey] = struct{}{}
 		t.mults = append(t.mults, multRule{
 			host:   host,
 			factor: m.Factor,
@@ -401,6 +422,21 @@ func (t *Table) Resolve(endpoint, model string, promptTotal int) (Rates, Provena
 	// already pinned. The weaker reading looks more conservative and is in fact less
 	// informative.
 	f, mprov := t.multiplierFor(endpoint)
+	// A multiplier WEAKER than the rates it would scale is dropped.
+	//
+	// The case is an operator who measured their gateway and pinned the real per-model
+	// rates for a host that also carries a shipped multiplier: the pinned figures are
+	// already post-discount, so scaling them again understates spend by the factor —
+	// ~24% for the shipped 0.76, and understating is the direction this package treats
+	// as dangerous, because it hides cost rather than exaggerating it.
+	//
+	// Framed as provenance rather than as a special case for bundled: a scalar derived
+	// from list may only scale rates that are themselves list-derived. Configured rates
+	// with a configured multiplier still both apply — the operator asked for both, and
+	// `abctl pricing --host` shows the factor being applied.
+	if mprov < prov {
+		f, mprov = 1, ProvNone
+	}
 	// Provenance is bumped OUTSIDE the f != 1 guard. An operator who writes
 	// `multiplier: 1.0` to say "this endpoint bills at list" has told us about their
 	// gateway just as much as one who writes 0.76 — that is the whole rationale above —

--- a/authbridge/authlib/pricing/table.go
+++ b/authbridge/authlib/pricing/table.go
@@ -386,18 +386,7 @@ func (t *Table) Resolve(endpoint, model string, promptTotal int) (Rates, Provena
 	if t == nil {
 		return Rates{}, ProvNone
 	}
-	// Built once per request, not per row: every row matches against the same forms.
-	forms := modelNameForms(strings.ToLower(strings.TrimSpace(model)))
-	var best *row
-	for i := range t.rows {
-		r := &t.rows[i]
-		if !matchHost(r.host, endpoint) || !r.model.match(forms) {
-			continue
-		}
-		if best == nil || r.prov > best.prov || (r.prov == best.prov && r.spec.beats(best.spec)) {
-			best = r
-		}
-	}
+	best := t.bestRow(endpoint, model)
 	if best == nil {
 		return Rates{}, ProvNone
 	}
@@ -411,13 +400,44 @@ func (t *Table) Resolve(endpoint, model string, promptTotal int) (Rates, Provena
 	// gateway, so reporting bundled would send them to pin rates they have effectively
 	// already pinned. The weaker reading looks more conservative and is in fact less
 	// informative.
-	if f, mprov := t.multiplierFor(endpoint); f != 1 {
+	f, mprov := t.multiplierFor(endpoint)
+	// Provenance is bumped OUTSIDE the f != 1 guard. An operator who writes
+	// `multiplier: 1.0` to say "this endpoint bills at list" has told us about their
+	// gateway just as much as one who writes 0.76 — that is the whole rationale above —
+	// and gating the bump on the factor being interesting would report their deliberate
+	// pin as bundled, then send them a WarnIfUnpinned line telling them to pin it.
+	// multiplierFor returns ProvNone when nothing matches, so this is a no-op then.
+	if mprov > prov {
+		prov = mprov
+	}
+	if f != 1 {
 		rates = rates.scale(f)
-		if mprov > prov {
-			prov = mprov
-		}
 	}
 	return rates, prov
+}
+
+// bestRow picks the row that wins for one (endpoint, model) pair, or nil.
+//
+// Shared with the describe path rather than reimplemented there: two copies of this
+// ranking would diverge the first time it is touched, and the divergence would be silent
+// — a marker or an annotation attached to a different row than the one being charged.
+func (t *Table) bestRow(endpoint, model string) *row {
+	if t == nil {
+		return nil
+	}
+	// Built once per call, not per row: every row matches against the same forms.
+	forms := modelNameForms(strings.ToLower(strings.TrimSpace(model)))
+	var best *row
+	for i := range t.rows {
+		r := &t.rows[i]
+		if !matchHost(r.host, endpoint) || !r.model.match(forms) {
+			continue
+		}
+		if best == nil || r.prov > best.prov || (r.prov == best.prov && r.spec.beats(best.spec)) {
+			best = r
+		}
+	}
+	return best
 }
 
 var _ Resolver = (*Table)(nil)

--- a/authbridge/authlib/pricing/table.go
+++ b/authbridge/authlib/pricing/table.go
@@ -23,7 +23,21 @@ type Entry struct {
 // Table is an immutable resolved rate table. Build one with NewTable; never
 // mutate one that is live, because a Registry hands the same pointer to every
 // concurrent reader.
-type Table struct{ rows []row }
+type Table struct {
+	rows []row
+	// mults are endpoint multiplier rules, most specific first. Kept separate from
+	// rows because a multiplier is a property of the ENDPOINT, not of a (host, model)
+	// pair: one rule scales every model that gateway serves, including ones no row
+	// names explicitly.
+	mults []multRule
+}
+
+type multRule struct {
+	host   string
+	spec   specificity
+	factor float64
+	prov   Provenance
+}
 
 type row struct {
 	host  string // lower-cased; "" or "*" means any
@@ -229,7 +243,7 @@ func (s specificity) beats(o specificity) bool {
 
 // NewTable compiles entries into a table, rejecting rows that cannot mean
 // anything useful.
-func NewTable(entries []Entry) (*Table, error) {
+func NewTable(entries []Entry, mults ...MultiplierRule) (*Table, error) {
 	t := &Table{rows: make([]row, 0, len(entries))}
 	// Duplicate rows were silently first-wins, so a config listing the same model
 	// twice under one endpoint had one of its rates quietly ignored — and which one
@@ -310,7 +324,55 @@ func NewTable(entries []Entry) (*Table, error) {
 			},
 		})
 	}
+	for i, m := range mults {
+		where := fmt.Sprintf("pricing multiplier[%d]", i)
+		if m.Host != "" {
+			where = fmt.Sprintf("pricing multiplier for host %q", m.Host)
+		}
+		if err := m.validate(where); err != nil {
+			return nil, err
+		}
+		switch m.Prov {
+		case ProvBundled, ProvDiscovered, ProvConfigured:
+		default:
+			return nil, fmt.Errorf("%s: provenance %d is not a table level", where, int(m.Prov))
+		}
+		host := strings.ToLower(m.Host)
+		t.mults = append(t.mults, multRule{
+			host:   host,
+			factor: m.Factor,
+			prov:   m.Prov,
+			spec: specificity{
+				namedHost: !anyHost(host),
+				exactHost: !anyHost(host) && (isIPv6Literal(host) || !strings.ContainsAny(host, globMeta)),
+				hostLen:   hostRankLen(host),
+				pattern:   host,
+			},
+		})
+	}
 	return t, nil
+}
+
+// multiplierFor returns the most specific matching factor and its provenance.
+//
+// Ranked by the same host rules as rate rows — a named host beats a catch-all, an exact
+// host beats a glob, a longer glob beats a shorter one — with provenance deciding first
+// so an operator's explicit factor outranks the shipped one for the same endpoint.
+func (t *Table) multiplierFor(endpoint string) (float64, Provenance) {
+	var best *multRule
+	for i := range t.mults {
+		m := &t.mults[i]
+		if !matchHost(m.host, endpoint) {
+			continue
+		}
+		if best == nil || m.prov > best.prov || (m.prov == best.prov && m.spec.beats(best.spec)) {
+			best = m
+		}
+	}
+	if best == nil {
+		return 1, ProvNone
+	}
+	return best.factor, best.prov
 }
 
 // Resolve returns the rates for one (endpoint, model) pair and where they came
@@ -339,7 +401,23 @@ func (t *Table) Resolve(endpoint, model string, promptTotal int) (Rates, Provena
 	if best == nil {
 		return Rates{}, ProvNone
 	}
-	return best.rates.At(promptTotal), best.prov
+	rates, prov := best.rates.At(promptTotal), best.prov
+	// A scaled figure reports the STRONGER of its two sources: bundled x bundled stays
+	// bundled, but either half configured makes the result configured.
+	//
+	// Because "bundled" is the label that means "you have told us nothing about this
+	// endpoint, expect it to be wrong" — it is what drives WarnIfUnpinned and what
+	// abctl annotates. An operator who set a multiplier HAS told us about their
+	// gateway, so reporting bundled would send them to pin rates they have effectively
+	// already pinned. The weaker reading looks more conservative and is in fact less
+	// informative.
+	if f, mprov := t.multiplierFor(endpoint); f != 1 {
+		rates = rates.scale(f)
+		if mprov > prov {
+			prov = mprov
+		}
+	}
+	return rates, prov
 }
 
 var _ Resolver = (*Table)(nil)

--- a/authbridge/authlib/runtimeutil/runtimeutil.go
+++ b/authbridge/authlib/runtimeutil/runtimeutil.go
@@ -121,9 +121,10 @@ func StartHealthServer(inboundH, outboundH *pipeline.Holder, addr string) (*http
 // in a goroutine, and returns the server for graceful shutdown. A bind failure
 // is returned so the caller can decide how to handle it (the mains log.Fatalf);
 // a serve-time failure after bind is logged.
-func StartStatServer(cfg *config.Config, cfgProvider observe.ConfigProvider, statsProvider observe.StatsProvider, reloadStatus http.Handler, addr string) (*observe.StatServer, error) {
+func StartStatServer(cfg *config.Config, cfgProvider observe.ConfigProvider, statsProvider observe.StatsProvider, reloadStatus, pricingTable http.Handler, addr string) (*observe.StatServer, error) {
 	srv := observe.NewStatServer(addr, cfgProvider, statsProvider,
-		observe.WithReloadStatus(reloadStatus))
+		observe.WithReloadStatus(reloadStatus),
+		observe.WithPricingTable(pricingTable))
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, err

--- a/authbridge/cmd/abctl/cmd_pricing.go
+++ b/authbridge/cmd/abctl/cmd_pricing.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// runPricing renders the rates the running proxy is actually using.
+//
+// This exists because no config file can answer the question. `pricing:` shows what the
+// operator wrote; the figures a request is charged come from that PLUS a rate table
+// compiled into the binary PLUS any shipped gateway discount. Storing the table in the
+// config instead would freeze every install at the rates current on its install date,
+// silently, because that file is written once and never refreshed — which is the exact
+// staleness the pricing work was done to remove.
+//
+// So: not stored, inspectable. And with --host it applies host scoping, specificity,
+// provenance precedence and the multiplier together, which is not something a reader
+// can carry out by eye over a rate table.
+func runPricing(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("abctl pricing", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	host := fs.String("host", "", "show the rates this endpoint is actually charged, discount applied")
+	asJSON := fs.Bool("json", false, "emit the raw JSON from the proxy")
+	statsURL := fs.String("stats-url", defaultCortexStatsURL, "base URL of the proxy's stat server")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `abctl pricing — show the model rates Cortex is using
+
+Usage:
+  abctl pricing                     every row in the table, unscaled
+  abctl pricing --host <gateway>    what that endpoint is charged, discount applied
+  abctl pricing --json              raw JSON
+
+The rates come from a table built into the binary (vendor list, refreshed per release),
+your `+"`pricing:`"+` config, and any gateway discount Cortex ships. --host is the useful
+form: it resolves all three the way a request would.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	u := strings.TrimSuffix(*statsURL, "/") + "/pricing/table"
+	if *host != "" {
+		u += "?host=" + *host
+	}
+	body, err := fetchPricing(u)
+	if err != nil {
+		fmt.Fprintf(stderr, "abctl pricing: %v\n", err)
+		fmt.Fprintf(stderr, "  is Cortex running? `abctl service status`\n")
+		return 1
+	}
+	if *asJSON {
+		fmt.Fprintln(stdout, string(body))
+		return 0
+	}
+	if *host != "" {
+		return renderEffective(body, stdout, stderr)
+	}
+	return renderTable(body, stdout, stderr)
+}
+
+func fetchPricing(url string) ([]byte, error) {
+	c := &http.Client{Timeout: 10 * time.Second}
+	resp, err := c.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach the stat server at %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%s returned 404 — this proxy predates the pricing endpoint", url)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s returned HTTP %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+}
+
+// effective mirrors pricing.Effective. Declared here rather than imported so abctl
+// keeps decoding a wire shape rather than linking the pricing package's internals; the
+// field names are what the JSON contract pins.
+type effective struct {
+	Host           string  `json:"host"`
+	Multiplier     float64 `json:"multiplier"`
+	MultiplierFrom string  `json:"multiplierFrom"`
+	Models         []struct {
+		Model      string  `json:"model"`
+		Provenance string  `json:"provenance"`
+		Unpriced   bool    `json:"unpriced"`
+		In         float64 `json:"inputPerMillion"`
+		CW         float64 `json:"cacheWritePerMillion"`
+		CR         float64 `json:"cacheReadPerMillion"`
+		Out        float64 `json:"outputPerMillion"`
+	} `json:"models"`
+}
+
+func renderEffective(body []byte, stdout, stderr io.Writer) int {
+	var e effective
+	if err := json.Unmarshal(body, &e); err != nil {
+		fmt.Fprintf(stderr, "abctl pricing: unreadable response: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Rates in effect for %s\n\n", e.Host)
+	fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", "model", "input", "cache-wr", "cache-rd", "output", "provenance")
+	fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s\n", "", "$/Mtok", "$/Mtok", "$/Mtok", "$/Mtok")
+	for _, m := range e.Models {
+		if m.Unpriced {
+			fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", m.Model, "-", "-", "-", "-", "UNPRICED")
+			continue
+		}
+		fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", m.Model,
+			rate(m.In), rate(m.CW), rate(m.CR), rate(m.Out), m.Provenance)
+	}
+	if e.Multiplier != 1 {
+		fmt.Fprintf(stdout, "\n  multiplier %.4g applied, from the %s rules — rates above are vendor list scaled by it\n",
+			e.Multiplier, e.MultiplierFrom)
+	} else {
+		fmt.Fprintf(stdout, "\n  no gateway discount applies to this endpoint; rates above are vendor list\n")
+	}
+	return 0
+}
+
+// rate formats a per-million figure, or "-" for a tier with no rate. A tier with no
+// rate is not free: pricing.Cost refuses to price a request that used one, so showing
+// 0.00 would misrepresent a coverage gap as a price.
+func rate(v float64) string {
+	if v == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.4g", v)
+}
+
+type describeBody struct {
+	UpstreamCommit string `json:"upstreamCommit"`
+	Rows           []struct {
+		Host       string  `json:"host"`
+		Model      string  `json:"model"`
+		Provenance string  `json:"provenance"`
+		In         float64 `json:"inputPerMillion"`
+		CW         float64 `json:"cacheWritePerMillion"`
+		CR         float64 `json:"cacheReadPerMillion"`
+		Out        float64 `json:"outputPerMillion"`
+	} `json:"rows"`
+	Multipliers []struct {
+		Host       string  `json:"host"`
+		Factor     float64 `json:"factor"`
+		Provenance string  `json:"provenance"`
+	} `json:"multipliers"`
+}
+
+func renderTable(body []byte, stdout, stderr io.Writer) int {
+	var d describeBody
+	if err := json.Unmarshal(body, &d); err != nil {
+		fmt.Fprintf(stderr, "abctl pricing: unreadable response: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Pricing table (%d rows)\n", len(d.Rows))
+	if d.UpstreamCommit != "" {
+		fmt.Fprintf(stdout, "  bundled rates generated from litellm %s\n", short(d.UpstreamCommit))
+	}
+	fmt.Fprintf(stdout, "\n  %-22s %-30s %9s %9s %9s %9s  %s\n",
+		"endpoint", "model", "input", "cache-wr", "cache-rd", "output", "from")
+	for _, r := range d.Rows {
+		h := r.Host
+		if h == "" || h == "*" {
+			h = "(any)"
+		}
+		fmt.Fprintf(stdout, "  %-22s %-30s %9s %9s %9s %9s  %s\n", h, r.Model,
+			rate(r.In), rate(r.CW), rate(r.CR), rate(r.Out), r.Provenance)
+	}
+	if len(d.Multipliers) > 0 {
+		fmt.Fprintf(stdout, "\nGateway discounts\n\n  %-30s %8s  %s\n", "endpoint", "factor", "from")
+		for _, m := range d.Multipliers {
+			h := m.Host
+			if h == "" || h == "*" {
+				h = "(any)"
+			}
+			fmt.Fprintf(stdout, "  %-30s %8.4g  %s\n", h, m.Factor, m.Provenance)
+		}
+		fmt.Fprintf(stdout, "\n  Rates above are UNSCALED. Use --host <endpoint> to see what one is charged.\n")
+	}
+	return 0
+}
+
+func short(s string) string {
+	if len(s) > 12 {
+		return s[:12]
+	}
+	return s
+}
+
+var _ = os.Stdout

--- a/authbridge/cmd/abctl/cmd_pricing.go
+++ b/authbridge/cmd/abctl/cmd_pricing.go
@@ -159,16 +159,30 @@ func rate(v float64) string {
 	return fmt.Sprintf("%.4g", v)
 }
 
+// thresholdRow is one long-context override on a raw row.
+//
+// Rendered rather than dropped: the raw view already warns that its rates are unscaled,
+// and staying silent about a second tier would leave the same gap in the other direction
+// — a figure presented as the whole answer when a longer request is charged more.
+type thresholdRow struct {
+	Above int     `json:"abovePromptTokens"`
+	In    float64 `json:"inputPerMillion"`
+	CW    float64 `json:"cacheWritePerMillion"`
+	CR    float64 `json:"cacheReadPerMillion"`
+	Out   float64 `json:"outputPerMillion"`
+}
+
 type describeBody struct {
 	UpstreamCommit string `json:"upstreamCommit"`
 	Rows           []struct {
-		Host       string  `json:"host"`
-		Model      string  `json:"model"`
-		Provenance string  `json:"provenance"`
-		In         float64 `json:"inputPerMillion"`
-		CW         float64 `json:"cacheWritePerMillion"`
-		CR         float64 `json:"cacheReadPerMillion"`
-		Out        float64 `json:"outputPerMillion"`
+		Host       string         `json:"host"`
+		Model      string         `json:"model"`
+		Provenance string         `json:"provenance"`
+		In         float64        `json:"inputPerMillion"`
+		CW         float64        `json:"cacheWritePerMillion"`
+		CR         float64        `json:"cacheReadPerMillion"`
+		Out        float64        `json:"outputPerMillion"`
+		Thresholds []thresholdRow `json:"thresholds"`
 	} `json:"rows"`
 	Multipliers []struct {
 		Host       string  `json:"host"`
@@ -196,6 +210,14 @@ func renderTable(body []byte, stdout, stderr io.Writer) int {
 		}
 		fmt.Fprintf(stdout, "  %-22s %-30s %9s %9s %9s %9s  %s\n", h, r.Model,
 			rate(r.In), rate(r.CW), rate(r.CR), rate(r.Out), r.Provenance)
+		// Overrides on a continuation line, so the row above is not silently the
+		// below-threshold half of a two-tier answer. A tier the override leaves unset
+		// renders "-", meaning "inherits the row above", which is what At() does.
+		for _, th := range r.Thresholds {
+			fmt.Fprintf(stdout, "  %-22s   %-28s %9s %9s %9s %9s\n", "",
+				"above "+commas(th.Above)+" tok:",
+				rate(th.In), rate(th.CW), rate(th.CR), rate(th.Out))
+		}
 	}
 	if len(d.Multipliers) > 0 {
 		fmt.Fprintf(stdout, "\nGateway discounts\n\n  %-30s %8s  %s\n", "endpoint", "factor", "from")

--- a/authbridge/cmd/abctl/cmd_pricing.go
+++ b/authbridge/cmd/abctl/cmd_pricing.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -76,7 +77,13 @@ Flags:
 
 func fetchPricing(url string) ([]byte, error) {
 	c := &http.Client{Timeout: 10 * time.Second}
-	resp, err := c.Get(url)
+	// Request carries a context even though the client bounds the deadline: it is what
+	// lets a caller cancel, and it keeps this call the same shape as the rest of abctl.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build a request for %s: %w", url, err)
+	}
+	resp, err := c.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot reach the stat server at %s: %w", url, err)
 	}
@@ -102,6 +109,10 @@ type effective struct {
 		Provenance string  `json:"provenance"`
 		Unpriced   bool    `json:"unpriced"`
 		LongCtx    int     `json:"longContextAbove"`
+		AboveIn    float64 `json:"aboveInputPerMillion"`
+		AboveCW    float64 `json:"aboveCacheWritePerMillion"`
+		AboveCR    float64 `json:"aboveCacheReadPerMillion"`
+		AboveOut   float64 `json:"aboveOutputPerMillion"`
 		In         float64 `json:"inputPerMillion"`
 		CW         float64 `json:"cacheWritePerMillion"`
 		CR         float64 `json:"cacheReadPerMillion"`
@@ -124,27 +135,37 @@ func renderEffective(body []byte, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", m.Model, "-", "-", "-", "-", "UNPRICED")
 			continue
 		}
-		name := m.Model
-		// Marked, because the figures on this row are the BELOW-threshold ones. An
-		// unmarked row would quote a long session a rate it is not charged, which is
-		// the failure the pricing work exists to remove — it must not come back in
-		// the tool built to inspect it.
-		if m.LongCtx > 0 {
-			name += " *"
-			breakpoints = append(breakpoints, m.LongCtx)
-		}
-		fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", name,
+		fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", m.Model,
 			rate(m.In), rate(m.CW), rate(m.CR), rate(m.Out), m.Provenance)
+		// The above-threshold rates, discount already applied, on a continuation line.
+		// Naming the breakpoint alone still left the operator to work out what their long
+		// sessions cost — by reading the raw table and applying the factor by hand, which
+		// is the arithmetic this command exists to do.
+		if m.LongCtx > 0 {
+			breakpoints = append(breakpoints, m.LongCtx)
+			fmt.Fprintf(stdout, "    %-28s %9s %9s %9s %9s\n",
+				"above "+commas(m.LongCtx)+" tok:",
+				rate(m.AboveIn), rate(m.AboveCW), rate(m.AboveCR), rate(m.AboveOut))
+		}
+	}
+	// The footer used to call the rates "vendor list" unconditionally, directly beneath
+	// rows that may read `configured` — an operator's own pinned figures described back
+	// to them as the vendor's. Keyed off what the rows actually say instead.
+	base := "vendor list"
+	if allConfigured(e) {
+		base = "your configured rates"
+	} else if anyConfigured(e) {
+		base = "vendor list except where a row reads `configured`"
 	}
 	if e.Multiplier != 1 {
-		fmt.Fprintf(stdout, "\n  multiplier %.4g applied, from the %s rules — rates above are vendor list scaled by it\n",
-			e.Multiplier, e.MultiplierFrom)
+		fmt.Fprintf(stdout, "\n  multiplier %.4g applied, from the %s rules — rates above are %s scaled by it\n",
+			e.Multiplier, e.MultiplierFrom, base)
 	} else {
-		fmt.Fprintf(stdout, "\n  no gateway discount applies to this endpoint; rates above are vendor list\n")
+		fmt.Fprintf(stdout, "\n  no gateway discount applies to this endpoint; rates above are %s\n", base)
 	}
 	if len(breakpoints) > 0 {
-		fmt.Fprintf(stdout, "  * long-context rates apply above %s prompt tokens — the figures above are the\n"+
-			"    below-threshold ones, so a longer request costs MORE than shown\n", breakpointList(breakpoints))
+		fmt.Fprintf(stdout, "  long-context rates apply above %s prompt tokens; the indented line under a\n"+
+			"  model is what a request past that breakpoint is charged\n", breakpointList(breakpoints))
 	}
 	return 0
 }
@@ -275,4 +296,29 @@ func commas(n int) string {
 		b.WriteString(s[i : i+3])
 	}
 	return b.String()
+}
+
+// allConfigured / anyConfigured report how much of a host view is the operator's own
+// pinning, so the footer can describe the rates it is actually printing.
+func allConfigured(e effective) bool {
+	n := 0
+	for _, m := range e.Models {
+		if m.Unpriced {
+			continue
+		}
+		if m.Provenance != "configured" {
+			return false
+		}
+		n++
+	}
+	return n > 0
+}
+
+func anyConfigured(e effective) bool {
+	for _, m := range e.Models {
+		if !m.Unpriced && m.Provenance == "configured" {
+			return true
+		}
+	}
+	return false
 }

--- a/authbridge/cmd/abctl/cmd_pricing.go
+++ b/authbridge/cmd/abctl/cmd_pricing.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+	"net/url"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -51,7 +53,10 @@ Flags:
 
 	u := strings.TrimSuffix(*statsURL, "/") + "/pricing/table"
 	if *host != "" {
-		u += "?host=" + *host
+		// Escaped, not concatenated: a host is operator-supplied and a "&" or "#" in
+		// it would silently truncate the parameter, so the proxy would answer for the
+		// wrong endpoint — a wrong answer presented as a right one.
+		u += "?" + url.Values{"host": {*host}}.Encode()
 	}
 	body, err := fetchPricing(u)
 	if err != nil {
@@ -96,6 +101,7 @@ type effective struct {
 		Model      string  `json:"model"`
 		Provenance string  `json:"provenance"`
 		Unpriced   bool    `json:"unpriced"`
+		LongCtx    int     `json:"longContextAbove"`
 		In         float64 `json:"inputPerMillion"`
 		CW         float64 `json:"cacheWritePerMillion"`
 		CR         float64 `json:"cacheReadPerMillion"`
@@ -112,12 +118,22 @@ func renderEffective(body []byte, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Rates in effect for %s\n\n", e.Host)
 	fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", "model", "input", "cache-wr", "cache-rd", "output", "provenance")
 	fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s\n", "", "$/Mtok", "$/Mtok", "$/Mtok", "$/Mtok")
+	var breakpoints []int
 	for _, m := range e.Models {
 		if m.Unpriced {
 			fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", m.Model, "-", "-", "-", "-", "UNPRICED")
 			continue
 		}
-		fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", m.Model,
+		name := m.Model
+		// Marked, because the figures on this row are the BELOW-threshold ones. An
+		// unmarked row would quote a long session a rate it is not charged, which is
+		// the failure the pricing work exists to remove — it must not come back in
+		// the tool built to inspect it.
+		if m.LongCtx > 0 {
+			name += " *"
+			breakpoints = append(breakpoints, m.LongCtx)
+		}
+		fmt.Fprintf(stdout, "  %-30s %9s %9s %9s %9s  %s\n", name,
 			rate(m.In), rate(m.CW), rate(m.CR), rate(m.Out), m.Provenance)
 	}
 	if e.Multiplier != 1 {
@@ -125,6 +141,10 @@ func renderEffective(body []byte, stdout, stderr io.Writer) int {
 			e.Multiplier, e.MultiplierFrom)
 	} else {
 		fmt.Fprintf(stdout, "\n  no gateway discount applies to this endpoint; rates above are vendor list\n")
+	}
+	if len(breakpoints) > 0 {
+		fmt.Fprintf(stdout, "  * long-context rates apply above %s prompt tokens — the figures above are the\n"+
+			"    below-threshold ones, so a longer request costs MORE than shown\n", breakpointList(breakpoints))
 	}
 	return 0
 }
@@ -198,4 +218,39 @@ func short(s string) string {
 	return s
 }
 
-var _ = os.Stdout
+// breakpointList renders the distinct long-context breakpoints, largest last.
+//
+// Distinct, because four models sharing one 200k threshold should read "200,000", not
+// the same number four times.
+func breakpointList(ns []int) string {
+	sort.Ints(ns)
+	var out []string
+	for i, n := range ns {
+		if i > 0 && n == ns[i-1] {
+			continue
+		}
+		out = append(out, commas(n))
+	}
+	return strings.Join(out, "/")
+}
+
+// commas groups a token count for reading: 200000 is hard to size at a glance, 200,000
+// is not, and these numbers only ever appear in prose meant for a human.
+func commas(n int) string {
+	s := strconv.Itoa(n)
+	if len(s) <= 3 {
+		return s
+	}
+	var b strings.Builder
+	lead := len(s) % 3
+	if lead > 0 {
+		b.WriteString(s[:lead])
+	}
+	for i := lead; i < len(s); i += 3 {
+		if b.Len() > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}

--- a/authbridge/cmd/abctl/cmd_pricing_test.go
+++ b/authbridge/cmd/abctl/cmd_pricing_test.go
@@ -71,20 +71,25 @@ func TestRunPricing_UnscaledEndpointSaysSo(t *testing.T) {
 	if !strings.Contains(got, "no gateway discount") {
 		t.Errorf("expected the no-discount note: %s", got)
 	}
-	// UNSCALED vendor list for opus-5: 5 in, 25 out. Asserted as a whole row, because
-	// "5" alone also matches the model name "claude-opus-5" and so proves nothing — and
-	// specifically NOT the discounted 3.8/19, which is what a multiplier leaking onto
-	// api.anthropic.com would print here.
-	row := modelRow(t, got, "claude-opus-5")
-	for _, want := range []string{"5", "25"} {
-		if !strings.Contains(row, want) {
-			t.Errorf("opus-5 row %q missing list rate %q", row, want)
-		}
+	// UNSCALED vendor list for opus-5: 5 in, 25 out. Asserted by COLUMN, not by
+	// Contains: "5" is a substring of the model name "claude-opus-5" and of "25", so a
+	// containment check on either the output or the row proves nothing at all.
+	//
+	// Columns are: model, input, cache-write, cache-read, output, provenance.
+	f := strings.Fields(modelRow(t, got, "claude-opus-5"))
+	if len(f) < 6 {
+		t.Fatalf("opus-5 row has %d columns, want 6: %q", len(f), f)
 	}
-	for _, unwanted := range []string{"3.8", "19"} {
-		if strings.Contains(row, unwanted) {
-			t.Errorf("opus-5 row %q carries the discounted rate %q on an undiscounted endpoint", row, unwanted)
-		}
+	if f[1] != "5" {
+		t.Errorf("input column = %q, want the list rate 5", f[1])
+	}
+	if f[4] != "25" {
+		t.Errorf("output column = %q, want the list rate 25", f[4])
+	}
+	// And specifically NOT the discounted figures, which is what a multiplier leaking
+	// onto api.anthropic.com would print here.
+	if f[1] == "3.8" || f[4] == "19" {
+		t.Errorf("opus-5 carries discounted rates on an undiscounted endpoint: %q", f)
 	}
 }
 
@@ -136,4 +141,30 @@ func TestRunPricing_ProxyDownIsActionable(t *testing.T) {
 	if !strings.Contains(errb.String(), "abctl service status") {
 		t.Errorf("error does not tell the operator what to check: %s", errb.String())
 	}
+}
+
+// The raw view must not present a two-tier row as a one-tier answer. Four bundled models
+// carry a 200k override; the wire has always had them and the renderer used to drop them.
+func TestRunPricing_TableViewShowsLongContextOverrides(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runPricing([]string{"--stats-url", realStatServer(t)}, &out, &errb); code != 0 {
+		t.Fatalf("exit %d: %s", code, errb.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "above 200,000 tok:") {
+		t.Errorf("no long-context override line in the raw view:\n%s", tail(got))
+	}
+	// The override rate itself, not just the breakpoint: sonnet-4-5's 200k input
+	// premium is 6.00/Mtok at list, and the raw view is unscaled.
+	if !strings.Contains(got, "        6 ") {
+		t.Errorf("override line does not carry the premium rate 6:\n%s", tail(got))
+	}
+}
+
+func tail(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > 12 {
+		lines = lines[len(lines)-12:]
+	}
+	return strings.Join(lines, "\n")
 }

--- a/authbridge/cmd/abctl/cmd_pricing_test.go
+++ b/authbridge/cmd/abctl/cmd_pricing_test.go
@@ -46,6 +46,20 @@ func TestRunPricing_HostViewShowsTheDiscountApplied(t *testing.T) {
 	if !strings.Contains(got, "vendor list scaled") {
 		t.Errorf("output does not explain that rates are scaled: %s", got)
 	}
+	// The bundled table gives sonnet-4-5 a 200k long-context tier, and the host view
+	// resolves at prompt size 0 — so its row MUST carry the marker and the footnote
+	// must give the breakpoint. Quoting a below-threshold rate as if it were the only
+	// rate is the exact failure this package exists to remove.
+	if row := modelRow(t, got, "claude-sonnet-4-5"); !strings.Contains(row, "*") {
+		t.Errorf("sonnet-4-5 row %q is not marked as having long-context tiers", row)
+	}
+	if !strings.Contains(got, "long-context rates apply above 200,000 prompt tokens") {
+		t.Errorf("no long-context footnote with a breakpoint: %s", got)
+	}
+	// A model without a tier must not be marked.
+	if row := modelRow(t, got, "claude-opus-5"); strings.Contains(row, "*") {
+		t.Errorf("opus-5 row %q is marked, but it has no long-context tier", row)
+	}
 }
 
 func TestRunPricing_UnscaledEndpointSaysSo(t *testing.T) {
@@ -57,10 +71,36 @@ func TestRunPricing_UnscaledEndpointSaysSo(t *testing.T) {
 	if !strings.Contains(got, "no gateway discount") {
 		t.Errorf("expected the no-discount note: %s", got)
 	}
-	// Vendor list for opus-5 input.
-	if !strings.Contains(got, "5") {
-		t.Errorf("expected list rates: %s", got)
+	// UNSCALED vendor list for opus-5: 5 in, 25 out. Asserted as a whole row, because
+	// "5" alone also matches the model name "claude-opus-5" and so proves nothing — and
+	// specifically NOT the discounted 3.8/19, which is what a multiplier leaking onto
+	// api.anthropic.com would print here.
+	row := modelRow(t, got, "claude-opus-5")
+	for _, want := range []string{"5", "25"} {
+		if !strings.Contains(row, want) {
+			t.Errorf("opus-5 row %q missing list rate %q", row, want)
+		}
 	}
+	for _, unwanted := range []string{"3.8", "19"} {
+		if strings.Contains(row, unwanted) {
+			t.Errorf("opus-5 row %q carries the discounted rate %q on an undiscounted endpoint", row, unwanted)
+		}
+	}
+}
+
+// modelRow returns one model's line, so a rate assertion is scoped to that model rather
+// than matching any digit anywhere in the table.
+func modelRow(t *testing.T, out, model string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		// Exact first field, not Contains: "claude-opus-5" is a prefix of
+		// "claude-opus-5-1", and a substring match would silently accept the wrong row.
+		if f := strings.Fields(line); len(f) > 0 && f[0] == model {
+			return line
+		}
+	}
+	t.Fatalf("no %s row in:\n%s", model, out)
+	return ""
 }
 
 func TestRunPricing_TableViewListsRowsAndDiscounts(t *testing.T) {

--- a/authbridge/cmd/abctl/cmd_pricing_test.go
+++ b/authbridge/cmd/abctl/cmd_pricing_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// End to end through the real handler: a real Registry, the real JSON, the real
+// renderer. A canned fixture would let the wire shape drift from the producer, which is
+// the failure this whole area keeps having.
+func realStatServer(t *testing.T) string {
+	t.Helper()
+	tab, err := pricing.Build(nil) // bundled rates + the shipped gateway discount
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(pricing.NewRegistry(tab).Handler())
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestRunPricing_HostViewShowsTheDiscountApplied(t *testing.T) {
+	var out, errb bytes.Buffer
+	code := runPricing([]string{
+		"--stats-url", realStatServer(t),
+		"--host", "ete-litellm.ai-models.vpc-int.res.ibm.com",
+	}, &out, &errb)
+	if code != 0 {
+		t.Fatalf("exit %d, stderr: %s", code, errb.String())
+	}
+	got := out.String()
+	t.Logf("\n%s", got)
+
+	// The measured gateway rates for opus-5: 3.8 in, 19 out.
+	for _, want := range []string{"claude-opus-5", "3.8", "19", "multiplier 0.76", "ete-litellm"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+	// It must say the figures are scaled, or a reader compares them against a
+	// published price list and concludes the tool is broken.
+	if !strings.Contains(got, "vendor list scaled") {
+		t.Errorf("output does not explain that rates are scaled: %s", got)
+	}
+}
+
+func TestRunPricing_UnscaledEndpointSaysSo(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runPricing([]string{"--stats-url", realStatServer(t), "--host", "api.anthropic.com"}, &out, &errb); code != 0 {
+		t.Fatalf("exit %d: %s", code, errb.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "no gateway discount") {
+		t.Errorf("expected the no-discount note: %s", got)
+	}
+	// Vendor list for opus-5 input.
+	if !strings.Contains(got, "5") {
+		t.Errorf("expected list rates: %s", got)
+	}
+}
+
+func TestRunPricing_TableViewListsRowsAndDiscounts(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runPricing([]string{"--stats-url", realStatServer(t)}, &out, &errb); code != 0 {
+		t.Fatalf("exit %d: %s", code, errb.String())
+	}
+	got := out.String()
+	for _, want := range []string{"Pricing table", "generated from litellm", "Gateway discounts", "res.ibm.com", "UNSCALED"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+// A tier with no rate must render "-", never 0.00: pricing.Cost refuses to price a
+// request that used such a tier, so a zero would misrepresent a coverage gap as free.
+func TestRunPricing_UnsetTierRendersAsAbsent(t *testing.T) {
+	if got := rate(0); got != "-" {
+		t.Errorf("rate(0) = %q, want %q", got, "-")
+	}
+	if got := rate(3.8); got != "3.8" {
+		t.Errorf("rate(3.8) = %q", got)
+	}
+}
+
+func TestRunPricing_ProxyDownIsActionable(t *testing.T) {
+	var out, errb bytes.Buffer
+	code := runPricing([]string{"--stats-url", "http://127.0.0.1:1"}, &out, &errb)
+	if code == 0 {
+		t.Fatal("expected a non-zero exit when the proxy is unreachable")
+	}
+	if !strings.Contains(errb.String(), "abctl service status") {
+		t.Errorf("error does not tell the operator what to check: %s", errb.String())
+	}
+}

--- a/authbridge/cmd/abctl/cmd_pricing_test.go
+++ b/authbridge/cmd/abctl/cmd_pricing_test.go
@@ -86,11 +86,8 @@ func TestRunPricing_UnscaledEndpointSaysSo(t *testing.T) {
 	if f[4] != "25" {
 		t.Errorf("output column = %q, want the list rate 25", f[4])
 	}
-	// And specifically NOT the discounted figures, which is what a multiplier leaking
-	// onto api.anthropic.com would print here.
-	if f[1] == "3.8" || f[4] == "19" {
-		t.Errorf("opus-5 carries discounted rates on an undiscounted endpoint: %q", f)
-	}
+	// No separate "and not 3.8/19" check: the two equalities above already exclude every
+	// other value, discounted ones included.
 }
 
 // modelRow returns one model's line, so a rate assertion is scoped to that model rather
@@ -150,15 +147,51 @@ func TestRunPricing_TableViewShowsLongContextOverrides(t *testing.T) {
 	if code := runPricing([]string{"--stats-url", realStatServer(t)}, &out, &errb); code != 0 {
 		t.Fatalf("exit %d: %s", code, errb.String())
 	}
-	got := out.String()
-	if !strings.Contains(got, "above 200,000 tok:") {
-		t.Errorf("no long-context override line in the raw view:\n%s", tail(got))
+	// By column, not by Contains: a Contains on "        6 " would depend on the %9s
+	// padding and would fail on a width change while the rate itself was correct.
+	//
+	// Override columns: "above", <breakpoint>, "tok:", then the four rates.
+	f := overrideAfter(t, out.String(), "claude-sonnet-4-5")
+	if len(f) != 7 {
+		t.Fatalf("override line has %d columns, want 7: %q", len(f), f)
 	}
-	// The override rate itself, not just the breakpoint: sonnet-4-5's 200k input
-	// premium is 6.00/Mtok at list, and the raw view is unscaled.
-	if !strings.Contains(got, "        6 ") {
-		t.Errorf("override line does not carry the premium rate 6:\n%s", tail(got))
+	if f[1] != "200,000" {
+		t.Errorf("breakpoint = %q, want 200,000", f[1])
 	}
+	// sonnet-4-5's 200k premium at list: 6.00 input, 22.50 output. The raw view is
+	// unscaled, so these are list and not the discounted figures.
+	if f[3] != "6" {
+		t.Errorf("override input = %q, want the premium 6", f[3])
+	}
+	if f[6] != "22.5" {
+		t.Errorf("override output = %q, want the premium 22.5", f[6])
+	}
+}
+
+// overrideAfter returns the long-context continuation line that follows a model's row in
+// the raw view, as columns.
+//
+// Positional on purpose: the continuation line only means anything attached to the row
+// above it, so finding it by scanning for "above" anywhere would not prove it landed on
+// the right model.
+func overrideAfter(t *testing.T, out, model string) []string {
+	t.Helper()
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		// Raw view columns: endpoint, model, four rates, provenance.
+		if f := strings.Fields(line); len(f) > 1 && f[1] == model {
+			if i+1 >= len(lines) {
+				t.Fatalf("%s is the last line; no override line follows it", model)
+			}
+			nf := strings.Fields(lines[i+1])
+			if len(nf) == 0 || nf[0] != "above" {
+				t.Fatalf("no override line after the %s row, got %q", model, lines[i+1])
+			}
+			return nf
+		}
+	}
+	t.Fatalf("no %s row in:\n%s", model, tail(out))
+	return nil
 }
 
 func tail(s string) string {

--- a/authbridge/cmd/abctl/cmd_pricing_test.go
+++ b/authbridge/cmd/abctl/cmd_pricing_test.go
@@ -50,15 +50,23 @@ func TestRunPricing_HostViewShowsTheDiscountApplied(t *testing.T) {
 	// resolves at prompt size 0 — so its row MUST carry the marker and the footnote
 	// must give the breakpoint. Quoting a below-threshold rate as if it were the only
 	// rate is the exact failure this package exists to remove.
-	if row := modelRow(t, got, "claude-sonnet-4-5"); !strings.Contains(row, "*") {
-		t.Errorf("sonnet-4-5 row %q is not marked as having long-context tiers", row)
-	}
 	if !strings.Contains(got, "long-context rates apply above 200,000 prompt tokens") {
-		t.Errorf("no long-context footnote with a breakpoint: %s", got)
+		t.Errorf("no long-context note with a breakpoint: %s", got)
 	}
-	// A model without a tier must not be marked.
-	if row := modelRow(t, got, "claude-opus-5"); strings.Contains(row, "*") {
-		t.Errorf("opus-5 row %q is marked, but it has no long-context tier", row)
+	// The above-threshold rates must be present AND scaled: sonnet-4-5's 200k input
+	// premium is 6.00 at list, so at 0.76 it is 4.56. Quoting 6.00 here would be the
+	// unscaled figure; quoting nothing would leave the operator doing the arithmetic
+	// this command exists to do.
+	af := overrideAfter(t, got, "claude-sonnet-4-5")
+	if len(af) != 7 {
+		t.Fatalf("override line has %d columns, want 7: %q", len(af), af)
+	}
+	if af[3] != "4.56" {
+		t.Errorf("above-threshold input = %q, want the scaled 4.56 (6.00 means unscaled)", af[3])
+	}
+	// A model without a tier gets no continuation line.
+	if _, ok := overrideLineAfter(got, "claude-opus-5"); ok {
+		t.Error("opus-5 has a long-context line, but it has no long-context tier")
 	}
 }
 
@@ -176,22 +184,32 @@ func TestRunPricing_TableViewShowsLongContextOverrides(t *testing.T) {
 // the right model.
 func overrideAfter(t *testing.T, out, model string) []string {
 	t.Helper()
+	f, ok := overrideLineAfter(out, model)
+	if !ok {
+		t.Fatalf("no long-context line after the %s row in:\n%s", model, tail(out))
+	}
+	return f
+}
+
+// overrideLineAfter returns the long-context continuation line following a model's row.
+//
+// Handles both views: the raw table leads with the endpoint (model is the second column),
+// the host view leads with the model. Matching either position keeps one helper for both
+// rather than two that can disagree about what "the line after" means.
+func overrideLineAfter(out, model string) ([]string, bool) {
 	lines := strings.Split(out, "\n")
 	for i, line := range lines {
-		// Raw view columns: endpoint, model, four rates, provenance.
-		if f := strings.Fields(line); len(f) > 1 && f[1] == model {
-			if i+1 >= len(lines) {
-				t.Fatalf("%s is the last line; no override line follows it", model)
-			}
-			nf := strings.Fields(lines[i+1])
-			if len(nf) == 0 || nf[0] != "above" {
-				t.Fatalf("no override line after the %s row, got %q", model, lines[i+1])
-			}
-			return nf
+		f := strings.Fields(line)
+		onRow := (len(f) > 0 && f[0] == model) || (len(f) > 1 && f[1] == model)
+		if !onRow || i+1 >= len(lines) {
+			continue
 		}
+		if nf := strings.Fields(lines[i+1]); len(nf) > 0 && nf[0] == "above" {
+			return nf, true
+		}
+		return nil, false
 	}
-	t.Fatalf("no %s row in:\n%s", model, tail(out))
-	return nil
+	return nil, false
 }
 
 func tail(s string) string {

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -36,7 +36,7 @@ var version = "dev"
 // One list rather than two: the unknown-subcommand error used to hardcode its own
 // copy, so adding a subcommand meant editing both and forgetting one left a typo
 // getting an incomplete list. A test holds the usage block to this slice.
-var dispatchableSubcommands = []string{"observe", "service", "claude-code", "exec", "tools"}
+var dispatchableSubcommands = []string{"observe", "service", "claude-code", "exec", "tools", "pricing"}
 
 // unknownSubcommandMessage is the error for an unrecognised first argument.
 func unknownSubcommandMessage(name string) string {
@@ -59,6 +59,7 @@ Usage:
   abctl exec -- CMD [ARG...] run CMD with Cortex's proxy and CA in its
                              environment, for tools with no settings file
   abctl tools <action>       tool-definition costs: scan
+  abctl pricing              show the model rates in effect (--host <gateway>)
 
   abctl                      deprecated: same as "abctl observe". Bare abctl
                              will stop opening the viewer in a future release.
@@ -80,6 +81,8 @@ func main() {
 		switch os.Args[1] {
 		case "tools":
 			os.Exit(runTools(os.Args[2:], os.Stdout, os.Stderr))
+		case "pricing":
+			os.Exit(runPricing(os.Args[2:], os.Stdout, os.Stderr))
 		case "claude-code":
 			os.Exit(runClaudeCode(os.Args[2:], os.Stdout, os.Stderr))
 		case "exec":

--- a/authbridge/cmd/authbridge-cpex/main.go
+++ b/authbridge/cmd/authbridge-cpex/main.go
@@ -260,7 +260,7 @@ func main() {
 		sources = append(sources, plugins.CollectStats(outboundH.Load())...)
 		return auth.MergeStats(sources...)
 	}
-	statSrv, statErr := runtimeutil.StartStatServer(cfg, rld.ConfigProvider(), statsProvider, rld.Handler(), cfg.Stats.StatsAddress)
+	statSrv, statErr := runtimeutil.StartStatServer(cfg, rld.ConfigProvider(), statsProvider, rld.Handler(), pricingRegistry.Handler(), cfg.Stats.StatsAddress)
 	if statErr != nil {
 		log.Fatalf("stat server listen: %v", statErr)
 	}

--- a/authbridge/cmd/authbridge-envoy/main.go
+++ b/authbridge/cmd/authbridge-envoy/main.go
@@ -249,7 +249,7 @@ func main() {
 		sources = append(sources, plugins.CollectStats(outboundH.Load())...)
 		return auth.MergeStats(sources...)
 	}
-	statSrv, statErr := runtimeutil.StartStatServer(cfg, rld.ConfigProvider(), statsProvider, rld.Handler(), cfg.Stats.StatsAddress)
+	statSrv, statErr := runtimeutil.StartStatServer(cfg, rld.ConfigProvider(), statsProvider, rld.Handler(), pricingRegistry.Handler(), cfg.Stats.StatsAddress)
 	if statErr != nil {
 		log.Fatalf("stat server listen: %v", statErr)
 	}

--- a/authbridge/cmd/authbridge-proxy/local.go
+++ b/authbridge/cmd/authbridge-proxy/local.go
@@ -114,6 +114,27 @@ tls_bridge:
   # explicit empty list means "intercept everything". Never list an inference
   # endpoint: skipping one silently removes the parsing and the token savings,
   # with no error to notice it by.
+# Cost accounting. Nothing here is required.
+#
+# Rates come from a table built into the binary -- vendor list, refreshed each
+# release -- scaled by any gateway discount Cortex knows about. To see what is
+# actually in effect, including where each figure came from:
+#
+#   abctl pricing --host <your-gateway>
+#
+# Gateways matching a shipped rule already have their discount applied and need
+# nothing here. If yours is not one of them and it bills a fraction of list, say
+# so once: one scalar tracks upstream repricing, where a copied rate card freezes
+# today's numbers and goes stale with nothing to say it has.
+#
+# pricing:
+#   endpoints:
+#     - hosts: ["my-gateway.example.com"]
+#       multiplier: 0.80          # a FRACTION of list, so 0.80 is a 20% discount
+#
+# For a gateway whose prices are genuinely negotiated per model rather than
+# derived from list, give rates instead of a multiplier -- see
+# docs/plugin-catalog.md.
 pipeline:
   outbound:
     plugins:

--- a/authbridge/cmd/authbridge-proxy/main.go
+++ b/authbridge/cmd/authbridge-proxy/main.go
@@ -639,7 +639,7 @@ func main() {
 		sources = append(sources, plugins.CollectStats(outboundH.Load())...)
 		return auth.MergeStats(sources...)
 	}
-	statSrv, statErr := runtimeutil.StartStatServer(cfg, rld.ConfigProvider(), statsProvider, rld.Handler(), cfg.Stats.StatsAddress)
+	statSrv, statErr := runtimeutil.StartStatServer(cfg, rld.ConfigProvider(), statsProvider, rld.Handler(), pricingRegistry.Handler(), cfg.Stats.StatsAddress)
 	if statErr != nil {
 		log.Fatalf("stat server listen: %v", statErr)
 	}

--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -333,3 +333,30 @@ The cost event gained a `provenance` field, **additively**: the original
 consumer that knows only those four still decodes. `source` is retained rather than
 replaced — it says which *path* priced the request (gateway header vs token counts),
 where `provenance` says how much to trust the rates.
+
+
+## Drift detection
+
+A non-streamed response carries both the gateway's own settled cost and the token counts,
+so the modelled figure can be checked against the real one for free. When they diverge by
+more than 5%, the plugin warns once per endpoint and model:
+
+```
+WARN pricing: the rate table disagrees with what the gateway charged
+     endpoint=gw.internal model=claude-opus-5 modelled_usd=0.085000
+     gateway_usd=0.064600 ratio=1.316x
+     effect=overstating every request this table prices, including streamed ones
+     fix=set pricing.endpoints[].multiplier for this endpoint ...
+```
+
+That matters because **streamed responses have no authoritative cost** — the gateway
+reports 0 in the header by design, since the total is unknown when headers are sent. So a
+misconfigured rate table is invisible on exactly the traffic an agent generates. The
+occasional non-streamed call is the only place the error is observable, and this is what
+looks.
+
+Once per endpoint and model, not per request: an agent makes thousands of calls, and a
+per-request warning would bury every other line in the log.
+
+The ledger always uses the authoritative figure. Drift is a diagnostic about the rate
+table, never a reason to distrust the gateway's own number.

--- a/authbridge/docs/plugin-catalog.md
+++ b/authbridge/docs/plugin-catalog.md
@@ -368,15 +368,50 @@ pricing:
 service name and its external alias, bill identically, and repeating the whole models
 block per host invites the two copies to drift. Each host becomes its own table row.
 
+`multiplier` scales every rate that resolves for those hosts, including tiers and
+long-context thresholds. Absent means 1.0. A multiplier-only endpoint needs no `models`
+block. The factor is capped at 10, because `multiplier: 76` for `0.76` inflates every
+figure a hundredfold and reads as plausible in a config file.
+
+**Inspecting what is in effect.** No config file can answer this: the figures a request
+is charged come from your `pricing:` section *plus* the table compiled into the binary
+*plus* any shipped gateway discount. Two views:
+
+```
+abctl pricing                      every row, unscaled
+abctl pricing --host <gateway>     what that endpoint is charged, discount applied
+```
+
+Both are served by `GET /pricing/table[?host=]` on the diagnostic listener, beside
+`/config` and `/reload/status`.
+
 **Rates are scoped per endpoint**, which a per-plugin table could not express: the
 same model bills differently on a discounted gateway than on the vendor endpoint,
 and only the request's target host distinguishes them.
 
 ### Pinning a gateway that bills below list
 
-This is the one piece of configuration most deployments need, so it is worth stating
-plainly. The bundled table ships vendor-list prices; a gateway that bills below list is
-overstated until you pin it. Eight lines:
+The bundled table ships vendor-list prices, so a gateway that bills below list is
+overstated until Cortex knows the discount. **Most gateways bill a uniform fraction of
+list, and for those the whole answer is one scalar:**
+
+```yaml
+pricing:
+  endpoints:
+    - hosts: ["my-gateway.example.com"]
+      multiplier: 0.76        # a FRACTION of list, so 0.76 is a 24% discount
+```
+
+One number rather than twelve, and it **tracks upstream repricing**: the gateway's price
+is derived from list, so refreshing the bundled table moves both together. A copied rate
+card freezes today's numbers and goes stale silently.
+
+Some gateways already have a discount shipped with Cortex and need no configuration at
+all — `abctl pricing --host <gateway>` says which, and shows the rates in effect with
+their provenance. The `multiplier` you set outranks any shipped one.
+
+Reach for per-model rates only when a gateway's prices are genuinely negotiated per
+model rather than derived from list:
 
 ```yaml
 pricing:

--- a/authbridge/docs/plugin-catalog.md
+++ b/authbridge/docs/plugin-catalog.md
@@ -437,7 +437,9 @@ reports what it charged, so the factor is one division:
 # Non-streamed, so the gateway settles the cost before replying. A streamed response
 # reports 0 in that header by design, which is why this cannot be learned from live
 # agent traffic.
-curl -sD - -o /dev/null "$GATEWAY/v1/messages" \
+# --proto '=https' so a mistyped http:// URL fails instead of putting $KEY on the wire
+# in cleartext.
+curl -sD - -o /dev/null --proto '=https' "$GATEWAY/v1/messages" \
   -H "Authorization: Bearer $KEY" -H 'content-type: application/json' \
   -d '{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}' \
   | grep -i x-litellm-response-cost-original
@@ -453,6 +455,13 @@ Cortex checks this for you as traffic flows. When a non-streamed response carrie
 settled cost that disagrees with the modelled figure by more than 5%, `litellm-budget-track`
 warns once per endpoint and model with both numbers and the ratio — so a stale or missing
 factor announces itself rather than quietly misreporting spend.
+
+**Pinned rates are never scaled by a shipped multiplier.** If you pin per-model rates for
+a host that also matches a discount Cortex ships, the shipped factor is dropped for that
+host — your figures are already what the gateway charges, and scaling them again would
+understate spend by the factor. `abctl pricing --host <gateway>` shows `multiplier 1` there
+to confirm it. A multiplier you configure yourself does still apply on top of your own
+rates, since asking for both is a thing an operator can legitimately mean.
 
 Reach for per-model rates only when a gateway's prices are genuinely negotiated per
 model rather than derived from list:

--- a/authbridge/docs/plugin-catalog.md
+++ b/authbridge/docs/plugin-catalog.md
@@ -410,6 +410,50 @@ Some gateways already have a discount shipped with Cortex and need no configurat
 all — `abctl pricing --host <gateway>` says which, and shows the rates in effect with
 their provenance. The `multiplier` you set outranks any shipped one.
 
+**Provenance decides before specificity, so a catch-all you configure beats a specific
+rule Cortex ships.** These are not equivalent:
+
+```yaml
+pricing:
+  endpoints:
+    - hosts: ["*"]            # applies to EVERY endpoint, including ones with a
+      multiplier: 0.9         # shipped discount — 0.9 replaces their 0.76
+```
+
+That is deliberate: a configured factor means an operator checked their bill, and a rule
+compiled into a binary should never silently win over that. But it does mean a catch-all
+written for one gateway quietly reprices the rest. Scope the `hosts` list unless you mean
+every endpoint, and check the result with `abctl pricing --host <gateway>`.
+
+To drop a shipped discount for an endpoint without scaling it, set `multiplier: 1.0`
+explicitly — that is a configured rule of 1.0, which outranks the shipped factor and
+leaves the rates at vendor list. Omitting `multiplier` does NOT do this; it leaves the
+shipped rule in force.
+
+**Measuring your gateway's factor.** You do not have to be told it — a LiteLLM gateway
+reports what it charged, so the factor is one division:
+
+```sh
+# Non-streamed, so the gateway settles the cost before replying. A streamed response
+# reports 0 in that header by design, which is why this cannot be learned from live
+# agent traffic.
+curl -sD - -o /dev/null "$GATEWAY/v1/messages" \
+  -H "Authorization: Bearer $KEY" -H 'content-type: application/json' \
+  -d '{"model":"claude-opus-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}' \
+  | grep -i x-litellm-response-cost-original
+```
+
+Divide that by what the same token counts cost at list (`abctl pricing` shows the list
+rates; the response's `usage` block gives the counts). Repeat for one more model: a single
+factor across both means a uniform discount and `multiplier` is the whole answer, while
+figures that disagree mean the prices are negotiated per model and need the `models`
+block below.
+
+Cortex checks this for you as traffic flows. When a non-streamed response carries a
+settled cost that disagrees with the modelled figure by more than 5%, `litellm-budget-track`
+warns once per endpoint and model with both numbers and the ratio — so a stale or missing
+factor announces itself rather than quietly misreporting spend.
+
 Reach for per-model rates only when a gateway's prices are genuinely negotiated per
 model rather than derived from list:
 


### PR DESCRIPTION
## Summary

Makes gateway pricing accurate by default and inspectable at runtime, on top of the
consolidation in #928.

The starting point was a measurement. Differencing `x-litellm-response-cost-original`
across paired non-streamed calls against `ete-litellm.ai-models.vpc-int.res.ibm.com`:

| model | input | cache-write | cache-read | output | vs list |
|---|---|---|---|---|---|
| claude-opus-5 | 3.80 | 4.75 | 0.38 | 19.00 | **0.7600** |
| claude-sonnet-5 | 1.52 | 1.90 | 0.152 | 7.60 | **0.7600** |
| claude-haiku-4-5 | 0.76 | — | — | 3.80 | **0.7600** |

Twelve figures agreeing to four decimal places. A gateway discount is a **scalar**, not a
rate card — so it is expressed as one.

Key changes:

- **`pricing.endpoints[].multiplier`** — scales every rate that resolves for those hosts,
  tiers and long-context thresholds included. One number instead of twelve, and it tracks
  upstream repricing: the gateway's price is derived from list, so refreshing the bundled
  table moves both together. A copied rate card freezes today's numbers and goes stale
  with nothing to say it has.
- **The measured 0.76 ships** as a bundled rule for `*.res.ibm.com`, **scoped rather than
  global**. A global default would silently understate anyone going straight to
  `api.anthropic.com` by 24%, and understating hides spend. Scoped, both audiences are
  right with no configuration.
- **`abctl pricing`** and **`GET /pricing/table[?host=]`** show the rates in effect, with
  provenance.
- **Drift detection** in `litellm-budget-track`: when the modelled cost diverges from the
  gateway's own by more than 5%, warn once per endpoint and model.
- **A commented `pricing:` block** in the generated config, so the knob is visible without
  reading docs.

Verified end to end: a real captured turn (12 input / 169,511 cache-read / 9 output on
opus-5) now prices at **$0.0646 — exactly what the gateway charged** — while
`api.anthropic.com` stays at $0.0850 list.

## Why not write the rates into the config file

That was the obvious alternative and it is a trap. `install.sh` writes the config **only
when absent** (`:1111`), so rates stored there would be frozen at each install's date and
never move again, silently — the exact staleness #928 existed to remove. It would also
take the config from 65 lines to ~242, and leave no sane answer to "config says 3.80,
binary says 5.00, which wins?"

So the table is made **inspectable** rather than stored, and the config carries only the
knob, as comments that cannot go stale because they assert nothing.

## Two things the measurement turned up

**`/model/info` is 403 for a scoped virtual key** — *"Virtual key is not allowed to call
this route. Only allowed to call routes: `['llm_api_routes']`"*. The rate-discovery
feature deferred from #928 would not have worked on this gateway even if built and even
with a key mounted. Its cost/benefit rejection stands on stronger ground than the one
given at the time.

**Haiku's cache accounting looks broken gateway-side.** Two calls, one writing 18,388
tokens and one reading them, returned an identical cost — those tokens billed at zero.
Haiku's input and output rates are solid; only its cache tiers are unmeasurable. Applying
the multiplier uniformly (as decided) will slightly overstate haiku cache traffic until
that is fixed gateway-side, and the drift check is what will keep surfacing it.

## Corrections to merged content

`WarnIfUnpinned` and `tool-prune-plugin.md` asserted a bare `1.32x` derived from
comparing hand-measured rates against *current* list, when the repo's own comment claimed
"roughly 4x". Both were reasoning where a measurement was available. The figure is now
measured, and the text says `0.76x of list` with the multiplier as the fix.

## Testing

- `authlib` and 5 other modules build, vet and `go test -race` clean
- `golangci-lint --new-from-rev=upstream/main` reports 0 issues in `authlib` and `abctl`
- `abctl pricing` is tested end to end through the real handler and a real `Registry`,
  not a canned fixture, so the wire shape cannot drift from its producer

One pre-existing failure is untouched and unrelated:
`cmd/abctl TestRunExec_BeforeFirstStartRunsAndSaysWhatIsLost` fails identically on clean
`main` with these changes stashed. It arrived with `abctl exec` (#916) and reports
`~/.cortex/ca/bundle.crt` "does not exist" when the file is present.

## Disclosure of the shipped factor

`bundledMultipliers` publishes `0.76` bound to `*.res.ibm.com` — i.e. it states in a
public Apache-2.0 repository that IBM's internal LiteLLM gateways bill 76% of Anthropic's
list price. That is a deliberate decision, taken by @huang195 as maintainer, on the basis
that the factor is not confidential; it is recorded here rather than only in code so the
comment in `bundled_multipliers.go` has something checkable to point at.

Scope of what is disclosed: the host pattern (already present on `main` in five files,
including `docs/laptop-service.md` and `authlib/tlsbridge/decision_test.go`), the factor,
and the per-model rates that follow from it. Widening the pattern to other gateways, or
changing the factor, should be treated as a fresh disclosure decision and not a data
refresh.

## Related issue(s)

Refs #910

---

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pricing details to the stats page and a new `abctl pricing` command, with host-specific effective rates and JSON output.
  - Added configurable gateway pricing multipliers, including bundled discounts for supported gateways.
  - Added pricing diagnostics for rate sources, discounts, and unresolved models.

- **Bug Fixes**
  - Added warnings when reported costs differ significantly from modeled pricing while preserving authoritative billing figures.

- **Documentation**
  - Documented pricing multipliers, effective-rate inspection, and cost drift detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
