### PR TITLE
Feat: Persist abctl user settings in ~/.cortex/abctl-config.yaml

### DIFF
--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -303,7 +303,7 @@ Layered on top of all of them:
 | `Enter` / `→` / `l` | sessions, events | drill into selection |
 | `Esc` / `←` / `h` | detail, events | back out |
 | `Esc` | sessions, pipeline | (picker mode) tear down port-forward and back to pods |
-| `/` | sessions, events | filter (substring match; Enter commits, Esc cancels) |
+| `/` | sessions, events | filter (substring match; Enter commits and saves, Esc cancels the edit and saves nothing; clear the box and press Enter to remove a saved filter) |
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
 | `c` | events | open the column picker (`↑↓`/`jk` move, `space`/`x` toggle, `r` reset, `Esc`/`Enter`/`c` close); the selection is saved on close |
 | `p` | any | pause/resume stream |
@@ -330,15 +330,17 @@ Layered on top of all of them:
 abctl remembers the events-table column selection and the active filter in
 `~/.cortex/abctl-config.yaml`. Columns are saved when the column picker closes with
 `Esc`/`Enter`/`c` (`q` quits without saving); the filter is saved when you commit it
-with `Enter` or clear it with `Esc`. There is no explicit save step.
+with `Enter`. There is no explicit save step.
 
 A restored filter is shown in the footer as `[filter: …]` while it is in effect but
 not being edited — otherwise a shortened list would have no explanation on screen.
 Pressing `/` puts the cursor in the restored value so you extend it rather than
-replace it. In picker mode the restored filter applies to the first session view you
-open and is then cleared when you go back to the pod list: a filter surviving a pod
-switch reads as data loss, so the active one is dropped while the saved one stays on
-disk for the next start.
+replace it, and `Esc` abandons the edit and puts the previous filter back without
+writing anything. `Enter` is the only key that saves a filter, so clearing one means
+emptying the box and pressing `Enter`. In picker mode the restored filter applies to
+the first session view you open and is then dropped when you go back to the pod list:
+a filter surviving a pod switch reads as data loss, so the active one is cleared while
+the saved one stays on disk for the next start.
 
 `--prefs PATH` reads and writes somewhere else. This is *not* the Cortex proxy
 config — that is `~/.cortex/config.yaml`, and `--config` on `abctl service` and

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -332,6 +332,14 @@ abctl remembers the events-table column selection and the active filter in
 `Esc`/`Enter`/`c` (`q` quits without saving); the filter is saved when you commit it
 with `Enter` or clear it with `Esc`. There is no explicit save step.
 
+A restored filter is shown in the footer as `[filter: …]` while it is in effect but
+not being edited — otherwise a shortened list would have no explanation on screen.
+Pressing `/` puts the cursor in the restored value so you extend it rather than
+replace it. In picker mode the restored filter applies to the first session view you
+open and is then cleared when you go back to the pod list: a filter surviving a pod
+switch reads as data loss, so the active one is dropped while the saved one stays on
+disk for the next start.
+
 `--prefs PATH` reads and writes somewhere else. This is *not* the Cortex proxy
 config — that is `~/.cortex/config.yaml`, and `--config` on `abctl service` and
 `abctl claude-code`.

--- a/authbridge/cmd/abctl/README.md
+++ b/authbridge/cmd/abctl/README.md
@@ -305,7 +305,7 @@ Layered on top of all of them:
 | `Esc` | sessions, pipeline | (picker mode) tear down port-forward and back to pods |
 | `/` | sessions, events | filter (substring match; Enter commits, Esc cancels) |
 | `s` | events | toggle skip-row visibility (default: hidden; the events footer shows the hidden count) |
-| `c` | events | open the column picker (`↑↓`/`jk` move, `space`/`x` toggle, `r` reset, `Esc`/`Enter`/`c` close) |
+| `c` | events | open the column picker (`↑↓`/`jk` move, `space`/`x` toggle, `r` reset, `Esc`/`Enter`/`c` close); the selection is saved on close |
 | `p` | any | pause/resume stream |
 | `y` | detail | yank event JSON to `~/.cortex/abctl-events` (path stays until the next keypress) |
 | `g` / `G` | lists | jump to top / bottom |
@@ -324,6 +324,38 @@ Layered on top of all of them:
 | `Esc` | edit/{fetching,editing,applying} | abort the edit, return to Pipeline pane |
 | `Esc` | edit/{waiting,rollback} | background the watch; result lands as a footer flash |
 | `q` / `Ctrl+C` | any | quit (closes the key-help overlay first, if open) |
+
+## Settings
+
+abctl remembers the events-table column selection and the active filter in
+`~/.cortex/abctl-config.yaml`. Columns are saved when the column picker closes with
+`Esc`/`Enter`/`c` (`q` quits without saving); the filter is saved when you commit it
+with `Enter` or clear it with `Esc`. There is no explicit save step.
+
+`--prefs PATH` reads and writes somewhere else. This is *not* the Cortex proxy
+config — that is `~/.cortex/config.yaml`, and `--config` on `abctl service` and
+`abctl claude-code`.
+
+```yaml
+# abctl user settings. Written by abctl; safe to hand-edit or delete.
+# Columns not listed under events.columns are visible — only deviations are recorded.
+events:
+  columns:
+    - name: COST
+      visible: false
+    - name: TOKENS
+      visible: false
+filter: github-tool
+```
+
+**Columns not listed are visible.** The file records only what you changed, so a
+column added in a later abctl shows up rather than staying hidden because your file
+predates it. A column id this build does not recognise is ignored.
+
+Settings resolve **flags > this file > built-in defaults**. (No environment variable
+feeds any of these today; if one is ever added it sits between the two.) A missing
+file is normal and silent. An unreadable or malformed one is reported on stderr and
+ignored in full — never partially applied, and never fatal.
 
 ## Editing the pipeline
 
@@ -491,6 +523,9 @@ results; treat the output accordingly.
 ## Deferred to later PRs
 
 - Native clipboard (currently writes a file under `~/.cortex/abctl-events`).
+- More persisted settings (#954): sort order, pane sizes, theme. Each needs the
+  setting itself before there is anything to persist — the events table has no sort
+  state, pane sizes are recomputed per frame, and there is no theme to choose.
 - Fuzzy search beyond substring match.
 - Per-user filtering (`Identity.Subject == X`).
 - Krew plugin packaging.

--- a/authbridge/cmd/abctl/cmd_observe_test.go
+++ b/authbridge/cmd/abctl/cmd_observe_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"flag"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -136,4 +138,55 @@ func TestRootUsage_DocumentsVersion(t *testing.T) {
 	if !strings.Contains(out, "abctl observe") || !strings.Contains(out, "Viewer flags") {
 		t.Errorf("usage does not scope the flag list to the viewer:\n%s", out)
 	}
+}
+
+// TestObserveFlags_DocumentThePrefsFile renders the flag set runObserve actually
+// builds, rather than usageText's hand-mirrored copy — the point is to catch the
+// real flag drifting, which a mirror cannot do.
+//
+// Also asserts the value renders as "string": flag.PrintDefaults reads the first
+// backquoted word in a usage string as the value's NAME, so a stray `abctl service`
+// in the description silently rendered the flag as "-prefs abctl service".
+func TestObserveFlags_DocumentThePrefsFile(t *testing.T) {
+	// runObserve's flag set is built inline and it opens the TUI, so it cannot be
+	// rendered directly here without extracting a helper this PR has no other reason
+	// to add. `--help` on the real binary is the honest substitute: it exercises the
+	// registration exactly as a user meets it.
+	out := runObserveHelp(t)
+
+	if !strings.Contains(out, "-prefs string") {
+		t.Errorf("--prefs is missing or mis-rendered:\n%s", out)
+	}
+	if !strings.Contains(out, "abctl-config.yaml") {
+		t.Errorf("--prefs does not name the default file:\n%s", out)
+	}
+	// The whole reason the flag is not called --config. Matched as a flag-list entry
+	// ("  -config") rather than as a bare substring, because --prefs's own description
+	// mentions --config in order to point at the proxy config.
+	if strings.Contains(out, "  -config") {
+		t.Errorf("the viewer grew a -config flag; --config already means the proxy config "+
+			"on 'abctl service' and 'abctl claude-code':\n%s", out)
+	}
+}
+
+// runObserveHelp runs `abctl observe --help` in a subprocess and returns its
+// output. A subprocess because the flag set is ExitOnError, so -h exits the
+// process — which is fine for a child and fatal for a test binary.
+func runObserveHelp(t *testing.T) string {
+	t.Helper()
+	if os.Getenv("ABCTL_HELP_CHILD") == "1" {
+		// Re-exec'd child: be abctl.
+		os.Args = []string{"abctl", "observe", "--help"}
+		main()
+		return ""
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestObserveFlags_DocumentThePrefsFile")
+	cmd.Env = append(os.Environ(), "ABCTL_HELP_CHILD=1")
+	out, err := cmd.CombinedOutput()
+	// -h exits 0 through ExitOnError, but the test binary wrapping it may report
+	// otherwise; the output is what matters.
+	if len(out) == 0 && err != nil {
+		t.Fatalf("child produced no output: %v", err)
+	}
+	return string(out)
 }

--- a/authbridge/cmd/abctl/main.go
+++ b/authbridge/cmd/abctl/main.go
@@ -170,6 +170,15 @@ func runObserve(args []string) int {
 
 	endpoint := fs.String("endpoint", "",
 		"AuthBridge session API URL (e.g. http://localhost:9094). When omitted, abctl connects to the Cortex on this machine if one is running, otherwise it opens a Namespaces → Pods picker.")
+	// Named --prefs rather than --config: `abctl service` and `abctl claude-code`
+	// already spell the PROXY's config that way, and one flag name meaning two
+	// different files in one binary is worse than a second word.
+	//
+	// No backticks in the usage string: flag.PrintDefaults reads the first
+	// backquoted word as the value's NAME, so "`abctl service`" rendered the flag as
+	// "-prefs abctl service" instead of "-prefs string".
+	prefs := fs.String("prefs", "",
+		"abctl's own settings file — events-table columns and the active filter, saved as you change them (default ~/.cortex/abctl-config.yaml). Not the Cortex proxy config, which is --config on 'abctl service' and 'abctl claude-code'.")
 	// ExitOnError, so Parse exits 2 itself (0 for -h) rather than returning — there
 	// is no error branch to write here. Chosen over ContinueOnError because a bad
 	// flag has nothing useful to fall back to: the alternative is printing usage and
@@ -181,6 +190,22 @@ func runObserve(args []string) int {
 	// crash) so a user can recover an in-progress edit; the sweep keeps
 	// $TMPDIR bounded for users who edit often.
 	_ = edit.SweepStaleTempfiles()
+
+	// Load the user's settings — and print any complaint about a broken file — here,
+	// well before tea.NewProgram takes the alt screen: after that, anything written to
+	// the terminal corrupts the frame instead of reaching the user.
+	//
+	// A path we cannot resolve (no $HOME) means no load and no save rather than a
+	// failure. The viewer's job does not depend on remembering column choices.
+	prefsPath := *prefs
+	if prefsPath == "" {
+		var perr error
+		if prefsPath, perr = userConfigPath(); perr != nil {
+			fmt.Fprintf(os.Stderr, "abctl: not loading or saving settings: %v\n", perr)
+			prefsPath = ""
+		}
+	}
+	tui.Settings = loadUserConfig(prefsPath, os.Stderr)
 
 	// With no --endpoint, prefer a Cortex running on this machine. Before this,
 	// a bare `abctl` on a laptop demanded kubectl and opened a cluster picker,
@@ -228,6 +253,9 @@ func runObserve(args []string) int {
 	// working `kubectl port-forward` on 9094 could not be reached with the one key
 	// that exists for exactly that.
 	opts := tui.RunOptions{Endpoint: *endpoint}
+	if prefsPath != "" {
+		opts.Save = func(s tui.UserSettings) error { return saveUserConfig(prefsPath, s) }
+	}
 	if localUp {
 		opts.LocalEndpoint = local
 	}

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -234,6 +234,11 @@ type model struct {
 	// eventColumns is which events-table columns are shown. Keyed by a stable id
 	// rather than an index, so a future column inserted in the middle does not
 	// silently change what an existing selection means.
+	//
+	// Derived from Settings.Events at startup and written back to it when the
+	// picker closes. Kept as a map on the model rather than read from Settings on
+	// every cell, because rebuildEventsTable consults it per column per row — up to
+	// 500 rows on every SSE event and every resize.
 	eventColumns map[eventColumnID]bool
 	// eventColsDropped is how many selected columns did not fit the terminal on the
 	// last rebuild. Surfaced in the footer: with every column on the table needs
@@ -244,9 +249,13 @@ type model struct {
 	colPicker    bool
 	colCursor    int
 	selectedSess string
-	filter       string
-	filtering    bool
-	paused       bool
+	// filter is the ACTIVE filter, which is not the same as the saved one:
+	// backToPodsPane clears this on teardown so a filter cannot survive a pod
+	// switch and read as data loss. Settings.Filter is the persisted value that
+	// seeds it, and that clear deliberately does not write back.
+	filter    string
+	filtering bool
+	paused    bool
 	// hideInactive toggles whether passthrough / skip-only messages are
 	// hidden from the events table. False (default) shows every message —
 	// the operator asked to see all network traffic, processed or not.
@@ -361,6 +370,11 @@ type model struct {
 	// editRunner is the kubectl Runner the edit flow uses for fetch/apply.
 	// Set in newPickerModel to edit.DefaultRunner; tests inject a stub.
 	editRunner edit.Runner
+
+	// save persists Settings when a setting changes. A callback rather than a path
+	// so this package needs no home-directory or filesystem logic, and so its tests
+	// never touch $HOME. Nil disables saving, which is what every test wants.
+	save func(UserSettings) error
 }
 
 // New returns a fresh model pointed at the given client. ctx governs both
@@ -379,7 +393,8 @@ func New(ctx context.Context, c *apiclient.Client) tea.Model {
 		cancel:       cancel,
 		events:       make(map[string][]pipeline.SessionEvent),
 		pane:         paneSessions,
-		eventColumns: defaultColumnSelection(),
+		eventColumns: Settings.columnSelection(),
+		filter:       Settings.Filter,
 		sessionsTbl:  newSessionsTable(),
 		eventsTbl:    newEventsTable(),
 		pipelineTbl:  newPipelineTable(),
@@ -1442,6 +1457,13 @@ type RunOptions struct {
 	// LocalEndpoint overrides where `[l]` connects. Empty means
 	// defaultLocalEndpoint.
 	LocalEndpoint string
+	// Save persists the user's settings when one changes — the column picker
+	// closing, a filter being committed or cleared. A callback rather than a path
+	// keeps $HOME and the YAML out of this package, so its tests need neither.
+	//
+	// Nil disables persistence: what tests pass, and what main passes when there is
+	// no resolvable home directory to write to.
+	Save func(UserSettings) error
 }
 
 // Run starts the bubbletea program. See RunOptions for mode selection.
@@ -1457,6 +1479,9 @@ func Run(ctx context.Context, opts RunOptions) error {
 		m = newPickerModel(ctx, opts.Lister, opts.PortForwarder)
 	}
 	m.localEndpoint = opts.LocalEndpoint
+	// After the constructor branch, so the two paths cannot disagree about it:
+	// newPickerModel and New would otherwise each need their own copy.
+	m.save = opts.Save
 	defer func() {
 		if m.activePF != nil {
 			_ = m.activePF.Close()

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -385,6 +385,12 @@ func New(ctx context.Context, c *apiclient.Client) tea.Model {
 	ti := textinput.New()
 	ti.Placeholder = "filter…"
 	ti.Prompt = "/ "
+	// Seed the input, not just m.filter: the filter box renders only while filtering,
+	// so a restored filter was applied invisibly — the list came back truncated with
+	// nothing on screen saying why. Worse, `/` then one character replaced the saved
+	// filter with that character, and `/` then Esc persisted an empty one, discarding
+	// it for good.
+	ti.SetValue(Settings.Filter)
 
 	return &model{
 		endpoint:     c.Endpoint(),

--- a/authbridge/cmd/abctl/tui/app.go
+++ b/authbridge/cmd/abctl/tui/app.go
@@ -255,7 +255,13 @@ type model struct {
 	// seeds it, and that clear deliberately does not write back.
 	filter    string
 	filtering bool
-	paused    bool
+	// filterBeforeEdit is the committed filter as it stood when `/` was pressed, so
+	// Esc can restore it. Esc is documented as cancelling and means cancel everywhere
+	// else in abctl, but it used to clear the filter outright — and once the filter
+	// began persisting, that turned a mis-keyed Esc into the permanent loss of a
+	// committed filter. Clearing is still one action: empty the box and press Enter.
+	filterBeforeEdit string
+	paused           bool
 	// hideInactive toggles whether passthrough / skip-only messages are
 	// hidden from the events table. False (default) shows every message —
 	// the operator asked to see all network traffic, processed or not.
@@ -482,6 +488,13 @@ func (m *model) backToPodsPane() {
 	m.selectedSess = ""
 	m.filter = ""
 	m.filtering = false
+	// The input too, not just the value. Since the input is seeded from saved
+	// settings it is a second source of truth, and leaving it behind meant that after
+	// backing out and entering the next pod, `/` presented the OLD filter text
+	// already in the box — one keystroke then committed "github-toolx" and Enter
+	// persisted it, over a list the footer correctly showed as unfiltered.
+	m.filterInput.SetValue("")
+	m.filterBeforeEdit = ""
 	m.visibleRows = nil
 	m.connState = connStateInfo{phase: connConnecting}
 

--- a/authbridge/cmd/abctl/tui/e2e_test.go
+++ b/authbridge/cmd/abctl/tui/e2e_test.go
@@ -136,6 +136,11 @@ func TestModel_PauseTogglesViaKey(t *testing.T) {
 // pane: entering `/ foo enter` should narrow the table to rows matching
 // "foo".
 func TestModel_FilterNarrowsSessions(t *testing.T) {
+	// Before New: the constructors seed filter and filterInput from Settings, so a
+	// filter another test committed would make the "unfiltered" baseline below
+	// already filtered. Committing "foo" here also writes Settings, so this keeps it
+	// from leaking outward too.
+	resetSettingsForTest(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := apiclient.New("http://127.0.0.1:1")

--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -61,6 +61,14 @@ func (m *model) footerView() string {
 	if m.paused {
 		status.WriteString(styleWarn.Render("   [paused]"))
 	}
+	// A filter that is ON but not being edited has nowhere else to show: the filter
+	// box renders only while m.filtering, so a filter restored from the config file
+	// silently truncated the list with nothing on screen explaining it. Shown here
+	// rather than in the hint line because it is state, not a keybinding — the same
+	// reason [paused] sits above.
+	if m.filter != "" && !m.filtering {
+		status.WriteString(styleWarn.Render("   [filter: " + m.filter + "]"))
+	}
 
 	// Flash message (e.g. "yanked → ~/.cortex/abctl-events/...").
 	if m.flash != "" && (m.flashSticky || time.Now().Before(m.flashUntil)) {

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -159,6 +159,12 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			// handler rather than being reimplemented here.
 		case "c", "esc", "enter":
 			m.colPicker = false
+			// Persist on close, not on each toggle: a user trying four columns on the
+			// way to the two they want would otherwise produce three writes describing
+			// states they rejected. `q` is not handled here — it falls through to the
+			// global quit above, because quitting is not settling on a selection.
+			Settings.Events.Columns = columnSettingsFrom(m.eventColumns)
+			m.persistSettings()
 			return nil
 		case "up", "k":
 			if m.colCursor > 0 {
@@ -296,11 +302,19 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			m.filtering = false
 			m.filter = ""
 			m.filterInput.SetValue("")
+			// Clearing is as deliberate as setting, so it persists too — otherwise a
+			// filter the user explicitly dismissed would come back on the next start.
+			Settings.Filter = ""
+			m.persistSettings()
 			m.refreshActivePane()
 			return nil
 		case "enter":
 			m.filter = m.filterInput.Value()
 			m.filtering = false
+			// Commit, not keystroke: the fallthrough below re-reads the input on every
+			// character typed, and saving there would write once per keypress.
+			Settings.Filter = m.filter
+			m.persistSettings()
 			m.refreshActivePane()
 			return nil
 		}
@@ -697,6 +711,26 @@ func (m *model) setFlash(s string) {
 	// Explicitly clear: a timed message arriving after a sticky one must not
 	// inherit its stickiness.
 	m.flashSticky = false
+}
+
+// persistSettings hands the current Settings to the save hook, if one is wired.
+//
+// Failure is reported once through the footer flash and then dropped. Three
+// constraints shape that: bubbletea owns the terminal via WithAltScreen, so
+// writing to stderr here would corrupt the frame; the user cannot fix a read-only
+// $HOME from inside the TUI, so an error that blocks or repeats is noise; and a
+// preference that failed to save costs them one re-toggle next launch. Silence was
+// the alternative, and it would leave a read-only home failing invisibly forever —
+// the flash mechanism already exists for exactly this class of non-fatal problem.
+//
+// Never retries: a full disk would turn a retry loop into a redraw storm.
+func (m *model) persistSettings() {
+	if m.save == nil {
+		return
+	}
+	if err := m.save(Settings); err != nil {
+		m.setFlash("could not save settings: " + err.Error())
+	}
 }
 
 // setStickyFlash shows a message that stays until the next keypress. For yank,

--- a/authbridge/cmd/abctl/tui/keys.go
+++ b/authbridge/cmd/abctl/tui/keys.go
@@ -295,17 +295,21 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return m.handleEditKey(msg)
 	}
 
-	// Filter-mode: input box consumes most keys. Esc cancels, Enter commits.
+	// Filter-mode: input box consumes most keys. Esc cancels (restores the filter as
+	// it was at `/`), Enter commits and is the only key that persists.
 	if m.filtering {
 		switch msg.String() {
 		case "esc":
+			// Cancel, so it restores what was in effect when `/` was pressed and writes
+			// nothing. It used to clear the filter instead — which, once filters began
+			// persisting, meant one mis-keyed Esc permanently discarded a committed
+			// filter, while the README and this file both called the key "cancel".
+			//
+			// Clearing has not been lost: empty the box and press Enter. That keeps Enter
+			// as the only key that writes, which is the property worth having.
 			m.filtering = false
-			m.filter = ""
-			m.filterInput.SetValue("")
-			// Clearing is as deliberate as setting, so it persists too — otherwise a
-			// filter the user explicitly dismissed would come back on the next start.
-			Settings.Filter = ""
-			m.persistSettings()
+			m.filter = m.filterBeforeEdit
+			m.filterInput.SetValue(m.filterBeforeEdit)
 			m.refreshActivePane()
 			return nil
 		case "enter":
@@ -313,6 +317,9 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 			m.filtering = false
 			// Commit, not keystroke: the fallthrough below re-reads the input on every
 			// character typed, and saving there would write once per keypress.
+			//
+			// The only key that persists a filter. An empty box committed here is how a
+			// filter is cleared and the clearing made durable, now that Esc cancels.
 			Settings.Filter = m.filter
 			m.persistSettings()
 			m.refreshActivePane()
@@ -344,6 +351,9 @@ func (m *model) handleKey(msg tea.KeyMsg) tea.Cmd {
 
 	case "/":
 		m.filtering = true
+		// Snapshot for Esc. Taken here rather than derived on the way out, because by
+		// then the input has already been edited and the original is gone.
+		m.filterBeforeEdit = m.filter
 		m.filterInput.Focus()
 		return nil
 

--- a/authbridge/cmd/abctl/tui/namespaces_pane.go
+++ b/authbridge/cmd/abctl/tui/namespaces_pane.go
@@ -86,11 +86,16 @@ func newPickerModel(ctx context.Context, lister cluster.Lister, pf cluster.PortF
 
 	return &model{
 		// endpoint and client are set later, when portForwardReadyMsg arrives.
-		parentCtx:    parentCtx,
-		ctx:          ctx,
-		cancel:       cancel,
-		events:       make(map[string][]pipeline.SessionEvent),
-		pane:         paneNamespaces,
+		parentCtx: parentCtx,
+		ctx:       ctx,
+		cancel:    cancel,
+		events:    make(map[string][]pipeline.SessionEvent),
+		pane:      paneNamespaces,
+		// Seeded here as well as in New: this constructor's doc comment promises it
+		// mirrors New's field initialization, and the events table it reaches after a
+		// port-forward reads both of these.
+		eventColumns: Settings.columnSelection(),
+		filter:       Settings.Filter,
 		sessionsTbl:  newSessionsTable(),
 		eventsTbl:    newEventsTable(),
 		pipelineTbl:  newPipelineTable(),

--- a/authbridge/cmd/abctl/tui/namespaces_pane.go
+++ b/authbridge/cmd/abctl/tui/namespaces_pane.go
@@ -83,6 +83,12 @@ func newPickerModel(ctx context.Context, lister cluster.Lister, pf cluster.PortF
 	ti := textinput.New()
 	ti.Placeholder = "filter…"
 	ti.Prompt = "/ "
+	// Seed the input, not just m.filter: the filter box renders only while filtering,
+	// so a restored filter was applied invisibly — the list came back truncated with
+	// nothing on screen saying why. Worse, `/` then one character replaced the saved
+	// filter with that character, and `/` then Esc persisted an empty one, discarding
+	// it for good.
+	ti.SetValue(Settings.Filter)
 
 	return &model{
 		// endpoint and client are set later, when portForwardReadyMsg arrives.

--- a/authbridge/cmd/abctl/tui/settings.go
+++ b/authbridge/cmd/abctl/tui/settings.go
@@ -62,17 +62,31 @@ type ColumnSetting struct {
 // matters because anyColumnSelected and selectedColumns both walk the definition:
 // a phantom key would make the former report a selection the latter cannot render.
 //
-// Absent means visible, which is the rule this whole shape exists for.
+// Absent means "unchanged", so the column falls back to its own defaultOn. Every
+// column is defaultOn today, which is what makes "absent means visible" a true
+// description of the file format — but the fallback is the default, not a literal
+// true, so a future defaultOn:false column behaves the same way here as it does in
+// defaultColumnSelection.
 func (u UserSettings) columnSelection() map[eventColumnID]bool {
-	off := make(map[string]bool, len(u.Events.Columns))
+	// Both directions, not just the off-list: a column whose defaultOn is false has
+	// to be turnable ON by the file, or the picker could not persist enabling it.
+	set := make(map[string]bool, len(u.Events.Columns))
 	for _, c := range u.Events.Columns {
-		if !c.Visible {
-			off[c.Name] = true
-		}
+		set[c.Name] = c.Visible
 	}
 	out := make(map[eventColumnID]bool, len(eventColumns))
 	for _, c := range eventColumns {
-		out[c.id] = !off[string(c.id)]
+		// The fallback is c.defaultOn, not an unconditional true: "absent from the file"
+		// means "I never changed this", so the answer is whatever the built-in default
+		// is. The two agree today because all twelve entries are defaultOn — which is
+		// exactly why hardcoding true here would be a trap. The first column added with
+		// defaultOn:false would otherwise render ON for every user, fresh installs
+		// included, and disagree with defaultColumnSelection.
+		if v, ok := set[string(c.id)]; ok {
+			out[c.id] = v
+			continue
+		}
+		out[c.id] = c.defaultOn
 	}
 	// A file turning every column off would render a table with no columns. The
 	// picker cannot produce that state (its toggle re-seeds the defaults), but a
@@ -87,9 +101,10 @@ func (u UserSettings) columnSelection() map[eventColumnID]bool {
 
 // columnSettingsFrom is the inverse: the deviations worth writing down.
 //
-// Emits only the columns that are OFF, so an untouched selection serialises to
-// nothing rather than to twelve `visible: true` entries — the file should record
-// what the user changed.
+// Emits only the columns that differ from their own defaultOn, so an untouched
+// selection serialises to nothing rather than to twelve `visible: true` entries —
+// the file should record what the user changed. With every column defaultOn, that
+// means the off entries and nothing else.
 //
 // Ordered by eventColumns, not by map iteration: Go randomises the latter, which
 // would rewrite the file with the same entries reshuffled on every save. That
@@ -97,8 +112,13 @@ func (u UserSettings) columnSelection() map[eventColumnID]bool {
 func columnSettingsFrom(sel map[eventColumnID]bool) []ColumnSetting {
 	var out []ColumnSetting
 	for _, c := range eventColumns {
-		if !sel[c.id] {
-			out = append(out, ColumnSetting{Name: string(c.id), Visible: false})
+		// Compared against the column's own default, in both directions: turning ON a
+		// defaultOn:false column is as much a deviation as turning off a default one,
+		// and recording only the off-list would make enabling such a column
+		// unpersistable. Every column is defaultOn today, so in practice this still
+		// writes only the off entries.
+		if sel[c.id] != c.defaultOn {
+			out = append(out, ColumnSetting{Name: string(c.id), Visible: sel[c.id]})
 		}
 	}
 	return out

--- a/authbridge/cmd/abctl/tui/settings.go
+++ b/authbridge/cmd/abctl/tui/settings.go
@@ -1,0 +1,105 @@
+package tui
+
+// Settings is abctl's live user settings, global to the process.
+//
+// One struct rather than the fields it replaces (eventColumns, filter) scattered
+// across the model: persisting a new setting then means adding a field here and a
+// save call at the keypress that changes it, rather than finding every place the
+// value is read. It is also what gets marshalled, so the file's shape and the
+// in-memory shape cannot drift.
+//
+// Package-level because there is exactly one abctl TUI per process — bubbletea
+// owns the terminal, so a second model in the same process has nowhere to render.
+// Threading this through both constructors and every handler would buy testability
+// the callback in RunOptions already provides.
+//
+// The cost is real and worth naming: tests share it, so each one that touches
+// Settings must reset it (resetSettingsForTest), and t.Parallel is unavailable in
+// this package. Nothing here is parallel today, and t.Setenv in the yank tests
+// already forbids it independently.
+var Settings UserSettings
+
+// UserSettings is the persisted shape. Every field is optional: a file written by
+// an older abctl must not disable a setting it never knew about, so the zero value
+// has to mean "use the default" for each one.
+type UserSettings struct {
+	Events EventSettings `yaml:"events,omitempty"`
+	// Filter is the committed substring filter. One field because there is one
+	// m.filter: the sessions and events panes share it (sessions_pane.go, and
+	// events_pane.go's matchEventRow).
+	Filter string `yaml:"filter,omitempty"`
+}
+
+// EventSettings is the events-table view state.
+type EventSettings struct {
+	// Columns records only DEVIATIONS from the defaults — a column absent here is
+	// visible. Two consequences, both deliberate:
+	//
+	// A column added in a later build shows up for everyone who already has a
+	// config file, instead of starting hidden because their file predates it. And
+	// the file stays legible: turn two columns off and it has two entries, not
+	// twelve.
+	//
+	// The alternative (a list of what is ON) reads more obviously but inverts both
+	// of those, since every column is defaultOn today.
+	Columns []ColumnSetting `yaml:"columns,omitempty"`
+}
+
+// ColumnSetting is one column's visibility, keyed by the stable id the picker
+// shows as its header (#, TIME, DIR, …). Keyed by name rather than position
+// because eventColumns' order is a display decision that may change; see the
+// eventColumnID doc comment.
+type ColumnSetting struct {
+	Name    string `yaml:"name"`
+	Visible bool   `yaml:"visible"`
+}
+
+// columnSelection converts the persisted deviations into the selection map the
+// table renders from.
+//
+// Iterates eventColumns — the definition — rather than the file, so a name this
+// build does not have cannot create a map key with no column behind it. That
+// matters because anyColumnSelected and selectedColumns both walk the definition:
+// a phantom key would make the former report a selection the latter cannot render.
+//
+// Absent means visible, which is the rule this whole shape exists for.
+func (u UserSettings) columnSelection() map[eventColumnID]bool {
+	off := make(map[string]bool, len(u.Events.Columns))
+	for _, c := range u.Events.Columns {
+		if !c.Visible {
+			off[c.Name] = true
+		}
+	}
+	out := make(map[eventColumnID]bool, len(eventColumns))
+	for _, c := range eventColumns {
+		out[c.id] = !off[string(c.id)]
+	}
+	// A file turning every column off would render a table with no columns. The
+	// picker cannot produce that state (its toggle re-seeds the defaults), but a
+	// hand-edited file can, and selectedColumns' fallback only rescues the render —
+	// the picker's checkboxes would still show twelve empty boxes. Re-seed here so
+	// the two agree, matching what the toggle handler already does.
+	if !anyColumnSelected(out) {
+		return defaultColumnSelection()
+	}
+	return out
+}
+
+// columnSettingsFrom is the inverse: the deviations worth writing down.
+//
+// Emits only the columns that are OFF, so an untouched selection serialises to
+// nothing rather than to twelve `visible: true` entries — the file should record
+// what the user changed.
+//
+// Ordered by eventColumns, not by map iteration: Go randomises the latter, which
+// would rewrite the file with the same entries reshuffled on every save. That
+// churn is invisible in the TUI and obvious in a diff.
+func columnSettingsFrom(sel map[eventColumnID]bool) []ColumnSetting {
+	var out []ColumnSetting
+	for _, c := range eventColumns {
+		if !sel[c.id] {
+			out = append(out, ColumnSetting{Name: string(c.id), Visible: false})
+		}
+	}
+	return out
+}

--- a/authbridge/cmd/abctl/tui/settings_persist_test.go
+++ b/authbridge/cmd/abctl/tui/settings_persist_test.go
@@ -1,0 +1,276 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/apiclient"
+)
+
+// newTestFilterInput mirrors the textinput both constructors build. Duplicated
+// here rather than extracted from them: this PR has no other reason to touch that
+// initialization.
+func newTestFilterInput() textinput.Model {
+	ti := textinput.New()
+	ti.Placeholder = "filter…"
+	ti.Prompt = "/ "
+	return ti
+}
+
+// recordSaves wires a save hook onto m that records every call, and returns a
+// pointer to the recorded settings slice. Settings is package-global, so every
+// caller resets it too.
+func recordSaves(t *testing.T, m *model) *[]UserSettings {
+	t.Helper()
+	resetSettingsForTest(t)
+	var got []UserSettings
+	m.save = func(s UserSettings) error {
+		got = append(got, s)
+		return nil
+	}
+	return &got
+}
+
+// TestColumnPicker_ClosingSavesTheSelection: each of the three close keys is a
+// deliberate "I am done choosing", so each one persists.
+func TestColumnPicker_ClosingSavesTheSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{"c", keyRune('c')},
+		{"esc", tea.KeyMsg{Type: tea.KeyEsc}},
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestEventsModel(t)
+			saves := recordSaves(t, m)
+
+			m.handleKey(keyRune('c'))
+			// Move to TOKENS and turn it off, so the saved settings carry a real
+			// deviation rather than an empty list that would pass trivially.
+			for m.colCursor < len(eventColumns) && eventColumns[m.colCursor].id != colTokens {
+				m.handleKey(keyRune('j'))
+			}
+			m.handleKey(keyRune(' '))
+			if len(*saves) != 0 {
+				t.Fatalf("toggling saved %d times; the save belongs on close", len(*saves))
+			}
+
+			m.handleKey(tc.key)
+			if m.colPicker {
+				t.Fatalf("%q did not close the picker", tc.name)
+			}
+			if len(*saves) != 1 {
+				t.Fatalf("closing with %q produced %d saves, want exactly 1", tc.name, len(*saves))
+			}
+			want := []ColumnSetting{{Name: string(colTokens), Visible: false}}
+			got := (*saves)[0].Events.Columns
+			if len(got) != 1 || got[0] != want[0] {
+				t.Errorf("saved columns = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestColumnPicker_TogglingDoesNotSave pins the timing decision: a user trying
+// four columns on the way to the two they want must not produce three writes
+// describing states they rejected.
+func TestColumnPicker_TogglingDoesNotSave(t *testing.T) {
+	m := newTestEventsModel(t)
+	saves := recordSaves(t, m)
+
+	m.handleKey(keyRune('c'))
+	for i := 0; i < 4; i++ {
+		m.handleKey(keyRune(' '))
+		m.handleKey(keyRune('j'))
+	}
+	m.handleKey(keyRune('r')) // reset is a toggle too, not a commit
+	if len(*saves) != 0 {
+		t.Errorf("%d saves while the picker was still open, want 0", len(*saves))
+	}
+}
+
+// TestColumnPicker_QuitDoesNotSave: `q` inside the picker falls through to the
+// global quit handler. Quitting is not settling on a selection.
+func TestColumnPicker_QuitDoesNotSave(t *testing.T) {
+	m := newTestEventsModel(t)
+	// `q` cancels the context on its way to tea.Quit.
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	saves := recordSaves(t, m)
+
+	m.handleKey(keyRune('c'))
+	m.handleKey(keyRune(' '))
+	m.handleKey(keyRune('q'))
+	if len(*saves) != 0 {
+		t.Errorf("`q` in the picker saved %d times, want 0", len(*saves))
+	}
+}
+
+// TestPersistSettings_NilHookIsSafe: nil means "no persistence", which is what
+// every other test in this package relies on implicitly and what main passes when
+// there is no resolvable home directory.
+func TestPersistSettings_NilHookIsSafe(t *testing.T) {
+	m := newTestEventsModel(t)
+	resetSettingsForTest(t)
+	m.save = nil
+
+	m.handleKey(keyRune('c'))
+	m.handleKey(keyRune(' '))
+	m.handleKey(keyRune('c')) // close: would call the nil hook
+	if m.colPicker {
+		t.Error("picker did not close")
+	}
+}
+
+// TestPersistSettings_FailureFlashesAndDoesNotCrash: the TUI owns the terminal, so
+// a failed save cannot go to stderr. It goes to the footer once and is dropped.
+func TestPersistSettings_FailureFlashesAndDoesNotCrash(t *testing.T) {
+	m := newTestEventsModel(t)
+	resetSettingsForTest(t)
+	m.save = func(UserSettings) error { return errors.New("read-only file system") }
+
+	m.handleKey(keyRune('c'))
+	m.handleKey(keyRune(' '))
+	m.handleKey(keyRune('c'))
+
+	if m.colPicker {
+		t.Error("a failed save left the picker open")
+	}
+	if !strings.Contains(m.flash, "could not save settings") {
+		t.Errorf("flash = %q, want it to name the failed save", m.flash)
+	}
+	if !strings.Contains(m.flash, "read-only file system") {
+		t.Errorf("flash = %q, want the underlying cause", m.flash)
+	}
+}
+
+// TestFilter_EnterCommitsAndSaves: Enter is the commit, so that is where the
+// filter persists.
+func TestFilter_EnterCommitsAndSaves(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.filterInput = newTestFilterInput()
+	saves := recordSaves(t, m)
+
+	m.handleKey(keyRune('/'))
+	for _, r := range "github" {
+		m.handleKey(keyRune(r))
+	}
+	if len(*saves) != 0 {
+		t.Fatalf("typing saved %d times; the save belongs on commit", len(*saves))
+	}
+
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if len(*saves) != 1 {
+		t.Fatalf("Enter produced %d saves, want 1", len(*saves))
+	}
+	if got := (*saves)[0].Filter; got != "github" {
+		t.Errorf("saved filter = %q, want %q", got, "github")
+	}
+}
+
+// TestFilter_KeystrokesDoNotSave: m.filter is re-read on every character typed
+// (the fallthrough in the filtering block), so a save there would write once per
+// keypress.
+func TestFilter_KeystrokesDoNotSave(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.filterInput = newTestFilterInput()
+	saves := recordSaves(t, m)
+
+	m.handleKey(keyRune('/'))
+	for _, r := range "abcdefgh" {
+		m.handleKey(keyRune(r))
+	}
+	if len(*saves) != 0 {
+		t.Errorf("%d saves while typing, want 0", len(*saves))
+	}
+}
+
+// TestFilter_EscClearsAndSaves: dismissing a filter is as deliberate as setting
+// one, so the cleared value persists — otherwise a filter the user explicitly got
+// rid of would return on the next start.
+func TestFilter_EscClearsAndSaves(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.filterInput = newTestFilterInput()
+	resetSettingsForTest(t)
+	Settings.Filter = "stale"
+	m.filter = "stale"
+	var got []UserSettings
+	m.save = func(s UserSettings) error { got = append(got, s); return nil }
+
+	m.handleKey(keyRune('/'))
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if len(got) != 1 {
+		t.Fatalf("Esc produced %d saves, want 1", len(got))
+	}
+	if got[0].Filter != "" {
+		t.Errorf("saved filter = %q, want it cleared", got[0].Filter)
+	}
+	if m.filter != "" {
+		t.Errorf("m.filter = %q, want it cleared", m.filter)
+	}
+}
+
+// TestBackToPodsPane_DoesNotEraseTheSavedFilter is the trap in this design.
+// backToPodsPane clears the ACTIVE filter so it cannot survive a pod switch and
+// read as data loss — but that clear must not reach Settings, or backing out of a
+// pane would silently discard the filter the user saved.
+func TestBackToPodsPane_DoesNotEraseTheSavedFilter(t *testing.T) {
+	m := newPickerModel(context.Background(), nil, nil)
+	saves := recordSaves(t, m)
+	Settings.Filter = "github"
+	m.filter = "github"
+	m.parentCtx = context.Background()
+
+	m.backToPodsPane()
+
+	if m.filter != "" {
+		t.Errorf("m.filter = %q; the active filter should clear on teardown", m.filter)
+	}
+	if Settings.Filter != "github" {
+		t.Errorf("Settings.Filter = %q, want the saved value untouched by teardown", Settings.Filter)
+	}
+	if len(*saves) != 0 {
+		t.Errorf("teardown saved %d times, want 0 — it is not a user action", len(*saves))
+	}
+}
+
+// TestConstructors_SeedFromSettings: both constructors must honour a loaded
+// config. newPickerModel historically set neither field, so the picker path
+// ignored the user's saved selection entirely.
+func TestConstructors_SeedFromSettings(t *testing.T) {
+	resetSettingsForTest(t)
+	Settings = UserSettings{
+		Events: EventSettings{Columns: []ColumnSetting{{Name: string(colCost), Visible: false}}},
+		Filter: "seeded",
+	}
+
+	for _, tc := range []struct {
+		name string
+		m    *model
+	}{
+		{"New", New(context.Background(), apiclient.New("http://localhost:0")).(*model)},
+		{"newPickerModel", newPickerModel(context.Background(), nil, nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.m.eventColumns == nil {
+				t.Fatal("eventColumns is nil; the column picker would panic writing to it")
+			}
+			if tc.m.eventColumns[colCost] {
+				t.Error("COST was saved off but the model has it on")
+			}
+			if !tc.m.eventColumns[colHost] {
+				t.Error("HOST was not mentioned in the config and should default on")
+			}
+			if tc.m.filter != "seeded" {
+				t.Errorf("filter = %q, want the saved %q", tc.m.filter, "seeded")
+			}
+		})
+	}
+}

--- a/authbridge/cmd/abctl/tui/settings_persist_test.go
+++ b/authbridge/cmd/abctl/tui/settings_persist_test.go
@@ -191,29 +191,111 @@ func TestFilter_KeystrokesDoNotSave(t *testing.T) {
 	}
 }
 
-// TestFilter_EscClearsAndSaves: dismissing a filter is as deliberate as setting
-// one, so the cleared value persists — otherwise a filter the user explicitly got
-// rid of would return on the next start.
-func TestFilter_EscClearsAndSaves(t *testing.T) {
+// TestFilter_EscCancelsAndPersistsNothing: Esc means cancel here as it does
+// everywhere else in abctl, so it restores the filter that was in effect when `/`
+// was pressed and writes nothing.
+//
+// It used to clear the filter outright. Harmless while filters were per-session;
+// once they persisted, one mis-keyed Esc permanently discarded a committed filter —
+// while the README and the code comment both called the key "cancel".
+func TestFilter_EscCancelsAndPersistsNothing(t *testing.T) {
 	m := newTestEventsModel(t)
 	m.filterInput = newTestFilterInput()
 	resetSettingsForTest(t)
-	Settings.Filter = "stale"
-	m.filter = "stale"
+	Settings.Filter = "committed"
+	m.filter = "committed"
+	m.filterInput.SetValue("committed")
+	var got []UserSettings
+	m.save = func(s UserSettings) error { got = append(got, s); return nil }
+
+	// Edit, then change your mind.
+	m.handleKey(keyRune('/'))
+	m.handleKey(keyRune('x'))
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if len(got) != 0 {
+		t.Errorf("Esc saved %d times, want 0 — cancelling is not a decision to record", len(got))
+	}
+	if Settings.Filter != "committed" {
+		t.Errorf("Settings.Filter = %q, want the committed filter untouched", Settings.Filter)
+	}
+	if m.filter != "committed" {
+		t.Errorf("m.filter = %q, want the pre-edit filter restored", m.filter)
+	}
+	if got := m.filterInput.Value(); got != "committed" {
+		t.Errorf("filterInput = %q, want the pre-edit value restored so the next `/` is not "+
+			"pre-loaded with the abandoned edit", got)
+	}
+}
+
+// TestFilter_ClearingIsCommittedWithEnter: Esc no longer clears, so emptying the box
+// and pressing Enter is the way to clear a filter and make that durable. Without
+// this there would be no way to discard a saved filter from the TUI at all.
+func TestFilter_ClearingIsCommittedWithEnter(t *testing.T) {
+	m := newTestEventsModel(t)
+	m.filterInput = newTestFilterInput()
+	resetSettingsForTest(t)
+	Settings.Filter = "committed"
+	m.filter = "committed"
+	m.filterInput.SetValue("committed")
 	var got []UserSettings
 	m.save = func(s UserSettings) error { got = append(got, s); return nil }
 
 	m.handleKey(keyRune('/'))
-	m.handleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	m.filterInput.SetValue("")
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 
 	if len(got) != 1 {
-		t.Fatalf("Esc produced %d saves, want 1", len(got))
+		t.Fatalf("Enter on an empty box produced %d saves, want 1", len(got))
 	}
 	if got[0].Filter != "" {
 		t.Errorf("saved filter = %q, want it cleared", got[0].Filter)
 	}
 	if m.filter != "" {
 		t.Errorf("m.filter = %q, want it cleared", m.filter)
+	}
+}
+
+// TestBackToPodsPane_ClearsTheFilterInputToo: the input is seeded from saved
+// settings, which makes it a second source of truth that teardown has to reset.
+//
+// Leaving it behind meant that after backing out to the pod list and entering the
+// next pod, the list was correctly unfiltered and the footer badge correctly gone,
+// but `/` presented the OLD filter text already in the box — so one keystroke
+// committed "github-toolx" and Enter persisted it.
+func TestBackToPodsPane_ClearsTheFilterInputToo(t *testing.T) {
+	resetSettingsForTest(t)
+	m := newPickerModel(context.Background(), nil, nil)
+	m.parentCtx = context.Background()
+	m.bodyHeight, m.width = 12, 200
+	var got []UserSettings
+	m.save = func(s UserSettings) error { got = append(got, s); return nil }
+
+	m.pane = paneSessions
+	m.handleKey(keyRune('/'))
+	for _, r := range "github-tool" {
+		m.handleKey(keyRune(r))
+	}
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	m.backToPodsPane()
+
+	if v := m.filterInput.Value(); v != "" {
+		t.Fatalf("filterInput = %q after teardown; the next `/` starts pre-loaded with it", v)
+	}
+
+	// The next pod: `/` then one character must mean that one character.
+	m.pane = paneSessions
+	m.handleKey(keyRune('/'))
+	m.handleKey(keyRune('x'))
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.filter != "x" {
+		t.Errorf("filter = %q, want %q — the previous pod's filter leaked into this one",
+			m.filter, "x")
+	}
+	if Settings.Filter != "x" {
+		t.Errorf("Settings.Filter = %q, want %q persisted", Settings.Filter, "x")
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/settings_persist_test.go
+++ b/authbridge/cmd/abctl/tui/settings_persist_test.go
@@ -271,6 +271,56 @@ func TestConstructors_SeedFromSettings(t *testing.T) {
 			if tc.m.filter != "seeded" {
 				t.Errorf("filter = %q, want the saved %q", tc.m.filter, "seeded")
 			}
+			// The input, not just the value. Seeding only m.filter applied the filter
+			// invisibly — the filter box renders only while filtering, so the list came
+			// back truncated with nothing on screen saying why — and worse, `/` then one
+			// character REPLACED the saved filter, while `/` then Esc persisted an empty
+			// one and discarded it for good. Asserting m.filter alone passed throughout.
+			if got := tc.m.filterInput.Value(); got != "seeded" {
+				t.Errorf("filterInput = %q, want the saved filter pre-filled so `/` edits "+
+					"it rather than replacing it", got)
+			}
 		})
+	}
+}
+
+// TestRestoredFilter_IsEditableRatherThanReplaced: with only m.filter seeded, `/`
+// opened an EMPTY box, so the first character typed replaced the saved filter
+// instead of extending it. Pressing `/` on a restored filter must land the cursor
+// in the value that is actually in effect.
+func TestRestoredFilter_IsEditableRatherThanReplaced(t *testing.T) {
+	resetSettingsForTest(t)
+	Settings.Filter = "github"
+	m := New(context.Background(), apiclient.New("http://127.0.0.1:1")).(*model)
+	m.bodyHeight, m.width = 12, 200
+
+	m.handleKey(keyRune('/'))
+	m.handleKey(keyRune('-'))
+	m.handleKey(keyRune('t'))
+	m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if got := m.filter; got != "github-t" {
+		t.Errorf("filter = %q, want the restored value extended to %q", got, "github-t")
+	}
+}
+
+// TestRestoredFilter_ShowsInTheFooterWhileInactive: the filter box renders only
+// while filtering, so a restored filter silently truncated the list. The footer is
+// the only place left to say so.
+func TestRestoredFilter_ShowsInTheFooterWhileInactive(t *testing.T) {
+	resetSettingsForTest(t)
+	Settings.Filter = "github"
+	m := New(context.Background(), apiclient.New("http://127.0.0.1:1")).(*model)
+	m.width, m.height, m.bodyHeight = 200, 40, 12
+
+	if got := m.footerView(); !strings.Contains(got, "github") {
+		t.Errorf("footer does not mention the active filter, so a truncated list has no "+
+			"explanation on screen:\n%s", got)
+	}
+
+	// While editing, the input box carries it and the indicator would be redundant.
+	m.handleKey(keyRune('/'))
+	if got := m.footerView(); strings.Contains(got, "[filter:") {
+		t.Errorf("footer shows the indicator while the filter box is open:\n%s", got)
 	}
 }

--- a/authbridge/cmd/abctl/tui/settings_test.go
+++ b/authbridge/cmd/abctl/tui/settings_test.go
@@ -150,3 +150,61 @@ func TestColumnSettings_RoundTrip(t *testing.T) {
 		t.Errorf("round trip = %v, want %v", got, want)
 	}
 }
+
+// TestColumnSelection_AbsentHonorsDefaultOn: "absent from the file" means "the user
+// never changed this", so the fallback must be the column's own defaultOn — not a
+// literal true.
+//
+// Cannot be observed through eventColumns as it stands: all twelve entries are
+// defaultOn, so the two spellings agree. This substitutes a table containing a
+// defaultOn:false column, which is what a future column would look like, and pins
+// that columnSelection agrees with defaultColumnSelection about it.
+func TestColumnSelection_AbsentHonorsDefaultOn(t *testing.T) {
+	prev := eventColumns
+	t.Cleanup(func() { eventColumns = prev })
+	eventColumns = []eventColumn{
+		{id: colTime, width: 12, defaultOn: true, cell: func(cellContext) string { return "" }},
+		{id: "OPTIONAL", width: 8, defaultOn: false, cell: func(cellContext) string { return "" }},
+	}
+
+	// Nothing in the file: each column gets its own default.
+	got := (UserSettings{}).columnSelection()
+	if !got[colTime] {
+		t.Error("a defaultOn:true column is off with an empty config")
+	}
+	if got["OPTIONAL"] {
+		t.Error("a defaultOn:false column is ON with an empty config; absent must mean the default, not visible")
+	}
+	if want := defaultColumnSelection(); !reflect.DeepEqual(got, want) {
+		t.Errorf("columnSelection = %v, want it to agree with defaultColumnSelection %v", got, want)
+	}
+
+	// A file can still turn the opt-in column on explicitly.
+	on := UserSettings{Events: EventSettings{Columns: []ColumnSetting{{Name: "OPTIONAL", Visible: true}}}}
+	if !on.columnSelection()["OPTIONAL"] {
+		t.Error("an explicit visible:true did not turn on a defaultOn:false column")
+	}
+}
+
+// TestColumnSettings_RoundTripsADefaultOffColumn: turning ON a defaultOn:false
+// column is as much a deviation as turning a default one off, so it has to survive
+// a save/load. Recording only the off-list would make it unpersistable — the user
+// would enable the column, close the picker, and find it off again next launch.
+func TestColumnSettings_RoundTripsADefaultOffColumn(t *testing.T) {
+	prev := eventColumns
+	t.Cleanup(func() { eventColumns = prev })
+	eventColumns = []eventColumn{
+		{id: colTime, width: 12, defaultOn: true, cell: func(cellContext) string { return "" }},
+		{id: "OPTIONAL", width: 8, defaultOn: false, cell: func(cellContext) string { return "" }},
+	}
+
+	want := map[eventColumnID]bool{colTime: true, "OPTIONAL": true}
+	written := columnSettingsFrom(want)
+	if len(written) != 1 || written[0] != (ColumnSetting{Name: "OPTIONAL", Visible: true}) {
+		t.Fatalf("wrote %+v, want just OPTIONAL visible:true", written)
+	}
+	got := UserSettings{Events: EventSettings{Columns: written}}.columnSelection()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round trip = %v, want %v", got, want)
+	}
+}

--- a/authbridge/cmd/abctl/tui/settings_test.go
+++ b/authbridge/cmd/abctl/tui/settings_test.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+)
+
+// resetSettingsForTest clears the package-level Settings and restores it after the
+// test. Settings is global (see its doc comment), so without this a test that sets
+// a filter leaks it into every later test in the package — and the failure would
+// surface as an unrelated test failing depending on run order.
+//
+// t.Cleanup rather than a defer in each caller: the reset has to happen even when
+// the test fails partway through.
+func resetSettingsForTest(t *testing.T) {
+	t.Helper()
+	prev := Settings
+	Settings = UserSettings{}
+	t.Cleanup(func() { Settings = prev })
+}
+
+// TestColumnSelection_AbsentColumnsDefaultOn is the headline rule of the file
+// format: the config records deviations, so a column the file does not mention is
+// VISIBLE. Inverting this would mean a column added in a later abctl starts hidden
+// for everyone who already has a config file.
+func TestColumnSelection_AbsentColumnsDefaultOn(t *testing.T) {
+	s := UserSettings{Events: EventSettings{Columns: []ColumnSetting{
+		{Name: string(colCost), Visible: false},
+	}}}
+	sel := s.columnSelection()
+
+	if sel[colCost] {
+		t.Errorf("COST was named visible:false in the config but is on")
+	}
+	// Every other column — eleven of them — must be on without being mentioned.
+	for _, c := range eventColumns {
+		if c.id == colCost {
+			continue
+		}
+		if !sel[c.id] {
+			t.Errorf("column %q is absent from the config and should default ON, got off", c.id)
+		}
+	}
+}
+
+// TestColumnSelection_EmptyConfigIsAllDefaults: the zero value (no file, or a file
+// with no columns key) must be exactly the built-in selection.
+func TestColumnSelection_EmptyConfigIsAllDefaults(t *testing.T) {
+	got, want := (UserSettings{}).columnSelection(), defaultColumnSelection()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty config selection = %v, want the defaults %v", got, want)
+	}
+}
+
+// TestColumnSelection_UnknownNamesAreIgnored: a name from a newer build (or a
+// typo) must not create a map key with no column behind it. anyColumnSelected and
+// selectedColumns both walk eventColumns, so a phantom key would make the former
+// claim a selection the latter cannot render.
+func TestColumnSelection_UnknownNamesAreIgnored(t *testing.T) {
+	s := UserSettings{Events: EventSettings{Columns: []ColumnSetting{
+		{Name: "WARP_DRIVE", Visible: false},
+		{Name: string(colHost), Visible: false},
+	}}}
+	sel := s.columnSelection()
+
+	if _, ok := sel["WARP_DRIVE"]; ok {
+		t.Error("unknown column name leaked into the selection map")
+	}
+	if len(sel) != len(eventColumns) {
+		t.Errorf("selection has %d entries, want one per known column (%d)", len(sel), len(eventColumns))
+	}
+	// The known entry alongside it still applies — one bad name must not discard
+	// the rest of the file.
+	if sel[colHost] {
+		t.Error("HOST was named visible:false but is on; a neighbouring unknown name should not void it")
+	}
+}
+
+// TestColumnSelection_AllOffFallsBackToDefaults: a hand-edited file can turn
+// everything off, which would render a table with no columns. selectedColumns'
+// fallback rescues the render but not the picker's checkboxes, so the selection
+// itself is re-seeded — matching what the toggle handler already does.
+func TestColumnSelection_AllOffFallsBackToDefaults(t *testing.T) {
+	var all []ColumnSetting
+	for _, c := range eventColumns {
+		all = append(all, ColumnSetting{Name: string(c.id), Visible: false})
+	}
+	s := UserSettings{Events: EventSettings{Columns: all}}
+
+	if got, want := s.columnSelection(), defaultColumnSelection(); !reflect.DeepEqual(got, want) {
+		t.Errorf("all-off config selection = %v, want the defaults %v", got, want)
+	}
+}
+
+// TestColumnSettingsFrom_RecordsOnlyDeviations: an untouched selection serialises
+// to nothing, so a user who never opened the picker gets no columns key at all
+// rather than twelve `visible: true` lines.
+func TestColumnSettingsFrom_RecordsOnlyDeviations(t *testing.T) {
+	if got := columnSettingsFrom(defaultColumnSelection()); len(got) != 0 {
+		t.Errorf("default selection serialised to %v, want nothing written down", got)
+	}
+
+	sel := defaultColumnSelection()
+	sel[colTokens] = false
+	got := columnSettingsFrom(sel)
+	want := []ColumnSetting{{Name: string(colTokens), Visible: false}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("one column off serialised to %v, want %v", got, want)
+	}
+}
+
+// TestColumnSettingsFrom_IsDeterministicInDisplayOrder: Go randomises map
+// iteration, so emitting in map order would rewrite the file with the same
+// entries reshuffled on every save — invisible in the TUI, obvious in a diff.
+func TestColumnSettingsFrom_IsDeterministicInDisplayOrder(t *testing.T) {
+	sel := defaultColumnSelection()
+	sel[colHost] = false
+	sel[colIndex] = false
+	sel[colMethod] = false
+
+	first := columnSettingsFrom(sel)
+	// Display order, per eventColumns: # before METHOD before HOST.
+	want := []ColumnSetting{
+		{Name: string(colIndex), Visible: false},
+		{Name: string(colMethod), Visible: false},
+		{Name: string(colHost), Visible: false},
+	}
+	if !reflect.DeepEqual(first, want) {
+		t.Errorf("got %v, want display order %v", first, want)
+	}
+	// Repeat on the same map: map iteration order varies between range loops, so a
+	// single call cannot catch this.
+	for i := 0; i < 20; i++ {
+		if got := columnSettingsFrom(sel); !reflect.DeepEqual(got, first) {
+			t.Fatalf("iteration %d returned %v, want the stable %v", i, got, first)
+		}
+	}
+}
+
+// TestColumnSettings_RoundTrip: selection → file → selection is the identity, for
+// a non-default selection. This is what makes a saved preference actually come
+// back on the next start.
+func TestColumnSettings_RoundTrip(t *testing.T) {
+	want := defaultColumnSelection()
+	want[colCost] = false
+	want[colDuration] = false
+
+	s := UserSettings{Events: EventSettings{Columns: columnSettingsFrom(want)}}
+	if got := s.columnSelection(); !reflect.DeepEqual(got, want) {
+		t.Errorf("round trip = %v, want %v", got, want)
+	}
+}

--- a/authbridge/cmd/abctl/userconfig.go
+++ b/authbridge/cmd/abctl/userconfig.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/tui"
+)
+
+// userCfgRel is abctl's own settings file, relative to the user's home.
+//
+// A sibling of ~/.cortex/config.yaml (the PROXY's config), in the same tree but
+// under a distinct name, because the two have nothing to do with each other: one
+// is operator configuration the proxy reads at startup, this one is UI state abctl
+// writes back as the user works. Follows cortexCfgRel / stateRel and tui's
+// yankDirRel so there is one ~/.cortex tree rather than a new dotfile per tool.
+const userCfgRel = ".cortex/abctl-config.yaml"
+
+// userConfigPath returns ~/.cortex/abctl-config.yaml.
+//
+// Errors rather than falling back to a relative path: a settings file written into
+// whatever directory abctl happened to start in would be found again only by
+// accident, and the caller's fallback (no persistence) is honest about what
+// happened. UserHomeDir only fails when $HOME is unset — a bare `env -i`, some
+// systemd units — so this costs nothing anyone hits by accident.
+func userConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine your home directory: %w", err)
+	}
+	if home == "" {
+		// A separate branch, not folded into the one above: %w on a nil error renders
+		// as "%!w(<nil>)", which would make this path unreadable to whoever hits it.
+		return "", errors.New("cannot determine your home directory: it is empty")
+	}
+	return filepath.Join(home, userCfgRel), nil
+}
+
+// loadUserConfig reads the settings file, degrading to defaults rather than
+// failing. It never returns an error, because there is no error worth stopping for:
+// settings are a convenience, and a corrupt one must not keep the viewer from
+// opening — the viewer being the tool you reach for when everything else is broken.
+//
+// A missing file is silent: nobody has one until they change something, and
+// scolding a first run for that would be noise on every fresh machine. Anything
+// else — unreadable, unparseable, a directory where a file should be — warns once
+// on warn and continues, because silently ignoring a file the user hand-edited
+// would look like abctl ignoring their edit.
+//
+// warn is an io.Writer rather than a hardcoded os.Stderr so tests assert on the
+// message. Callers must pass a writer that is safe to use before bubbletea takes
+// the alt screen; after that, writing to the terminal corrupts the frame.
+func loadUserConfig(path string, warn io.Writer) tui.UserSettings {
+	if path == "" {
+		return tui.UserSettings{}
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(warn, "abctl: ignoring %s: %v; using default settings\n", path, err)
+		}
+		return tui.UserSettings{}
+	}
+	var s tui.UserSettings
+	if err := yaml.Unmarshal(body, &s); err != nil {
+		fmt.Fprintf(warn, "abctl: ignoring %s: %v; using default settings\n", path, err)
+		// Discard the struct entirely rather than keeping what parsed: yaml.v3 can
+		// populate some fields before erroring, and half a config applied silently is
+		// harder to diagnose than none.
+		return tui.UserSettings{}
+	}
+	return s
+}
+
+// saveUserConfig writes s to path, creating ~/.cortex if it is not there.
+//
+// abctl does not otherwise create that directory — the proxy's writeBuiltinConfig
+// does, and tui's yank path is the one exception — so on a machine that has only
+// ever run the viewer, this is the first thing to make it. 0700 matches what
+// writeBuiltinConfig sets.
+//
+// SECURITY, considered rather than skipped: this deliberately does NOT use the
+// Lstat-every-component sweep that tui's checkYankDir applies to the same tree.
+// That sweep exists because yanked events carry identity subjects, raw LLM
+// completions and tool arguments, so a redirected write leaks secrets. This file
+// holds a filter string and a list of column names — a redirect leaks nothing worth
+// having, and the sweep's other half (chmod 0700 in place) would mean that merely
+// opening the viewer retightens a directory the user or an installer deliberately
+// set. The residual symlink risk is closed more cheaply instead: O_EXCL refuses a
+// pre-planted tempfile, and os.Rename replaces a symlink at the destination rather
+// than following it.
+//
+// What would change that calculus: any future setting holding a secret, a
+// filesystem path, or a command line. At that point this needs checkYankDir's
+// posture, not this comment.
+func saveUserConfig(path string, s tui.UserSettings) error {
+	if path == "" {
+		return errors.New("no settings path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	body, err := yaml.Marshal(s)
+	if err != nil {
+		return err
+	}
+	// Atomic: a crash between truncate and write would otherwise leave a half-file
+	// that the next start reports as malformed. Same shape cmd_config_migrate.go uses.
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(fileHeader); err == nil {
+		_, err = f.Write(body)
+	}
+	if cerr := f.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// fileHeader explains the file to whoever opens it, since it is meant to be
+// hand-editable. The absent-means-visible rule is the one thing that is not
+// guessable from the contents.
+var fileHeader = []byte("# abctl user settings. Written by abctl; safe to hand-edit or delete.\n" +
+	"# Columns not listed under events.columns are visible — only deviations are recorded.\n")

--- a/authbridge/cmd/abctl/userconfig.go
+++ b/authbridge/cmd/abctl/userconfig.go
@@ -130,8 +130,14 @@ func saveUserConfig(path string, s tui.UserSettings) error {
 		return err
 	}
 	tmp := f.Name()
-	if _, err := f.Write(fileHeader); err == nil {
-		_, err = f.Write(body)
+	// err, not a fresh `err :=`. An earlier version wrote `if _, err := f.Write(...)`,
+	// which declared a NEW err scoped to the if: both writes landed in it, it was
+	// discarded, and the outer err stayed nil — so Close and Rename saw success and a
+	// truncated settings file was renamed over the good one, with saveUserConfig
+	// returning nil. The next start would have reported a malformed config and nothing
+	// would have said why.
+	if _, err = writeAll(f, fileHeader); err == nil {
+		_, err = writeAll(f, body)
 	}
 	if cerr := f.Close(); err == nil {
 		err = cerr
@@ -158,3 +164,8 @@ func saveUserConfig(path string, s tui.UserSettings) error {
 // guessable from the contents.
 var fileHeader = []byte("# abctl user settings. Written by abctl; safe to hand-edit or delete.\n" +
 	"# Columns not listed under events.columns are visible — only deviations are recorded.\n")
+
+// writeAll is io.Writer.Write, indirected so a test can make a write fail. The
+// shadowing bug above was invisible to every test because a write to a tempfile on
+// a working filesystem does not fail, so the only way to pin it is to inject one.
+var writeAll = func(w io.Writer, p []byte) (int, error) { return w.Write(p) }

--- a/authbridge/cmd/abctl/userconfig.go
+++ b/authbridge/cmd/abctl/userconfig.go
@@ -91,9 +91,10 @@ func loadUserConfig(path string, warn io.Writer) tui.UserSettings {
 // holds a filter string and a list of column names — a redirect leaks nothing worth
 // having, and the sweep's other half (chmod 0700 in place) would mean that merely
 // opening the viewer retightens a directory the user or an installer deliberately
-// set. The residual symlink risk is closed more cheaply instead: O_EXCL refuses a
-// pre-planted tempfile, and os.Rename replaces a symlink at the destination rather
-// than following it.
+// set. The residual symlink risk is closed more cheaply instead: the tempfile is
+// created by os.CreateTemp, whose name an attacker cannot predict and which passes
+// O_EXCL itself, and os.Rename replaces a symlink at the destination rather than
+// following it.
 //
 // What would change that calculus: any future setting holding a secret, a
 // filesystem path, or a command line. At that point this needs checkYankDir's
@@ -110,12 +111,25 @@ func saveUserConfig(path string, s tui.UserSettings) error {
 		return err
 	}
 	// Atomic: a crash between truncate and write would otherwise leave a half-file
-	// that the next start reports as malformed. Same shape cmd_config_migrate.go uses.
-	tmp := path + ".tmp"
-	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	// that the next start reports as malformed.
+	//
+	// CreateTemp, not a fixed path+".tmp" with O_EXCL. That combination looked
+	// stronger and was strictly worse: a hard kill between create and rename leaves
+	// the tempfile behind, and every save afterwards fails with "file exists" —
+	// forever, visible only as a footer flash the user cannot act on, with the config
+	// frozen at its pre-crash value. Verified before this change: five consecutive
+	// saves failed and the file never moved.
+	//
+	// CreateTemp keeps what O_EXCL was there for. It passes O_EXCL itself on a name
+	// no attacker can predict, so a pre-planted symlink cannot be written through
+	// (the test for that still passes), while crash debris is inert rather than
+	// wedging. It is also what every other tempfile in this module uses —
+	// toolscan/patch.go, tui's yank, edit's two.
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return err
 	}
+	tmp := f.Name()
 	if _, err := f.Write(fileHeader); err == nil {
 		_, err = f.Write(body)
 	}
@@ -123,6 +137,12 @@ func saveUserConfig(path string, s tui.UserSettings) error {
 		err = cerr
 	}
 	if err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	// CreateTemp makes the file 0600 already; chmod is belt-and-braces against a
+	// umask surprise and costs one syscall on a path taken once per keypress at most.
+	if err := os.Chmod(tmp, 0o600); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}

--- a/authbridge/cmd/abctl/userconfig_e2e_test.go
+++ b/authbridge/cmd/abctl/userconfig_e2e_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/tui"
+)
+
+// End-to-end through the real file: save what the TUI would produce, then load it
+// back the way main does at startup. This is the loop the feature exists for, and
+// no other test spans both packages.
+func TestEndToEnd_SettingsSurviveARestart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	path, err := userConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".cortex", "abctl-config.yaml"); path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+
+	// --- "first run": nothing on disk, defaults, no complaint.
+	var warn bytes.Buffer
+	tui.Settings = loadUserConfig(path, &warn)
+	if warn.Len() != 0 {
+		t.Errorf("first run warned: %q", warn.String())
+	}
+
+	// --- the user turns COST off and commits a filter, as the key handlers do.
+	tui.Settings.Events.Columns = []tui.ColumnSetting{{Name: "COST", Visible: false}}
+	tui.Settings.Filter = "github-tool"
+	if err := saveUserConfig(path, tui.Settings); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("file on disk:\n%s", body)
+
+	// --- "restart": a fresh process loads it.
+	tui.Settings = tui.UserSettings{}
+	warn.Reset()
+	tui.Settings = loadUserConfig(path, &warn)
+	if warn.Len() != 0 {
+		t.Errorf("reload warned: %q", warn.String())
+	}
+	if tui.Settings.Filter != "github-tool" {
+		t.Errorf("filter = %q after restart, want it remembered", tui.Settings.Filter)
+	}
+	if len(tui.Settings.Events.Columns) != 1 || tui.Settings.Events.Columns[0].Name != "COST" {
+		t.Errorf("columns = %+v after restart", tui.Settings.Events.Columns)
+	}
+}

--- a/authbridge/cmd/abctl/userconfig_test.go
+++ b/authbridge/cmd/abctl/userconfig_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -360,4 +362,85 @@ func reflectDeepEqualSettings(a, b tui.UserSettings) bool {
 		}
 	}
 	return true
+}
+
+// TestSaveUserConfig_ReportsAWriteFailure: a write that fails must not be renamed
+// into place and reported as success.
+//
+// The bug this pins was a shadowed variable: `if _, err := f.Write(...)` declared a
+// NEW err scoped to the if, so both writes landed in it and it was discarded. The
+// outer err stayed nil, Close and Rename saw nil, and a truncated settings file was
+// renamed over the good one while saveUserConfig returned success — the footer would
+// have shown nothing and the next start would have warned about a malformed file.
+//
+// Driven by filling the filesystem, which is not portable, so this uses the one
+// reliably-failing write available: a tempfile directory on a read-only parent makes
+// CreateTemp itself fail, which covers the early return. For the write path proper,
+// the guard is that err is assigned rather than shadowed — checked by vet's
+// shadow-adjacent analysers and by this test's sibling below.
+func TestSaveUserConfig_ReportsACreateFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix modes")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	home := prefsHome(t)
+	dir := filepath.Join(home, ".cortex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Read-only directory: MkdirAll succeeds (it exists), CreateTemp cannot.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := saveUserConfig(filepath.Join(dir, "abctl-config.yaml"), tui.UserSettings{Filter: "x"}); err == nil {
+		t.Error("saveUserConfig reported success on an unwritable directory")
+	}
+}
+
+// TestSaveUserConfig_AWriteFailureDoesNotClobberTheGoodFile is the shadowing bug
+// proper: a failed write must not be renamed into place, and must be reported.
+//
+// Injects the failure because a write to a tempfile on a working filesystem does
+// not fail, which is precisely why the bug survived every other test here.
+func TestSaveUserConfig_AWriteFailureDoesNotClobberTheGoodFile(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "good"}); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := writeAll
+	t.Cleanup(func() { writeAll = prev })
+	writeAll = func(io.Writer, []byte) (int, error) { return 0, errors.New("no space left on device") }
+
+	err := saveUserConfig(path, tui.UserSettings{Filter: "truncated"})
+	if err == nil {
+		t.Error("a failed write reported success; a truncated file would be renamed into place")
+	} else if !strings.Contains(err.Error(), "no space left") {
+		t.Errorf("error = %v, want the underlying write failure", err)
+	}
+
+	// The good file must still be there and still good.
+	writeAll = prev
+	var warn bytes.Buffer
+	if got := loadUserConfig(path, &warn).Filter; got != "good" {
+		t.Errorf("filter = %q; the previous config was clobbered by a failed save", got)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("config no longer parses after a failed save: %q", warn.String())
+	}
+	// And no debris left behind.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("failed save left a tempfile: %s", e.Name())
+		}
+	}
 }

--- a/authbridge/cmd/abctl/userconfig_test.go
+++ b/authbridge/cmd/abctl/userconfig_test.go
@@ -271,10 +271,16 @@ func TestSaveUserConfig_OverwritesAnExistingFile(t *testing.T) {
 	}
 }
 
-// TestSaveUserConfig_RefusesAPrePlantedTempfile is the residual symlink risk that
-// O_EXCL closes, and the reason saveUserConfig does not need checkYankDir's sweep.
-// A tempfile another local user planted must not be written through.
-func TestSaveUserConfig_RefusesAPrePlantedTempfile(t *testing.T) {
+// TestSaveUserConfig_DoesNotWriteThroughAPlantedTempfile is the residual symlink
+// risk, and the reason saveUserConfig does not need checkYankDir's Lstat sweep.
+//
+// Asserts the PROPERTY (the planted target is never written) rather than the
+// mechanism. An earlier version demanded an error, which pinned the fixed-name
+// O_EXCL implementation — and that implementation wedged permanently on crash
+// debris. CreateTemp writes to an unpredictable name, so a planted symlink is
+// bypassed entirely: the save succeeds and the attacker's file is untouched, which
+// is a better outcome than the refusal, not a weaker one.
+func TestSaveUserConfig_DoesNotWriteThroughAPlantedTempfile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlinks")
 	}
@@ -287,19 +293,57 @@ func TestSaveUserConfig_RefusesAPrePlantedTempfile(t *testing.T) {
 	if err := os.WriteFile(target, []byte("untouched\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	// The name the old implementation used, and the obvious guess for an attacker.
 	if err := os.Symlink(target, path+".tmp"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := saveUserConfig(path, tui.UserSettings{Filter: "x"}); err == nil {
-		t.Error("saved through a pre-planted tempfile symlink, want a refusal")
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "x"}); err != nil {
+		t.Fatalf("save failed: %v", err)
 	}
+
 	body, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(body) != "untouched\n" {
 		t.Errorf("symlink target was written through: %q", body)
+	}
+	// And the real config still landed.
+	var warn bytes.Buffer
+	if got := loadUserConfig(path, &warn).Filter; got != "x" {
+		t.Errorf("filter = %q, want the save to have succeeded regardless", got)
+	}
+}
+
+// TestSaveUserConfig_SurvivesTempfileDebris is the crash-recovery property.
+//
+// A hard kill between create and rename leaves a tempfile behind. With a fixed
+// name plus O_EXCL, every save afterwards failed with "file exists" — forever,
+// surfacing only as a footer flash the user cannot act on, with the config frozen
+// at its pre-crash value. Verified at five consecutive failed saves before the fix.
+func TestSaveUserConfig_SurvivesTempfileDebris(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "before-crash"}); err != nil {
+		t.Fatal(err)
+	}
+	// Debris at the old fixed name, and at a CreateTemp-shaped one.
+	for _, junk := range []string{path + ".tmp", filepath.Join(filepath.Dir(path), ".abctl-config.yaml.123.tmp")} {
+		if err := os.WriteFile(junk, []byte("debris\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := saveUserConfig(path, tui.UserSettings{Filter: "after-crash"}); err != nil {
+			t.Fatalf("save %d failed on leftover debris: %v", i+1, err)
+		}
+	}
+
+	var warn bytes.Buffer
+	if got := loadUserConfig(path, &warn).Filter; got != "after-crash" {
+		t.Errorf("filter = %q; saves after a crash never took effect", got)
 	}
 }
 

--- a/authbridge/cmd/abctl/userconfig_test.go
+++ b/authbridge/cmd/abctl/userconfig_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/cmd/abctl/tui"
+)
+
+// prefsHome points $HOME at a fresh temp dir and returns it.
+//
+// Sets USERPROFILE to the SAME directory: os.UserHomeDir reads that on Windows and
+// HOME elsewhere, so two separate t.TempDir() calls would make the two disagree and
+// the test would exercise a different home depending on platform. Same reasoning as
+// tui's yankHome. t.Setenv is incompatible with t.Parallel; nothing here is parallel.
+func prefsHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	return dir
+}
+
+// TestUserConfigPath_DefaultsUnderCortexDir pins the path the issue specifies, so
+// the constant cannot drift from what the README and the docs promise.
+func TestUserConfigPath_DefaultsUnderCortexDir(t *testing.T) {
+	home := prefsHome(t)
+	got, err := userConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(home, ".cortex", "abctl-config.yaml"); got != want {
+		t.Errorf("userConfigPath() = %q, want %q", got, want)
+	}
+}
+
+// TestUserConfigPath_NoHomeIsAnError: better to lose persistence than to drop a
+// settings file into whatever directory abctl started in, where it would be found
+// again only by accident.
+func TestUserConfigPath_NoHomeIsAnError(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	if got, err := userConfigPath(); err == nil {
+		t.Errorf("userConfigPath() = %q with no home, want an error", got)
+	}
+}
+
+// TestLoadUserConfig_MissingFileIsSilent: nobody has this file until they change a
+// setting, so a first run must not be scolded for it.
+func TestLoadUserConfig_MissingFileIsSilent(t *testing.T) {
+	home := prefsHome(t)
+	var warn bytes.Buffer
+
+	got := loadUserConfig(filepath.Join(home, ".cortex", "abctl-config.yaml"), &warn)
+
+	if !reflectDeepEqualSettings(got, tui.UserSettings{}) {
+		t.Errorf("got %+v, want the zero value", got)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("warned about a missing file: %q", warn.String())
+	}
+}
+
+// TestLoadUserConfig_EmptyPathIsSilent covers the no-home case main passes through.
+func TestLoadUserConfig_EmptyPathIsSilent(t *testing.T) {
+	var warn bytes.Buffer
+	if got := loadUserConfig("", &warn); !reflectDeepEqualSettings(got, tui.UserSettings{}) {
+		t.Errorf("got %+v, want the zero value", got)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("warned on an empty path: %q", warn.String())
+	}
+}
+
+// TestLoadUserConfig_MalformedWarnsAndFallsBack: an unusable file must not stop the
+// viewer from opening, but ignoring a hand-edited file silently would look like
+// abctl disregarding the edit. So: defaults, plus one line naming the path.
+func TestLoadUserConfig_MalformedWarnsAndFallsBack(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		dir  bool
+	}{
+		{name: "unclosed flow sequence", body: "events: [broken\n"},
+		{name: "top-level list", body: "- not\n- a mapping\n"},
+		{name: "wrong type for a known key", body: "filter:\n  nested: map\n"},
+		{name: "a directory where a file belongs", dir: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := prefsHome(t)
+			path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if tc.dir {
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var warn bytes.Buffer
+			got := loadUserConfig(path, &warn) // must not panic
+
+			if !reflectDeepEqualSettings(got, tui.UserSettings{}) {
+				t.Errorf("got %+v, want the zero value", got)
+			}
+			if !strings.Contains(warn.String(), path) {
+				t.Errorf("warning %q does not name the path the user must fix", warn.String())
+			}
+		})
+	}
+}
+
+// TestLoadUserConfig_PartialParseIsDiscarded: yaml.v3 can populate some fields
+// before failing. Half a config applied silently is harder to diagnose than none.
+func TestLoadUserConfig_PartialParseIsDiscarded(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// filter parses; events does not.
+	body := "filter: kept-if-partial\nevents:\n  columns: not-a-list\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	if got := loadUserConfig(path, &warn); got.Filter != "" {
+		t.Errorf("filter = %q; a failed parse must discard everything", got.Filter)
+	}
+	if warn.Len() == 0 {
+		t.Error("no warning for a partially-parseable file")
+	}
+}
+
+// TestLoadUserConfig_UnknownKeysLoadQuietly is the forward-compatibility property.
+// A key written by a newer abctl must not turn the whole load into a
+// warning-and-discard for an older binary — which is exactly what
+// yaml.Decoder.KnownFields(true) would do, so this test guards against that
+// refactor.
+func TestLoadUserConfig_UnknownKeysLoadQuietly(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "filter: github\ntheme: dark\nevents:\n  sort_order: cost\n  columns:\n    - name: COST\n      visible: false\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var warn bytes.Buffer
+	got := loadUserConfig(path, &warn)
+
+	if warn.Len() != 0 {
+		t.Errorf("unknown keys warned: %q", warn.String())
+	}
+	if got.Filter != "github" {
+		t.Errorf("filter = %q, want the known key applied alongside unknown ones", got.Filter)
+	}
+	if len(got.Events.Columns) != 1 || got.Events.Columns[0].Name != "COST" {
+		t.Errorf("columns = %+v, want the COST deviation", got.Events.Columns)
+	}
+}
+
+// TestSaveUserConfig_RoundTrips is what makes a saved preference come back.
+func TestSaveUserConfig_RoundTrips(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	want := tui.UserSettings{
+		Events: tui.EventSettings{Columns: []tui.ColumnSetting{{Name: "COST", Visible: false}}},
+		Filter: "github",
+	}
+
+	if err := saveUserConfig(path, want); err != nil {
+		t.Fatal(err)
+	}
+	var warn bytes.Buffer
+	got := loadUserConfig(path, &warn)
+
+	if warn.Len() != 0 {
+		t.Errorf("our own file warned on load: %q", warn.String())
+	}
+	if !reflectDeepEqualSettings(got, want) {
+		t.Errorf("round trip: got %+v, want %+v", got, want)
+	}
+}
+
+// TestSaveUserConfig_IsHandEditable: the file is documented as editable, so it
+// should carry the header explaining the one rule that is not guessable from the
+// contents.
+func TestSaveUserConfig_IsHandEditable(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(body), "#") {
+		t.Errorf("file does not start with an explanatory comment:\n%s", body)
+	}
+}
+
+// TestSaveUserConfig_CreatesCortexDirAt0700AndFileAt0600 pins the floor that
+// saveUserConfig's security comment reasons down to from checkYankDir's posture.
+// Without a test, "0600 is proportionate" is an argument nobody can regress against.
+func TestSaveUserConfig_CreatesCortexDirAt0700AndFileAt0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes")
+	}
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	dfi, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := dfi.Mode().Perm(); got != 0o700 {
+		t.Errorf("~/.cortex mode = %v, want 0700", got)
+	}
+	ffi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ffi.Mode().Perm(); got != 0o600 {
+		t.Errorf("settings file mode = %v, want 0600", got)
+	}
+}
+
+// TestSaveUserConfig_LeavesNoTempFile: a stray .tmp beside the config is litter in
+// a directory the user is told to inspect on uninstall.
+func TestSaveUserConfig_LeavesNoTempFile(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("tempfile survived the save (stat err = %v)", err)
+	}
+}
+
+// TestSaveUserConfig_OverwritesAnExistingFile: the second save of a session must
+// not fail on the O_EXCL tempfile or refuse because the target exists.
+func TestSaveUserConfig_OverwritesAnExistingFile(t *testing.T) {
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "second"}); err != nil {
+		t.Fatalf("second save failed: %v", err)
+	}
+	var warn bytes.Buffer
+	if got := loadUserConfig(path, &warn).Filter; got != "second" {
+		t.Errorf("filter = %q, want the later save to win", got)
+	}
+}
+
+// TestSaveUserConfig_RefusesAPrePlantedTempfile is the residual symlink risk that
+// O_EXCL closes, and the reason saveUserConfig does not need checkYankDir's sweep.
+// A tempfile another local user planted must not be written through.
+func TestSaveUserConfig_RefusesAPrePlantedTempfile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks")
+	}
+	home := prefsHome(t)
+	path := filepath.Join(home, ".cortex", "abctl-config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, "attacker-owned")
+	if err := os.WriteFile(target, []byte("untouched\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path+".tmp"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := saveUserConfig(path, tui.UserSettings{Filter: "x"}); err == nil {
+		t.Error("saved through a pre-planted tempfile symlink, want a refusal")
+	}
+	body, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "untouched\n" {
+		t.Errorf("symlink target was written through: %q", body)
+	}
+}
+
+// reflectDeepEqualSettings compares two settings without dragging reflect into
+// every assertion. Columns is the only slice, so a length-plus-elements walk is
+// enough and gives a better failure message than DeepEqual on nil-vs-empty.
+func reflectDeepEqualSettings(a, b tui.UserSettings) bool {
+	if a.Filter != b.Filter || len(a.Events.Columns) != len(b.Events.Columns) {
+		return false
+	}
+	for i := range a.Events.Columns {
+		if a.Events.Columns[i] != b.Events.Columns[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/authbridge/docs/laptop-service.md
+++ b/authbridge/docs/laptop-service.md
@@ -270,7 +270,7 @@ back.
 ```sh
 abctl claude-code disable     # 1. unwire Claude Code
 abctl service uninstall       # 2. stop it and remove the service
-rm -rf ~/.cortex              # 3. config, CA, logs
+rm -rf ~/.cortex              # 3. config, CA, logs, abctl's UI settings
 rm -f ~/.local/bin/abctl ~/.local/bin/authbridge-proxy
 ```
 


### PR DESCRIPTION
Every abctl setting reset on restart. Adds the user config file and persists the two settings that have state today: the events-table column selection and the active filter.

```yaml
# abctl user settings. Written by abctl; safe to hand-edit or delete.
# Columns not listed under events.columns are visible — only deviations are recorded.
events:
    columns:
        - name: COST
          visible: false
filter: github-tool
```

- **Absent means visible.** The file records deviations only. Every column is `defaultOn`, so a list of what's *on* would hide any column added in a later build from everyone whose file predates it. Unknown ids are ignored; an all-off file falls back to the defaults.
- **One `Settings` struct**, package-level in `tui`, replacing the fields it consolidates. The file is owned by `main` (which already owns every other `~/.cortex` path resolver); `tui` gets a callback, so it needs no filesystem or `$HOME` logic and its tests touch neither.
- **Saves when the user settles**: picker close, filter committed with `Enter` or cleared with `Esc`. Not per-toggle (would write states the user rejected), not on exit (SIGTERM and `ctrl+c` would lose it). A failed save flashes once in the footer and is dropped — the alt screen owns the terminal, so stderr is unavailable.
- **Graceful fallback**: missing file is silent; malformed warns with the path and is ignored in full, never partially applied. Unknown keys load quietly so a file from a newer abctl still works.
- **`--prefs`, not `--config`** — `abctl service` and `abctl claude-code` already spell the proxy's config that way.
- 0600, `O_EXCL` tempfile, atomic rename. Deliberately *not* `checkYankDir`'s Lstat sweep: that exists because yanked events carry identity subjects and raw completions; this file holds a filter string and column names. `saveUserConfig`'s comment records what would change that.

Precedence documented as **flags > file > defaults**. The issue asks for `flags > env > file > defaults`, but abctl reads no environment variable for any of these — documenting a layer that doesn't exist seemed worse than noting it's unclaimed.

### Verification

`go build`, `go vet`, `go test ./...` green with `GOWORK=off`; `gofmt` clean; pre-commit passes. Each new test was checked non-vacuous by reverting the corresponding change. The interactive TUI was **not** driven end to end (no TTY available) — the file round-trip and key handlers are covered programmatically.

### Scope

Part of #954, not a full fix. Sort order, pane sizes and theme are excluded because none has state to persist yet: no sort state exists in the model, pane sizes are recomputed every frame, and there is no theme to select. Each needs the setting built first, so none appears in the schema either.

Found but not fixed, flagged for follow-ups:
1. `newPickerModel` never initialized `eventColumns`, so the picker's `space`/`x` wrote to a nil map. Seeding both constructors makes that unreachable as a **side effect** — not claimed as the fix; it wants its own change with a regression test.
2. Unknown YAML keys are dropped on *save* (loading them works). Worth a `yaml.Node` passthrough when the deferred settings land.
3. The `.cortex` literal is duplicated in four places; abctl has no `defaultCortexDir()`.

Signed-off-by: Ed Snible <snible@us.ibm.com>
Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persistent settings for the `abctl observe` interface, including column visibility and active filters.
  - Settings are restored between sessions and saved when changes are committed.
  - Added a `--prefs` option with a default settings file and safe fallback behavior.
  - Filter edits can be canceled with Esc; Enter commits changes, including clearing saved filters.
  - Active filters are shown in the status footer.

- **Documentation**
  - Updated guidance for settings persistence, key behavior, configuration precedence, and `.cortex` cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->