### PR TITLE
Refactor: One owner for cost, and plugins that only act on it

### DIFF
--- a/authbridge/authlib/costevent/costevent.go
+++ b/authbridge/authlib/costevent/costevent.go
@@ -90,6 +90,61 @@ type Event struct {
 	//
 	// A settled zero is now a real answer that suppresses the fallback.
 	Settled bool `json:"settled,omitempty"`
+
+	// Avoided is cost that was NOT incurred. Nothing in here is spend.
+	//
+	// A nested list rather than sibling floats, deliberately. More counterfactuals are
+	// coming — compaction, redaction, "what a cheaper model would have cost" — and as
+	// flat fields beside CostUSD the record becomes half-real and half-hypothetical,
+	// which is how someone eventually sums two fields that must never be summed. One
+	// category-named container keeps the boundary visible in the type, and a new
+	// contributor appends an entry instead of adding a field.
+	//
+	// The invariant: no consumer may add any Avoided figure to spend, to a budget, or
+	// to usage totals. A test in the usage package asserts the aggregator's totals are
+	// unchanged by their presence.
+	Avoided []Saving `json:"avoided,omitempty"`
+}
+
+// Saving is one component's contribution to cost that was not incurred.
+type Saving struct {
+	// Component is what avoided the cost, e.g. "tool-prune". Attributed from the
+	// framework's own body-mutation record rather than self-reported, so a plugin
+	// cannot claim someone else's saving.
+	Component string `json:"component"`
+	// TokensAvoided is the estimated prompt-token reduction.
+	TokensAvoided int `json:"tokensAvoided,omitempty"`
+	// USD is TokensAvoided priced at the tier the prompt actually landed in, through
+	// the same table, multiplier and provenance as CostUSD above.
+	USD float64 `json:"usd,omitempty"`
+	// Tier names which prompt tier the saving came out of: cache-write, cache-read or
+	// input. It matters because they differ by 12.5x, and a saving quoted without it
+	// cannot be checked.
+	Tier string `json:"tier,omitempty"`
+	// Projected marks a saving that was measured but NOT APPLIED — tool-prune's
+	// observe mode leaves every byte on the wire. A consumer must present this as
+	// "would have saved", never as money already not spent, and must not add it to
+	// any total that includes applied savings.
+	Projected bool `json:"projected,omitempty"`
+	// Estimated marks TokensAvoided as derived from a bytes-to-tokens ratio rather
+	// than counted by a tokenizer. It is calibrated per request and therefore wrong
+	// when the removed span had a different token density from what remained — so a
+	// UI must not present the dollar figure as measured.
+	Estimated bool `json:"estimated,omitempty"`
+}
+
+// TotalAvoidedUSD sums the APPLIED savings, skipping projected ones.
+//
+// Provided so consumers do not each write the loop and disagree about whether
+// observe-mode figures count. They do not: a projected saving is money that WAS spent.
+func (e Event) TotalAvoidedUSD() float64 {
+	var t float64
+	for _, s := range e.Avoided {
+		if !s.Projected {
+			t += s.USD
+		}
+	}
+	return t
 }
 
 // Micros converts CostUSD to millionths of a dollar, rounded to nearest.

--- a/authbridge/authlib/costevent/costevent.go
+++ b/authbridge/authlib/costevent/costevent.go
@@ -33,6 +33,10 @@ import (
 //
 // Exactly ONE component may write this key per request. Extensions.Custom is a plain map,
 // so a second writer would win silently.
+//
+// A PRODUCER does not write this key directly — it writes Key+pipeline.PluginEventSuffix
+// into pctx.Extensions.Custom, and pipeline/snapshot.go strips the suffix when building
+// SessionEvent.Plugins. Use costing.Publish rather than assembling the key by hand.
 const Key = "cost"
 
 // PluginName is the LEGACY key: the name of the plugin that used to be the sole producer.

--- a/authbridge/authlib/costevent/costevent.go
+++ b/authbridge/authlib/costevent/costevent.go
@@ -91,6 +91,14 @@ type Event struct {
 	// A settled zero is now a real answer that suppresses the fallback.
 	Settled bool `json:"settled,omitempty"`
 
+	// PromptUSD is the modelled cost of the PROMPT alone, output excluded.
+	//
+	// A breakdown, not a component of a sum: it is the table's figure even when CostUSD
+	// is the gateway's, so PromptUSD + anything is not a total of anything. It exists so
+	// a request row can show what that request cost while the response row shows the
+	// call's total, which is a question the gateway's single number cannot answer.
+	PromptUSD float64 `json:"prompt_usd,omitempty"`
+
 	// Avoided is cost that was NOT incurred. Nothing in here is spend.
 	//
 	// A nested list rather than sibling floats, deliberately. More counterfactuals are
@@ -117,6 +125,14 @@ type Saving struct {
 	// USD is TokensAvoided priced at the tier the prompt actually landed in, through
 	// the same table, multiplier and provenance as CostUSD above.
 	USD float64 `json:"usd,omitempty"`
+	// Provenance is how trustworthy the dollar figure is: the rate table's level
+	// ("configured", "bundled", ...), or empty when no rate covered the tier.
+	//
+	// NOT the record's top-level Provenance, which may be "authoritative" because the
+	// gateway reported what the request actually cost. A saving is counterfactual, so it
+	// is always modelled from the table — claiming the gateway's authority for it would
+	// overstate a figure nobody measured.
+	Provenance string `json:"provenance,omitempty"`
 	// Tier names which prompt tier the saving came out of: cache-write, cache-read or
 	// input. It matters because they differ by 12.5x, and a saving quoted without it
 	// cannot be checked.

--- a/authbridge/authlib/costevent/costevent.go
+++ b/authbridge/authlib/costevent/costevent.go
@@ -18,8 +18,31 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
-// PluginName is the session-event key the cost event is published under. It must
-// equal litellm_budgettrack.BudgetTrack.Name(); a test in that package asserts it.
+// Key is the session-event key the cost record is published under.
+//
+// It names the CONCERN, not the producer. That distinction is the whole point: the key used
+// to be the producing plugin's name, so moving costing to whichever component actually
+// knows the tokens — cortex #972 moves it to inference-parser — would have been a breaking
+// wire change for every live consumer AND for every event already written to a session
+// store. Keyed on the concern, the producer can move and no consumer notices.
+//
+// The framework set this precedent and stated the reason. pipeline/context.go publishes
+// "body-mutation"+PluginEventSuffix from the core, which is not a plugin at all, because
+// "a switch of plugin names in a future refactor shouldn't break operators' dashboards".
+// pipeline/snapshot.go does not require the key to be a plugin name.
+//
+// Exactly ONE component may write this key per request. Extensions.Custom is a plain map,
+// so a second writer would win silently.
+const Key = "cost"
+
+// PluginName is the LEGACY key: the name of the plugin that used to be the sole producer.
+//
+// Still read by Decode and Record, because session stores hold events written under it and
+// a consumer reading history must not see a gap where the rename happened. Still written by
+// litellm-budget-track until #972 phase 2 moves the producer, and a test in that package
+// asserts it equals BudgetTrack.Name() for as long as that remains true.
+//
+// Deprecated: write Key. Reads keep working.
 const PluginName = "litellm-budget-track"
 
 // Source names how the cost was arrived at.
@@ -77,29 +100,66 @@ type Event struct {
 // sub-micro charge, not an unknown one.
 func (e Event) Micros() int64 { return int64(math.Round(e.CostUSD * 1e6)) }
 
-// Decode pulls the cost event off a session event.
+// Priced reports whether this record carries a usable dollar figure.
 //
-// A false return is the normal case, not an error: the plugin may not be in the
-// pipeline, and a request that charged nothing (cache hit, error) emits nothing.
-// A non-positive cost also returns false — "free" and "unknown" must not be
-// conflated, and a consumer that treated 0 as priced would render $0.00 for
-// traffic it simply cannot price.
-func Decode(e *pipeline.SessionEvent) (Event, bool) {
+// Named and exported because it is the predicate Decode applies, and a consumer that took
+// the record through Record needs to ask the same question without reimplementing it. The
+// two must agree; a test asserts they do.
+//
+// A settled zero is priced: the producer means "this call was free". An unsettled zero is
+// not: it means nobody priced this, and rendering $0.00 for it would report unpriced
+// traffic as free. A negative figure is never a price.
+func (e Event) Priced() bool {
+	if e.CostUSD < 0 {
+		return false
+	}
+	return e.CostUSD > 0 || e.Settled
+}
+
+// Record pulls the cost record off a session event, whether or not it carries a price.
+//
+// PRESENCE, which is a different question from pricedness — and the only one Decode could
+// answer. A record whose cost is an unsettled zero is real: it names the endpoint, the
+// source and the provenance, and #972 gives it avoided-cost entries too. Under Decode's
+// rule that record is indistinguishable from no record at all, so a consumer wanting its
+// non-cost fields could not reach them, and a saving on a request that could not be priced
+// — exactly the traffic where a saving is most interesting — would silently vanish.
+//
+// Reads the current key first and falls back to the legacy one. New wins when both are
+// present: a transitional deployment can run an old producer alongside a new one, and
+// taking the legacy value there would report the figure from the component being retired.
+func Record(e *pipeline.SessionEvent) (Event, bool) {
 	if e == nil || len(e.Plugins) == 0 {
 		return Event{}, false
 	}
-	raw, ok := e.Plugins[PluginName]
+	raw, ok := e.Plugins[Key]
 	if !ok {
-		return Event{}, false
+		if raw, ok = e.Plugins[PluginName]; !ok {
+			return Event{}, false
+		}
 	}
 	var ev Event
 	if err := json.Unmarshal(raw, &ev); err != nil {
 		return Event{}, false
 	}
-	// A settled zero counts: the producer means "this call was free", which is a
-	// different answer from "nobody priced this" and must not be re-priced. Without
-	// Settled, only a positive cost was a figure at all.
-	if ev.CostUSD < 0 || (ev.CostUSD == 0 && !ev.Settled) {
+	return ev, true
+}
+
+// Decode pulls a PRICED cost off a session event.
+//
+// A false return is the normal case, not an error: the producing plugin may not be in the
+// pipeline, and a request that charged nothing (cache hit, error) emits nothing. A
+// non-positive cost also returns false — "free" and "unknown" must not be conflated, and a
+// consumer that treated 0 as priced would render $0.00 for traffic it simply cannot price.
+//
+// Use Record instead when you want the record regardless of whether it priced anything.
+func Decode(e *pipeline.SessionEvent) (Event, bool) {
+	ev, ok := Record(e)
+	if !ok {
+		return Event{}, false
+	}
+	// One predicate, in one place — see Priced.
+	if !ev.Priced() {
 		return Event{}, false
 	}
 	return ev, true

--- a/authbridge/authlib/costevent/costevent_test.go
+++ b/authbridge/authlib/costevent/costevent_test.go
@@ -129,3 +129,141 @@ func TestMicros(t *testing.T) {
 		})
 	}
 }
+
+// The key names the CONCERN, not the producer.
+//
+// It used to be the producing plugin's name, pinned by a test to
+// litellm-budget-track.Name(). That made moving the producer — which cortex #972 does,
+// to inference-parser — a breaking wire change for every live consumer AND for every
+// event already sitting in a session store. The framework's own body-mutation event
+// established the alternative and said why: "a switch of plugin names in a future
+// refactor shouldn't break operators' dashboards" (pipeline/context.go).
+func TestKey_NamesTheConcernNotTheProducer(t *testing.T) {
+	if Key != "cost" {
+		t.Errorf("Key = %q, want %q — a producer name here couples every consumer to one plugin", Key, "cost")
+	}
+	if Key == PluginName {
+		t.Error("Key equals the legacy producer name; the point is that they differ")
+	}
+}
+
+// A record written under the new key decodes. A record written under the legacy key still
+// decodes, because session stores are full of them and a consumer reading history must not
+// see a gap where the rename happened.
+func TestDecode_ReadsBothKeys(t *testing.T) {
+	raw, err := json.Marshal(Event{CostUSD: 0.25, Source: SourceGatewayHeader})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{Key, PluginName} {
+		t.Run(key, func(t *testing.T) {
+			e := &pipeline.SessionEvent{Plugins: map[string]json.RawMessage{key: raw}}
+			got, ok := Decode(e)
+			if !ok {
+				t.Fatalf("no cost decoded under %q", key)
+			}
+			if got.CostUSD != 0.25 {
+				t.Errorf("CostUSD = %v, want 0.25", got.CostUSD)
+			}
+		})
+	}
+}
+
+// The new key wins when both are present. A transitional deployment can have an old
+// producer and a new one in the same pipeline; taking the legacy value there would report
+// the figure from the component being retired.
+func TestDecode_NewKeyWinsOverLegacy(t *testing.T) {
+	newRaw, err := json.Marshal(Event{CostUSD: 0.25, Source: SourceGatewayHeader})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldRaw, err := json.Marshal(Event{CostUSD: 9.99, Source: SourceUsageFallback})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := &pipeline.SessionEvent{Plugins: map[string]json.RawMessage{
+		Key:        newRaw,
+		PluginName: oldRaw,
+	}}
+	got, ok := Decode(e)
+	if !ok {
+		t.Fatal("nothing decoded")
+	}
+	if got.CostUSD != 0.25 {
+		t.Errorf("CostUSD = %v, want 0.25 from the new key", got.CostUSD)
+	}
+}
+
+// Presence and PRICEDNESS are different questions, and Decode only ever answered the
+// second: it returns false for a record whose cost is an unsettled zero, meaning a caller
+// cannot tell "nobody priced this" from "no record at all".
+//
+// That distinction is load-bearing for #972: the same record is about to carry avoided
+// cost, and a request that could not be priced is exactly the one whose savings figure is
+// most interesting. Under Decode's rule that record would vanish entirely.
+func TestRecord_PresenceIsNotPricedness(t *testing.T) {
+	unpriced, err := json.Marshal(Event{CostUSD: 0, Settled: false, Source: SourceUsageFallback})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := &pipeline.SessionEvent{Plugins: map[string]json.RawMessage{Key: unpriced}}
+
+	if _, ok := Decode(e); ok {
+		t.Error("Decode reported a priced figure for an unsettled zero")
+	}
+	got, ok := Record(e)
+	if !ok {
+		t.Fatal("Record did not report the record as PRESENT; a consumer cannot see its non-cost fields")
+	}
+	if got.Source != SourceUsageFallback {
+		t.Errorf("Source = %q, want the record's own value", got.Source)
+	}
+	if got.Priced() {
+		t.Error("Priced() true for an unsettled zero")
+	}
+}
+
+// Priced() is the rule Decode applies, named and reusable, so a consumer that took the
+// record via Record can ask the same question without reimplementing the predicate.
+func TestPriced_MatchesDecode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ev   Event
+		want bool
+	}{
+		{"positive", Event{CostUSD: 0.25}, true},
+		{"settled zero is an answer", Event{CostUSD: 0, Settled: true}, true},
+		{"unsettled zero is not", Event{CostUSD: 0}, false},
+		{"negative is never", Event{CostUSD: -1, Settled: true}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ev.Priced(); got != tc.want {
+				t.Errorf("Priced() = %v, want %v", got, tc.want)
+			}
+			raw, err := json.Marshal(tc.ev)
+			if err != nil {
+				t.Fatal(err)
+			}
+			e := &pipeline.SessionEvent{Plugins: map[string]json.RawMessage{Key: raw}}
+			if _, ok := Decode(e); ok != tc.want {
+				t.Errorf("Decode ok = %v, but Priced() = %v; the two must agree", ok, tc.want)
+			}
+		})
+	}
+}
+
+// No record at all stays a clean negative on both paths.
+func TestRecord_AbsentIsNotAnError(t *testing.T) {
+	for _, e := range []*pipeline.SessionEvent{
+		nil,
+		{},
+		{Plugins: map[string]json.RawMessage{"tool-prune": []byte(`{"bytesRemoved":1}`)}},
+	} {
+		if _, ok := Record(e); ok {
+			t.Errorf("Record found a record in %+v", e)
+		}
+		if _, ok := Decode(e); ok {
+			t.Errorf("Decode found a cost in %+v", e)
+		}
+	}
+}

--- a/authbridge/authlib/costing/avoided.go
+++ b/authbridge/authlib/costing/avoided.go
@@ -1,0 +1,104 @@
+package costing
+
+import (
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// pruneFacts is the shape this package reads out of tool-prune's event.
+//
+// Read structurally rather than by importing the plugin, because the dependency must not
+// run that way: a plugin that shrinks a body should know nothing about pricing, and this
+// package should not link a plugin. Only the fields needed to price a saving are declared,
+// so tool-prune can change everything else without touching costing.
+type pruneFacts struct {
+	BytesRemoved   int
+	BodyBytesAfter int
+	Projected      bool
+}
+
+// factsFrom pulls those fields off whatever a plugin published, via its JSON shape.
+//
+// The published value is a plugin-defined struct this package cannot name, so it is
+// re-decoded through its own wire tags. That indirection is the price of not linking the
+// plugin, and it is checked by a test that fails if tool-prune renames a field.
+func factsFrom(v any) (pruneFacts, bool) {
+	m, ok := asMap(v)
+	if !ok {
+		return pruneFacts{}, false
+	}
+	f := pruneFacts{
+		BytesRemoved:   intField(m, "bytesRemoved"),
+		BodyBytesAfter: intField(m, "bodyBytesAfter"),
+		Projected:      boolField(m, "projected"),
+	}
+	if f.BytesRemoved <= 0 || f.BodyBytesAfter <= 0 {
+		return pruneFacts{}, false
+	}
+	return f, true
+}
+
+// Avoided prices what other components kept off the wire, for this request.
+//
+// Runs HERE rather than in the component that did the pruning, because the dollar amount
+// depends on which prompt-cache tier the saving came out of — 1x, 1.25x or 0.1x of the same
+// rate — and that is only knowable from the response. The saving is inherently a
+// request-fact times a response-fact, so it can only be priced where both are in hand.
+//
+// Every figure is an ESTIMATE derived from a byte ratio, and every entry says so. Nothing
+// returned here is spend: see costevent.Saving.
+func Avoided(pctx *pipeline.Context, rates pricing.Resolver) []costevent.Saving {
+	if pctx == nil || len(pctx.Extensions.Custom) == 0 {
+		return nil
+	}
+	usage := pricing.UsageFromInference(pctx.Extensions.Inference)
+	prompt := usage.PromptTotal()
+	if prompt <= 0 {
+		return nil // no response usage yet: nothing to calibrate against
+	}
+	model := ""
+	if pctx.Extensions.Inference != nil {
+		model = pctx.Extensions.Inference.Model
+	}
+
+	var out []costevent.Saving
+	for _, component := range savingComponents {
+		v, ok := pctx.Extensions.Custom[component+pipeline.PluginEventSuffix]
+		if !ok {
+			continue
+		}
+		facts, ok := factsFrom(v)
+		if !ok {
+			continue
+		}
+		tokens := pricing.EstimateTokensFromBytes(facts.BytesRemoved, prompt, facts.BodyBytesAfter)
+		if tokens <= 0 {
+			continue
+		}
+		saved, tier := pricing.AvoidedUsage(usage, tokens)
+		s := costevent.Saving{
+			Component:     component,
+			TokensAvoided: tokens,
+			Tier:          tier.String(),
+			Projected:     facts.Projected,
+			Estimated:     true,
+		}
+		if micros, prov, ok := modelledCost(rates, pctx.Host, model, saved); ok {
+			s.USD, s.Provenance = float64(micros)/1e6, prov.String()
+		}
+		// Published even with no dollar figure: the token saving is still known, and
+		// reporting 0 dollars where a rate is missing would read as "this saved
+		// nothing" rather than "we cannot price it".
+		out = append(out, s)
+	}
+	return out
+}
+
+// savingComponents names the plugins whose events describe a body reduction worth pricing.
+//
+// An explicit list, not a scan for anything with a bytesRemoved field: a saving attributed
+// to the wrong component is worse than one not attributed at all, and a plugin should not be
+// able to opt itself into the money record by naming a field conveniently. Adding a
+// component here is a deliberate act with a test.
+var savingComponents = []string{"tool-prune"}

--- a/authbridge/authlib/costing/costing.go
+++ b/authbridge/authlib/costing/costing.go
@@ -321,8 +321,13 @@ func Amend(pctx *pipeline.Context, f func(*costevent.Event)) bool {
 	return true
 }
 
-// Record builds the wire record from a settled outcome.
-func Record(s Settled, avoided []costevent.Saving) costevent.Event {
+// NewRecord builds the wire record from a settled outcome.
+//
+// Named NewRecord, not Record, because costevent.Record READS a record off a session event
+// and these two packages are imported together — the cost owner imports costing, every
+// consumer imports costevent. Two functions with one name pointing opposite directions is a
+// coin flip at each call site, and the New prefix says which way this one goes.
+func NewRecord(s Settled, avoided []costevent.Saving) costevent.Event {
 	return costevent.Event{
 		CostUSD:    s.CostUSD,
 		Source:     s.Source,

--- a/authbridge/authlib/costing/costing.go
+++ b/authbridge/authlib/costing/costing.go
@@ -1,0 +1,334 @@
+// Package costing turns one response's facts into one settled cost.
+//
+// It exists because that decision was made in two places with two shapes — inside
+// litellm-budget-track and again inside the usage aggregator — and the two could disagree
+// about the same request. Whichever component owns costing now calls Settle, and there is
+// one precedence rule: an authoritative figure the gateway reported beats a figure modelled
+// from token counts and a rate table.
+//
+// Separate from the parser that produces the token counts, and separate from the plugins
+// that act on the money, because it is neither: a gateway's cost header is
+// vendor-specific knowledge that has no place in a provider-shaped body parser, and a
+// ledger has no business deciding what a request cost.
+package costing
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// Response cost headers emitted by LiteLLM.
+//
+// Exported because they are wire names, not internals: a test needs to synthesize them, and
+// a future adapter for a gateway that reports cost differently needs to say which of these
+// it is standing in for.
+//
+// MEASURED 2026-09-11 against ete-litellm (LiteLLM 1.85.5), because an earlier version of
+// this comment had the semantics backwards and a reviewer reasonably concluded from it
+// that drift detection would false-positive on every Anthropic-format request:
+//
+//	/v1/chat/completions  both headers present, IDENTICAL values
+//	/v1/messages          only "-original", same value the other path reports
+//
+// For 16 input + 4 output tokens of claude-opus-5 both paths reported
+// 0.00013680000000000002, which is 0.76 x vendor list (16x$5 + 4x$25 per Mtok = 0.00018).
+// So "-original" is the cost the gateway ACTUALLY CHARGED, not a pre-discount list price,
+// and falling back to it compares like with like.
+//
+// "Original" refers to LiteLLM's OWN discount/margin layer, reported alongside in
+// X-Litellm-Response-Cost-{Discount,Margin}-Amount: original is the figure before that
+// layer is applied. This gateway runs neither (both report 0.0), so the two agree. A
+// gateway that DOES configure them would see them diverge, which is why checkDrift
+// checks those headers before comparing — see driftComparable.
+//
+// The fallback itself is load-bearing: without it, budget tracking silently records $0
+// for every Anthropic-format request, which is the shape Claude Code sends.
+const (
+	ResponseCostHeader         = "X-Litellm-Response-Cost"
+	ResponseCostOriginalHeader = "X-Litellm-Response-Cost-Original"
+
+	// LiteLLM's own adjustment layer, non-zero only where an operator configured it.
+	DiscountAmountHeader = "X-Litellm-Response-Cost-Discount-Amount"
+	MarginAmountHeader   = "X-Litellm-Response-Cost-Margin-Amount"
+)
+
+// headerCostState says what the gateway's cost header actually told us. A bool
+// could not carry this, and collapsing these cases caused a real defect: every
+// state below except headerPositive returned (0, true), so "the gateway declared
+// this call free" was indistinguishable from "the header was garbage" and from
+// "this is a stream, where LiteLLM always stamps 0 as a placeholder". Publishing a
+// settled zero for all of them counted unpriced traffic as priced.
+type headerCostState int
+
+const (
+	// headerAbsent: no cost header at all. Price from token usage.
+	headerAbsent headerCostState = iota
+	// headerUnusable: a header was present but could not be believed — unparseable,
+	// negative, NaN or Inf. NOT a declaration of anything, so it must not suppress
+	// the usage fallback and must never publish a settled zero.
+	headerUnusable
+	// headerZero: present, parsed, finite and exactly zero. On a NON-streamed
+	// response this is the gateway saying the call was free — a cache hit, or an
+	// error it declined to charge for. On a streamed response it means nothing:
+	// LiteLLM stamps 0 there by design because the total is unknown when headers
+	// are sent.
+	headerZero
+	// headerPositive: a usable figure.
+	headerPositive
+)
+
+// headerCost returns the cost the gateway reported and what kind of answer it was.
+func headerCost(pctx *pipeline.Context) (cost float64, state headerCostState) {
+	costStr := pctx.ResponseHeaders.Get(ResponseCostHeader)
+	if costStr == "" {
+		// Anthropic /v1/messages (and newer LiteLLM) omit the bare header.
+		costStr = pctx.ResponseHeaders.Get(ResponseCostOriginalHeader)
+	}
+	if costStr == "" {
+		return 0, headerAbsent
+	}
+	c, err := strconv.ParseFloat(costStr, 64)
+	if err != nil || math.IsNaN(c) || math.IsInf(c, 0) || c < 0 {
+		return 0, headerUnusable
+	}
+	if c == 0 {
+		return 0, headerZero
+	}
+	return c, headerPositive
+}
+
+// IsEventStream reports whether the response is a text/event-stream (SSE) — the
+// streamed shape where LiteLLM reports cost 0 in the header, so usage-based
+// pricing is the intended fallback.
+func IsEventStream(pctx *pipeline.Context) bool {
+	ct := pctx.ResponseHeaders.Get("Content-Type")
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), "text/event-stream")
+}
+
+// Comparable reports whether the gateway's figure can be compared against a modelled
+// one at all.
+//
+// False when the bare header is absent AND LiteLLM's own discount/margin layer is active:
+// the fallback figure is then pre-adjustment while the modelled figure is what the caller
+// pays, so any comparison measures the gateway's adjustment rather than the rate table.
+func Comparable(pctx *pipeline.Context) bool {
+	if pctx.ResponseHeaders.Get(ResponseCostHeader) != "" {
+		return true // the effective figure itself; nothing to reconcile
+	}
+	for _, h := range []string{DiscountAmountHeader, MarginAmountHeader} {
+		v := pctx.ResponseHeaders.Get(h)
+		if v == "" {
+			continue
+		}
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Settled is what one response cost, and how that was arrived at.
+//
+// Carries BOTH figures, not just the winner. A consumer that only needs the number reads
+// CostUSD; the drift check needs the pair, and keeping them here means it compares what
+// was actually decided rather than recomputing either half and hoping the two agree.
+type Settled struct {
+	// CostUSD is the figure to charge. Meaningful only when Priced.
+	CostUSD float64
+	// Source is costevent.SourceGatewayHeader or costevent.SourceUsageFallback.
+	Source string
+	// Provenance is ProvAuthoritative for a gateway figure, else the rate table's level.
+	Provenance pricing.Provenance
+	// Priced reports that a figure exists — INCLUDING a settled zero, which is the
+	// gateway saying the call was free. Not the same as CostUSD > 0.
+	Priced bool
+	// DeclaredFree marks a gateway-reported, non-streamed, exactly-zero cost: a genuine
+	// free call. Distinguished from an unusable header and from a stream's placeholder
+	// zero, because publishing a settled zero for those counted unpriced traffic as
+	// priced.
+	DeclaredFree bool
+
+	// ReportedUSD is the gateway's own figure, when it gave one.
+	ReportedUSD float64
+	HasReported bool
+	// ModelledUSD is what the rate table says the same usage costs, when it can say.
+	// Computed even when a reported figure won, because the comparison is the only
+	// signal that a rate table has gone stale.
+	ModelledUSD float64
+	HasModelled bool
+	// ModelledProv is the provenance behind ModelledUSD.
+	ModelledProv pricing.Provenance
+
+	// PromptUSD is the PROMPT half of the modelled figure — output excluded, tiers
+	// weighted. It exists because a request row can show what it cost while the
+	// response row shows the total, and the two must not be a sum: a cache read bills
+	// at ~0.1x the uncached input rate and a write at ~1.25x, so a flat prompt figure
+	// overstates a cache-heavy turn by close to an order of magnitude.
+	//
+	// Modelled, never authoritative: a gateway reports one total for the call and does
+	// not break it down, so this is the table's answer even when the total is the
+	// gateway's.
+	PromptUSD float64
+	HasPrompt bool
+}
+
+// Settle prices one response.
+//
+// The precedence, in one place: a positive header figure wins outright. Otherwise the
+// token counts are priced through the rate table — but NOT when the gateway declared the
+// call free, because inventing a cost for a call it explicitly charged nothing for is how
+// a cache hit came to be billed. A stream's zero is a placeholder, not an answer, so it
+// falls back like an absent header.
+//
+// rates may be nil: a binary with no pricing wired reports unpriced rather than crashing.
+func Settle(pctx *pipeline.Context, rates pricing.Resolver) Settled {
+	var out Settled
+	if pctx == nil {
+		return out
+	}
+
+	cost, state := headerCost(pctx)
+	if state == headerPositive {
+		out.ReportedUSD, out.HasReported = cost, true
+	} else if state == headerZero && !IsEventStream(pctx) {
+		out.ReportedUSD, out.HasReported = 0, true
+	}
+
+	// Modelled alongside, always, so the pair is available for drift even when the
+	// gateway's figure wins.
+	usage := pricing.UsageFromInference(pctx.Extensions.Inference)
+	model := ""
+	if pctx.Extensions.Inference != nil {
+		model = pctx.Extensions.Inference.Model
+	}
+	if micros, prov, ok := modelledCost(rates, pctx.Host, model, usage); ok {
+		out.ModelledUSD, out.HasModelled, out.ModelledProv = float64(micros)/1e6, true, prov
+	}
+
+	// The prompt half, for a request row. Output zeroed rather than subtracted, because
+	// Cost refuses to price a tier that carried tokens with no rate — and a partial total
+	// presented as a whole one is worse than none.
+	promptOnly := usage
+	promptOnly.Output = 0
+	if micros, _, ok := modelledCost(rates, pctx.Host, model, promptOnly); ok {
+		out.PromptUSD, out.HasPrompt = float64(micros)/1e6, true
+	}
+
+	streamedPlaceholder := state == headerZero && IsEventStream(pctx)
+	out.DeclaredFree = state == headerZero && !streamedPlaceholder
+
+	switch {
+	case state == headerPositive:
+		out.CostUSD, out.Source, out.Provenance, out.Priced =
+			cost, costevent.SourceGatewayHeader, pricing.ProvAuthoritative, true
+	case out.DeclaredFree:
+		// A real answer of zero. Nothing is charged, but it must be published as
+		// PRICED so no consumer re-prices it from the usage block.
+		out.CostUSD, out.Source, out.Provenance, out.Priced =
+			0, costevent.SourceGatewayHeader, pricing.ProvAuthoritative, true
+	case out.HasModelled:
+		out.CostUSD, out.Source, out.Provenance, out.Priced =
+			out.ModelledUSD, costevent.SourceUsageFallback, out.ModelledProv, true
+	}
+	return out
+}
+
+// modelledCost prices usage through the rate table.
+//
+// The nil guard is on the INTERFACE, which is the trap: an un-injected consumer holds a
+// nil interface and calling a method on it panics, where a nil *pricing.Registry would
+// have been safe. tool-prune hit exactly this and its fail-open masked the panic, so
+// pruning silently stopped.
+func modelledCost(rates pricing.Resolver, host, model string, u pricing.Usage) (int64, pricing.Provenance, bool) {
+	if rates == nil || u == (pricing.Usage{}) {
+		return 0, pricing.ProvNone, false
+	}
+	r, prov := rates.Resolve(host, model, u.PromptTotal())
+	if prov == pricing.ProvNone {
+		return 0, pricing.ProvNone, false
+	}
+	micros, ok := pricing.Cost(r, u)
+	if !ok {
+		return 0, pricing.ProvNone, false
+	}
+	return micros, prov, true
+}
+
+// StateKey is where the full Settled outcome is stashed for the rest of the request.
+//
+// In-process only — deliberately not on the wire. A consumer that needs the number reads
+// the published costevent record; the drift check needs BOTH figures, and putting them in
+// the session event would widen a public shape for one diagnostic's benefit. Keeping them
+// here also means drift compares what was actually decided instead of recomputing a half
+// and hoping the two agree.
+const StateKey = "costing.settled"
+
+// Store stashes the outcome for later plugins in the same request.
+func Store(pctx *pipeline.Context, s Settled) {
+	pipeline.SetState(pctx, StateKey, &s)
+}
+
+// Load retrieves the outcome. False means no cost owner ran — which, given costing runs in
+// the parser and every consumer declares a hard dependency on it, means this request had no
+// inference in it at all.
+func Load(pctx *pipeline.Context) (Settled, bool) {
+	if s := pipeline.GetState[Settled](pctx, StateKey); s != nil {
+		return *s, true
+	}
+	return Settled{}, false
+}
+
+// Publish writes the wire record onto the session event.
+//
+// Under costevent.Key, and ALSO under the legacy plugin-name key: abctl is a separate
+// binary that can lag the proxy, and an older one reads only the legacy key, so writing
+// just the new one would blank the cost column for anyone who has not upgraded both. The
+// legacy write comes out a release later.
+//
+// Ledger fields are left zero. They belong to whoever enforces a budget, which is not this
+// package's business; litellm-budget-track amends them in place when it is present. That
+// amendment is the one sanctioned second write to this key.
+func Publish(pctx *pipeline.Context, ev costevent.Event) {
+	if pctx.Extensions.Custom == nil {
+		pctx.Extensions.Custom = map[string]any{}
+	}
+	pctx.Extensions.Custom[costevent.Key+pipeline.PluginEventSuffix] = ev
+	pctx.Extensions.Custom[costevent.PluginName+pipeline.PluginEventSuffix] = ev
+}
+
+// Amend rewrites the published record, for a consumer adding fields it owns.
+//
+// Returns false when nothing has been published, so a caller cannot resurrect a record for
+// a request that was never priced.
+func Amend(pctx *pipeline.Context, f func(*costevent.Event)) bool {
+	if pctx.Extensions.Custom == nil {
+		return false
+	}
+	ev, ok := pctx.Extensions.Custom[costevent.Key+pipeline.PluginEventSuffix].(costevent.Event)
+	if !ok {
+		return false
+	}
+	f(&ev)
+	Publish(pctx, ev)
+	return true
+}
+
+// Record builds the wire record from a settled outcome.
+func Record(s Settled, avoided []costevent.Saving) costevent.Event {
+	return costevent.Event{
+		CostUSD:    s.CostUSD,
+		Source:     s.Source,
+		Provenance: s.Provenance.String(),
+		Settled:    s.Priced,
+		PromptUSD:  s.PromptUSD,
+		Avoided:    avoided,
+	}
+}

--- a/authbridge/authlib/costing/costing_test.go
+++ b/authbridge/authlib/costing/costing_test.go
@@ -1,0 +1,242 @@
+package costing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// rates builds a table charging 1 micro-dollar per token in every tier, so a token count
+// reads directly as micros and an expectation needs no arithmetic to check.
+func rates(t *testing.T) pricing.Resolver {
+	t.Helper()
+	var r pricing.Rates
+	for _, tier := range []pricing.Tier{pricing.TierInput, pricing.TierCacheWrite, pricing.TierCacheRead, pricing.TierOutput} {
+		r.Base[tier], r.Set[tier] = 1e-6, true
+	}
+	tab, err := pricing.NewTable([]pricing.Entry{{Host: "*", Model: "*", Rates: r, Prov: pricing.ProvConfigured}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pricing.NewRegistry(tab)
+}
+
+func ctx(headers map[string]string, input, output int) *pipeline.Context {
+	h := http.Header{}
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	return &pipeline.Context{
+		Host:            "gw.internal",
+		ResponseHeaders: h,
+		Extensions: pipeline.Extensions{Inference: &pipeline.InferenceExtension{
+			Model:        "claude-opus-5",
+			InputTokens:  input,
+			OutputTokens: output,
+		}},
+	}
+}
+
+// The precedence rule, which is the reason this package exists: it used to be implemented
+// twice, in two shapes, and the two could disagree about the same request.
+func TestSettle_Precedence(t *testing.T) {
+	const json = "application/json"
+	for _, tc := range []struct {
+		name     string
+		headers  map[string]string
+		wantCost float64
+		wantSrc  string
+		wantProv pricing.Provenance
+		priced   bool
+		free     bool
+	}{{
+		name:     "gateway figure wins outright",
+		headers:  map[string]string{"Content-Type": json, ResponseCostHeader: "0.25"},
+		wantCost: 0.25,
+		wantSrc:  costevent.SourceGatewayHeader,
+		wantProv: pricing.ProvAuthoritative,
+		priced:   true,
+	}, {
+		name:     "the -original fallback is the charged cost, not a list price",
+		headers:  map[string]string{"Content-Type": json, ResponseCostOriginalHeader: "0.25"},
+		wantCost: 0.25,
+		wantSrc:  costevent.SourceGatewayHeader,
+		wantProv: pricing.ProvAuthoritative,
+		priced:   true,
+	}, {
+		// 1000 + 500 tokens at 1e-6 each.
+		name:     "no header at all falls back to the table",
+		headers:  map[string]string{"Content-Type": json},
+		wantCost: 0.0015,
+		wantSrc:  costevent.SourceUsageFallback,
+		wantProv: pricing.ProvConfigured,
+		priced:   true,
+	}, {
+		// The zero LiteLLM stamps on every stream is a placeholder, not an answer.
+		name:     "a stream's zero falls back like an absent header",
+		headers:  map[string]string{"Content-Type": "text/event-stream", ResponseCostHeader: "0"},
+		wantCost: 0.0015,
+		wantSrc:  costevent.SourceUsageFallback,
+		wantProv: pricing.ProvConfigured,
+		priced:   true,
+	}, {
+		// A zero on a NON-streamed response is the gateway saying "free". Pricing it
+		// from the usage block would bill a cache hit.
+		name:     "a declared zero is an answer, and suppresses the fallback",
+		headers:  map[string]string{"Content-Type": json, ResponseCostHeader: "0"},
+		wantCost: 0,
+		wantSrc:  costevent.SourceGatewayHeader,
+		wantProv: pricing.ProvAuthoritative,
+		priced:   true,
+		free:     true,
+	}, {
+		// Garbage is not a figure and not a declaration of free either.
+		name:     "an unusable header falls back to the table",
+		headers:  map[string]string{"Content-Type": json, ResponseCostHeader: "abc"},
+		wantCost: 0.0015,
+		wantSrc:  costevent.SourceUsageFallback,
+		wantProv: pricing.ProvConfigured,
+		priced:   true,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Settle(ctx(tc.headers, 1000, 500), rates(t))
+			if got.Priced != tc.priced {
+				t.Fatalf("Priced = %v, want %v", got.Priced, tc.priced)
+			}
+			if got.CostUSD != tc.wantCost {
+				t.Errorf("CostUSD = %v, want %v", got.CostUSD, tc.wantCost)
+			}
+			if got.Source != tc.wantSrc {
+				t.Errorf("Source = %q, want %q", got.Source, tc.wantSrc)
+			}
+			if got.Provenance != tc.wantProv {
+				t.Errorf("Provenance = %v, want %v", got.Provenance, tc.wantProv)
+			}
+			if got.DeclaredFree != tc.free {
+				t.Errorf("DeclaredFree = %v, want %v", got.DeclaredFree, tc.free)
+			}
+		})
+	}
+}
+
+// Both figures are carried even when one wins, because the drift check compares the pair
+// that was actually decided rather than recomputing a half of it.
+func TestSettle_CarriesBothFigures(t *testing.T) {
+	got := Settle(ctx(map[string]string{"Content-Type": "application/json", ResponseCostHeader: "0.25"}, 1000, 500), rates(t))
+	if !got.HasReported || got.ReportedUSD != 0.25 {
+		t.Errorf("reported = %v (has=%v), want 0.25", got.ReportedUSD, got.HasReported)
+	}
+	if !got.HasModelled || got.ModelledUSD != 0.0015 {
+		t.Errorf("modelled = %v (has=%v), want 0.0015", got.ModelledUSD, got.HasModelled)
+	}
+	if got.ModelledProv != pricing.ProvConfigured {
+		t.Errorf("ModelledProv = %v, want configured", got.ModelledProv)
+	}
+}
+
+// A binary with no pricing wired must report unpriced, not panic. The trap is that the
+// resolver is an INTERFACE: a nil one panics on call where a nil *Registry would not.
+func TestSettle_NilResolverIsUnpriced(t *testing.T) {
+	got := Settle(ctx(map[string]string{"Content-Type": "application/json"}, 1000, 500), nil)
+	if got.Priced {
+		t.Errorf("priced with no rate table: %+v", got)
+	}
+	if got.HasModelled {
+		t.Error("claims a modelled figure with no resolver")
+	}
+	// A gateway figure still lands, because reading a header needs no rate table.
+	withHeader := Settle(ctx(map[string]string{"Content-Type": "application/json", ResponseCostHeader: "0.25"}, 0, 0), nil)
+	if !withHeader.Priced || withHeader.CostUSD != 0.25 {
+		t.Errorf("gateway figure lost when no rates are configured: %+v", withHeader)
+	}
+}
+
+// No inference at all is not a pricing gap: a plain proxied request has no model and no
+// tokens, and inventing a figure for it would be worse than reporting none.
+func TestSettle_NoInferenceIsSilent(t *testing.T) {
+	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: http.Header{}}
+	if got := Settle(pctx, rates(t)); got.Priced {
+		t.Errorf("priced a request with no inference: %+v", got)
+	}
+	if got := Settle(nil, rates(t)); got.Priced {
+		t.Error("priced a nil context")
+	}
+}
+
+// Comparable is what keeps drift from blaming the rate table for a gateway's own
+// discount layer: when the effective header is absent and the gateway reports an
+// adjustment, the fallback figure is pre-adjustment and the two are not like for like.
+func TestComparable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{"effective header present", map[string]string{ResponseCostHeader: "0.25"}, true},
+		{"fallback with no adjustment", map[string]string{ResponseCostOriginalHeader: "0.25", DiscountAmountHeader: "0.0"}, true},
+		{"fallback with a discount", map[string]string{ResponseCostOriginalHeader: "0.25", DiscountAmountHeader: "0.05"}, false},
+		{"fallback with a margin", map[string]string{ResponseCostOriginalHeader: "0.25", MarginAmountHeader: "0.05"}, false},
+		{"no headers", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Comparable(ctx(tc.headers, 0, 0)); got != tc.want {
+				t.Errorf("Comparable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Publish writes both keys: abctl is a separate binary that can lag the proxy, and an
+// older one reads only the legacy key.
+func TestPublish_WritesBothKeys(t *testing.T) {
+	pctx := ctx(nil, 0, 0)
+	Publish(pctx, costevent.Event{CostUSD: 0.25, Settled: true})
+	for _, key := range []string{costevent.Key, costevent.PluginName} {
+		if _, ok := pctx.Extensions.Custom[key+pipeline.PluginEventSuffix]; !ok {
+			t.Errorf("nothing published under %q", key)
+		}
+	}
+}
+
+// Amend is how a budget adds the fields it owns without becoming the record's author.
+func TestAmend(t *testing.T) {
+	pctx := ctx(nil, 0, 0)
+	if Amend(pctx, func(*costevent.Event) { t.Error("amended a record that was never published") }) {
+		t.Error("Amend reported success with nothing published")
+	}
+
+	Publish(pctx, costevent.Event{CostUSD: 0.25, Settled: true})
+	if !Amend(pctx, func(ev *costevent.Event) { ev.DailyTotalUSD = 9 }) {
+		t.Fatal("Amend failed on a published record")
+	}
+	// Both keys must carry the amendment, or an older abctl shows a stale total.
+	for _, key := range []string{costevent.Key, costevent.PluginName} {
+		ev, ok := pctx.Extensions.Custom[key+pipeline.PluginEventSuffix].(costevent.Event)
+		if !ok {
+			t.Fatalf("%q missing after amend", key)
+		}
+		if ev.DailyTotalUSD != 9 || ev.CostUSD != 0.25 {
+			t.Errorf("%q = %+v, want the amendment applied and the cost preserved", key, ev)
+		}
+	}
+}
+
+// Store/Load hand the full outcome to later plugins in the same request without widening
+// the wire shape.
+func TestStoreLoad(t *testing.T) {
+	pctx := ctx(nil, 0, 0)
+	if _, ok := Load(pctx); ok {
+		t.Error("loaded an outcome that was never stored")
+	}
+	Store(pctx, Settled{CostUSD: 0.25, Priced: true, ModelledUSD: 0.3, HasModelled: true})
+	got, ok := Load(pctx)
+	if !ok {
+		t.Fatal("stored outcome not found")
+	}
+	if got.CostUSD != 0.25 || got.ModelledUSD != 0.3 {
+		t.Errorf("round trip lost data: %+v", got)
+	}
+}

--- a/authbridge/authlib/costing/decode.go
+++ b/authbridge/authlib/costing/decode.go
@@ -1,0 +1,38 @@
+package costing
+
+import "encoding/json"
+
+// The published plugin events are plugin-defined structs this package deliberately does not
+// import. These read the few fields needed through the same JSON tags the wire uses, so a
+// rename in the producer is caught by costing's own tests rather than silently zeroing a
+// saving.
+
+func asMap(v any) (map[string]any, bool) {
+	if m, ok := v.(map[string]any); ok {
+		return m, true
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, false
+	}
+	return m, true
+}
+
+func intField(m map[string]any, key string) int {
+	switch v := m[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	}
+	return 0
+}
+
+func boolField(m map[string]any, key string) bool {
+	b, _ := m[key].(bool)
+	return b
+}

--- a/authbridge/authlib/plugins/deps_test.go
+++ b/authbridge/authlib/plugins/deps_test.go
@@ -138,10 +138,29 @@ func TestPricingConsumerPlugins_FindsRegisteredConsumers(t *testing.T) {
 	}
 }
 
-func TestPricingConsumerPlugins_ExcludesNonConsumers(t *testing.T) {
-	for _, n := range PricingConsumerPlugins() {
-		if n == "inference-parser" {
-			t.Error("inference-parser reported as a pricing consumer; it publishes tokens, it does not price them")
+// inference-parser IS a pricing consumer, and litellm-budget-track is not — the inverse of
+// what this test asserted before cortex #972.
+//
+// The reason it flipped: the component that knows when token counts are FINAL is the one
+// that can price them exactly once, and a budget has no business computing the number it
+// enforces against. The old arrangement meant a pipeline without the budget plugin showed
+// token counts and no money, with the same field silently changing meaning depending on
+// configuration.
+func TestPricingConsumerPlugins_TracksTheCostOwner(t *testing.T) {
+	consumers := PricingConsumerPlugins()
+	var hasParser, hasBudget bool
+	for _, n := range consumers {
+		switch n {
+		case "inference-parser":
+			hasParser = true
+		case "litellm-budget-track":
+			hasBudget = true
 		}
+	}
+	if !hasParser {
+		t.Errorf("inference-parser is not reported as a pricing consumer, but it owns costing: %v", consumers)
+	}
+	if hasBudget {
+		t.Errorf("litellm-budget-track is reported as a pricing consumer; it bills a settled figure and computes nothing: %v", consumers)
 	}
 }

--- a/authbridge/authlib/plugins/inferenceparser/cost.go
+++ b/authbridge/authlib/plugins/inferenceparser/cost.go
@@ -58,7 +58,7 @@ func (p *InferenceParser) settleCost(pctx *pipeline.Context) {
 	if !settled.Priced && len(avoided) == 0 {
 		return
 	}
-	costing.Publish(pctx, costing.Record(settled, avoided))
+	costing.Publish(pctx, costing.NewRecord(settled, avoided))
 }
 
 // costSettledKey and settledOnce mark this request as already priced.

--- a/authbridge/authlib/plugins/inferenceparser/cost.go
+++ b/authbridge/authlib/plugins/inferenceparser/cost.go
@@ -55,7 +55,11 @@ func (p *InferenceParser) settleCost(pctx *pipeline.Context) {
 	// operator which rate to add. costevent.Decode still reports such a record as
 	// unpriced, so no consumer counts it as spend; that is what Record/Priced separate.
 	avoided := costing.Avoided(pctx, p.rates)
-	if !settled.Priced && len(avoided) == 0 {
+	// HasPrompt is checked separately from Priced, because the two really can differ: a
+	// table that prices every prompt tier but not a populated output tier yields a prompt
+	// figure and no total. Dropping the record there would lose a figure a request row
+	// can legitimately show, and the total stays absent rather than invented.
+	if !settled.Priced && !settled.HasPrompt && len(avoided) == 0 {
 		return
 	}
 	costing.Publish(pctx, costing.NewRecord(settled, avoided))

--- a/authbridge/authlib/plugins/inferenceparser/cost.go
+++ b/authbridge/authlib/plugins/inferenceparser/cost.go
@@ -1,0 +1,75 @@
+package inferenceparser
+
+import (
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
+	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
+)
+
+// This file makes the parser the one owner of what a request cost.
+//
+// It belongs here, and not in a plugin that acts on the money, for reasons that only
+// become clear from the pipeline's shape:
+//
+//   - The parser is the ONLY component that knows when usage is final. It owns the
+//     three finalization paths below, and it is where the assembled-usage fix lives
+//     (Claude Code's `?beta=true` path reports cache counts on message_delta, not
+//     message_start). Costing anywhere else duplicates that assembly or races it.
+//   - Cost then cannot be missing while tokens are present. Previously the figure came
+//     from litellm-budget-track, so a pipeline without it showed token counts and no
+//     money — the same field silently meaning "modelled" instead of "authoritative"
+//     depending on configuration. No parser means no tokens, so there is nothing to
+//     price and nothing to explain.
+//   - Consumers already declare the dependency needed to read it.
+//     litellm-budget-track has `RequiresLater: inference-parser`, and plugins/registry.go
+//     documents that as a hard AND with ordering: the pipeline refuses to build without
+//     the parser. Response passes run in reverse, so the parser settles before any
+//     consumer looks.
+//
+// The arithmetic and the gateway's header semantics live in authlib/costing, not here. A
+// provider-shaped body parser has no business knowing one gateway's header names.
+
+// settleCost prices the finalized response and publishes the record, exactly once.
+//
+// Called from every finalization path. The idempotence guard is not belt-and-braces: a
+// listener can dispatch a terminal frame twice — extproc does, once for headers and once
+// for the buffered body — and charging twice for one request is the failure that guard
+// exists to prevent. It mirrors the one litellm-budget-track keeps for the same reason.
+func (p *InferenceParser) settleCost(pctx *pipeline.Context) {
+	if pctx == nil || pctx.Extensions.Inference == nil {
+		return
+	}
+	if st := pipeline.GetState[settledOnce](pctx, costSettledKey); st != nil {
+		return
+	}
+	pipeline.SetState(pctx, costSettledKey, &settledOnce{})
+
+	settled := costing.Settle(pctx, p.rates)
+	// Stored even when nothing priced, so a consumer can tell "no figure" from "no
+	// inference at all" — and so the drift check can see both figures.
+	costing.Store(pctx, settled)
+
+	// Published when there is ANYTHING to say — a settled cost, or a saving another
+	// component achieved. Gating on the cost alone would drop the saving for a model the
+	// rate table cannot price, and the unpriced-model tally is precisely what tells an
+	// operator which rate to add. costevent.Decode still reports such a record as
+	// unpriced, so no consumer counts it as spend; that is what Record/Priced separate.
+	avoided := costing.Avoided(pctx, p.rates)
+	if !settled.Priced && len(avoided) == 0 {
+		return
+	}
+	costing.Publish(pctx, costing.Record(settled, avoided))
+}
+
+// costSettledKey and settledOnce mark this request as already priced.
+const costSettledKey = "inference-parser.cost-settled"
+
+type settledOnce struct{}
+
+// SetPricingResolver implements pricing.ResolverConsumer.
+//
+// Injected by plugins.BuildWithDeps when the process has a rate table. A nil resolver is a
+// supported state, not an error: a binary built without pricing wiring reports traffic as
+// unpriced rather than refusing to parse it. costing.Settle guards the interface — the trap
+// being that a nil INTERFACE panics on call where a nil *pricing.Registry would not.
+func (p *InferenceParser) SetPricingResolver(r pricing.Resolver) { p.rates = r }

--- a/authbridge/authlib/plugins/inferenceparser/plugin.go
+++ b/authbridge/authlib/plugins/inferenceparser/plugin.go
@@ -10,11 +10,19 @@ import (
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins/internal/parsercommon"
+	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
 
 // InferenceParser parses outbound OpenAI-compatible LLM inference requests
 // and populates pctx.Extensions.Inference for downstream policy plugins.
-type InferenceParser struct{}
+//
+// It also prices the finalized response — see cost.go for why the component that produces
+// the token counts is the one that turns them into money.
+type InferenceParser struct {
+	// rates is the process rate table, injected by plugins.BuildWithDeps. Nil when the
+	// process has no pricing wired, which costing.Settle handles by reporting unpriced.
+	rates pricing.Resolver
+}
 
 func NewInferenceParser() *InferenceParser { return &InferenceParser{} }
 
@@ -164,6 +172,7 @@ func (p *InferenceParser) OnResponse(_ context.Context, pctx *pipeline.Context) 
 	}
 
 	logInferenceFinalized(ext)
+	p.settleCost(pctx)
 	pctx.Observe("matched_" + ext.Model + "_response")
 	return pipeline.Action{Type: pipeline.Continue}
 }
@@ -247,6 +256,7 @@ func (p *InferenceParser) OnResponseFrame(_ context.Context, pctx *pipeline.Cont
 			parseInferenceJSON(frame, ext)
 		}
 		logInferenceFinalized(ext)
+		p.settleCost(pctx)
 		pctx.Observe("matched_" + ext.Model + "_response")
 		return pipeline.Action{Type: pipeline.Continue}
 	}
@@ -280,6 +290,7 @@ func (p *InferenceParser) OnResponseFrame(_ context.Context, pctx *pipeline.Cont
 			return pipeline.Action{Type: pipeline.Continue}
 		}
 		logInferenceFinalized(ext)
+		p.settleCost(pctx)
 		pctx.Observe("matched_" + ext.Model + "_response")
 	}
 	return pipeline.Action{Type: pipeline.Continue}

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift.go
@@ -3,10 +3,10 @@ package litellm_budgettrack
 import (
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
@@ -64,32 +64,30 @@ func (p *BudgetTrack) SetDriftLogger(l *slog.Logger) {
 	p.drift.mu.Unlock()
 }
 
-// checkDrift compares an authoritative cost against what the rate table would have
-// modelled, and warns on a material divergence.
+// checkDrift compares the gateway's own cost against what the rate table modelled, and
+// warns on a material divergence.
 //
-// Called only where an authoritative figure exists — a non-streamed response with a
-// usable cost header. A streamed response reports 0 there by design, so there is
-// nothing to compare and silence is correct.
+// Reads BOTH figures off the settled outcome rather than recomputing either. That is the
+// point of the outcome carrying the pair: a drift check that re-derives the modelled figure
+// is comparing its own arithmetic, not the arithmetic that was actually used, and the two
+// can drift apart without anything failing.
 //
-// The ledger keeps using the authoritative figure regardless: drift is a diagnostic
-// about the rate TABLE, never a reason to distrust the gateway's own number.
-func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) {
-	if authoritative <= 0 || p.rates == nil {
-		return
+// Called only where an authoritative figure exists — a non-streamed response with a usable
+// cost header. A streamed response reports 0 there by design, so there is nothing to compare
+// and silence is correct.
+//
+// The ledger keeps using the authoritative figure regardless: drift is a diagnostic about the
+// rate TABLE, never a reason to distrust the gateway's own number.
+func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, settled costing.Settled) {
+	authoritative := settled.CostUSD
+	if authoritative <= 0 || !settled.HasModelled {
+		return // unpriced by the table is a coverage gap, already reported as one
 	}
 	inf := pctx.Extensions.Inference
 	if inf == nil || inf.Model == "" {
 		return
 	}
-	u := pricing.UsageFromInference(inf)
-	if u == (pricing.Usage{}) {
-		return
-	}
-	micros, prov, ok := p.costOf(pctx.Host, inf.Model, u)
-	if !ok {
-		return // unpriced is already reported as a coverage gap; not drift
-	}
-	modelled := float64(micros) / 1e6
+	modelled, prov := settled.ModelledUSD, settled.ModelledProv
 	ratio := modelled / authoritative
 	// Inclusive bounds: the contract above says "more than 5%", and a strict compare
 	// warned AT exactly 5%.
@@ -102,7 +100,7 @@ func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) 
 	// layer, and comparing a modelled cost against it would report drift that is really
 	// the operator's own gateway-side adjustment. Skipped rather than guessed at,
 	// because the arithmetic relating the two is not something this code can verify.
-	if !driftComparable(pctx) {
+	if !costing.Comparable(pctx) {
 		return
 	}
 
@@ -150,28 +148,6 @@ func (p *BudgetTrack) checkDrift(pctx *pipeline.Context, authoritative float64) 
 		"effect", direction+"stating every request this table prices, including streamed ones where no gateway figure exists",
 		"rates_from", prov.String(),
 		"fix", "set pricing.endpoints[].multiplier for this endpoint (a fraction of list), or per-model rates; `abctl pricing --host <endpoint>` shows what is in effect")
-}
-
-// driftComparable reports whether the gateway's figure can be compared against a modelled
-// one at all.
-//
-// False when the bare header is absent AND LiteLLM's own discount/margin layer is active:
-// the fallback figure is then pre-adjustment while the modelled figure is what the caller
-// pays, so any comparison measures the gateway's adjustment rather than the rate table.
-func driftComparable(pctx *pipeline.Context) bool {
-	if pctx.ResponseHeaders.Get(responseCostHeader) != "" {
-		return true // the effective figure itself; nothing to reconcile
-	}
-	for _, h := range []string{costDiscountAmountHeader, costMarginAmountHeader} {
-		v := pctx.ResponseHeaders.Get(h)
-		if v == "" {
-			continue
-		}
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 // resetDrift clears the dedup set and the cap.

--- a/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/drift_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
@@ -30,7 +31,7 @@ func TestDrift_WarnsWhenModelledDivergesFromAuthoritative(t *testing.T) {
 	// 1000 in + 1000 out at 2e-6 = 0.004 modelled; gateway says 0.002.
 	h := http.Header{}
 	h.Set("Content-Type", "application/json")
-	h.Set(responseCostHeader, "0.002")
+	h.Set(costing.ResponseCostHeader, "0.002")
 	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 	pricedInference(pctx, 1000, 0, 0, 1000)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -61,7 +62,7 @@ func TestDrift_SilentWhenTheyAgree(t *testing.T) {
 
 	h := http.Header{}
 	h.Set("Content-Type", "application/json")
-	h.Set(responseCostHeader, "0.002") // 1000+1000 at 1e-6 = exactly 0.002
+	h.Set(costing.ResponseCostHeader, "0.002") // 1000+1000 at 1e-6 = exactly 0.002
 	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 	pricedInference(pctx, 1000, 0, 0, 1000)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -84,7 +85,7 @@ func TestDrift_WarnsOncePerEndpointModel(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		h := http.Header{}
 		h.Set("Content-Type", "application/json")
-		h.Set(responseCostHeader, "0.002")
+		h.Set(costing.ResponseCostHeader, "0.002")
 		pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 		pricedInference(pctx, 1000, 0, 0, 1000)
 		p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -106,7 +107,7 @@ func TestDrift_SilentOnStreamedResponses(t *testing.T) {
 
 	h := http.Header{}
 	h.Set("Content-Type", "text/event-stream")
-	h.Set(responseCostHeader, "0")
+	h.Set(costing.ResponseCostHeader, "0")
 	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 	pricedInference(pctx, 1000, 0, 0, 1000)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -130,7 +131,7 @@ func TestDrift_SeenMapIsBounded(t *testing.T) {
 	for i := 0; i < maxDriftKeys*3; i++ {
 		h := http.Header{}
 		h.Set("Content-Type", "application/json")
-		h.Set(responseCostHeader, "0.002")
+		h.Set(costing.ResponseCostHeader, "0.002")
 		pctx := &pipeline.Context{Host: fmt.Sprintf("gw-%d.internal", i), ResponseHeaders: h}
 		pricedInference(pctx, 1000, 0, 0, 1000)
 		p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -164,9 +165,9 @@ func TestDrift_SilentOnTheOriginalHeaderFallback(t *testing.T) {
 	h := http.Header{}
 	h.Set("Content-Type", "application/json")
 	// No bare header, exactly as /v1/messages replies.
-	h.Set(responseCostOriginalHeader, "0.002")
-	h.Set(costDiscountAmountHeader, "0.0")
-	h.Set(costMarginAmountHeader, "0.0")
+	h.Set(costing.ResponseCostOriginalHeader, "0.002")
+	h.Set(costing.DiscountAmountHeader, "0.0")
+	h.Set(costing.MarginAmountHeader, "0.0")
 	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 	pricedInference(pctx, 1000, 0, 0, 1000)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -193,8 +194,8 @@ func TestDrift_SilentWhenTheFallbackFigureIsPreAdjustment(t *testing.T) {
 
 	h := http.Header{}
 	h.Set("Content-Type", "application/json")
-	h.Set(responseCostOriginalHeader, "0.002") // modelled would be 0.004 → 2x, normally a warning
-	h.Set(costDiscountAmountHeader, "0.0005")  // but the gateway adjusts its own figure
+	h.Set(costing.ResponseCostOriginalHeader, "0.002") // modelled would be 0.004 → 2x, normally a warning
+	h.Set(costing.DiscountAmountHeader, "0.0005")      // but the gateway adjusts its own figure
 	pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 	pricedInference(pctx, 1000, 0, 0, 1000)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -225,7 +226,7 @@ func TestDrift_TolerancePeriodIsInclusive(t *testing.T) {
 
 			h := http.Header{}
 			h.Set("Content-Type", "application/json")
-			h.Set(responseCostHeader, tc.authorativ)
+			h.Set(costing.ResponseCostHeader, tc.authorativ)
 			pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 			pricedInference(pctx, 1000, 0, 0, 1000) // modelled 0.002
 			p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -249,7 +250,7 @@ func TestDrift_DedupKeyNormalizesTheHost(t *testing.T) {
 	for _, host := range []string{"gw.internal", "GW.internal", "gw.internal:443"} {
 		h := http.Header{}
 		h.Set("Content-Type", "application/json")
-		h.Set(responseCostHeader, "0.002")
+		h.Set(costing.ResponseCostHeader, "0.002")
 		pctx := &pipeline.Context{Host: host, ResponseHeaders: h}
 		pricedInference(pctx, 1000, 0, 0, 1000)
 		p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -270,7 +271,7 @@ func TestDrift_ConfigureResetsTheReporter(t *testing.T) {
 		p.SetDriftLogger(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
 		h := http.Header{}
 		h.Set("Content-Type", "application/json")
-		h.Set(responseCostHeader, "0.002")
+		h.Set(costing.ResponseCostHeader, "0.002")
 		pctx := &pipeline.Context{Host: "gw.internal", ResponseHeaders: h}
 		pricedInference(pctx, 1000, 0, 0, 1000)
 		p.OnResponseFrame(context.Background(), pctx, nil, true)

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -29,45 +29,13 @@ import (
 	"math"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
-	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
-)
-
-// Response cost headers emitted by LiteLLM.
-//
-// MEASURED 2026-09-11 against ete-litellm (LiteLLM 1.85.5), because an earlier version of
-// this comment had the semantics backwards and a reviewer reasonably concluded from it
-// that drift detection would false-positive on every Anthropic-format request:
-//
-//	/v1/chat/completions  both headers present, IDENTICAL values
-//	/v1/messages          only "-original", same value the other path reports
-//
-// For 16 input + 4 output tokens of claude-opus-5 both paths reported
-// 0.00013680000000000002, which is 0.76 x vendor list (16x$5 + 4x$25 per Mtok = 0.00018).
-// So "-original" is the cost the gateway ACTUALLY CHARGED, not a pre-discount list price,
-// and falling back to it compares like with like.
-//
-// "Original" refers to LiteLLM's OWN discount/margin layer, reported alongside in
-// X-Litellm-Response-Cost-{Discount,Margin}-Amount: original is the figure before that
-// layer is applied. This gateway runs neither (both report 0.0), so the two agree. A
-// gateway that DOES configure them would see them diverge, which is why checkDrift
-// checks those headers before comparing — see driftComparable.
-//
-// The fallback itself is load-bearing: without it, budget tracking silently records $0
-// for every Anthropic-format request, which is the shape Claude Code sends.
-const (
-	responseCostHeader         = "X-Litellm-Response-Cost"
-	responseCostOriginalHeader = "X-Litellm-Response-Cost-Original"
-
-	// LiteLLM's own adjustment layer, non-zero only where an operator configured it.
-	costDiscountAmountHeader = "X-Litellm-Response-Cost-Discount-Amount"
-	costMarginAmountHeader   = "X-Litellm-Response-Cost-Margin-Amount"
 )
 
 type budgetTrackConfig struct {
@@ -106,22 +74,23 @@ type spendLedger struct {
 	TotalCalls int     `json:"total_calls"`
 }
 
-// BudgetTrack enforces a daily spending budget based on x-litellm-response-cost.
+// BudgetTrack keeps the daily spend ledger and refuses requests once the budget is spent.
+//
+// It does NOT decide what a request cost. That is authlib/costing, driven by
+// inference-parser — the component that knows when token counts are final — and this plugin
+// bills the figure that was published. Before cortex #972 both jobs lived here, which meant
+// a pipeline without this plugin had no authoritative figure at all and every cost silently
+// became a modelled one.
 type BudgetTrack struct {
 	cfg    budgetTrackConfig
 	mu     sync.Mutex
 	ledger spendLedger
 
-	// rates is the process rate table, injected before Configure. Read only
-	// through costOf, which guards the nil interface.
-	rates pricing.Resolver
-
-	// drift reports when the table disagrees with the gateway's own figure.
+	// drift warns when the rate table disagrees with what the gateway charged. It stays
+	// here rather than moving with the arithmetic because the dedup, the cap and the
+	// operator advice are policy, and a body parser is the wrong home for policy.
 	drift driftReporter
 }
-
-// SetPricingResolver implements pricing.ResolverConsumer.
-func (p *BudgetTrack) SetPricingResolver(r pricing.Resolver) { p.rates = r }
 
 // New creates an unconfigured BudgetTrack plugin instance.
 func New() *BudgetTrack { return &BudgetTrack{} }
@@ -224,117 +193,81 @@ func (p *BudgetTrack) OnRequest(_ context.Context, pctx *pipeline.Context) pipel
 // so pipeline.RunResponse skips it and OnResponseFrame drives accumulation
 // instead; this remains for listeners that only call OnResponse.
 func (p *BudgetTrack) OnResponse(_ context.Context, pctx *pipeline.Context) pipeline.Action {
-	if cost, st := headerCost(pctx); st == headerPositive && cost > 0 {
-		if total, ok := p.accumulate(cost); ok {
-			p.emitCost(pctx, cost, costevent.SourceGatewayHeader, total, pricing.ProvAuthoritative)
-		}
-	}
+	p.bill(pctx)
 	return pipeline.Action{Type: pipeline.Continue}
 }
 
-// OnResponseFrame observes each response frame. It parses token usage out of
-// streamed SSE frames and, on the terminal frame, prices the request: the
-// response-header cost when present (non-streaming), otherwise the parsed
-// usage times the configured per-token rates (streaming).
+// OnResponseFrame bills the terminal frame.
+//
+// It no longer prices anything. inference-parser settles the cost — it is the component
+// that knows when usage is final — and this plugin's job is the ledger and the budget. See
+// authlib/costing and inferenceparser/cost.go for why the split runs that way.
 func (p *BudgetTrack) OnResponseFrame(_ context.Context, pctx *pipeline.Context, frame []byte, last bool) pipeline.Action {
 	if !last {
 		return pipeline.Action{Type: pipeline.Continue}
 	}
+	p.bill(pctx)
+	return pipeline.Action{Type: pipeline.Continue}
+}
 
-	// Terminal frame: settle the cost exactly once. Materialize the scratch
-	// unconditionally (a header-only response never allocated it above) so the
-	// guard also covers that path — a listener that dispatches last=true twice
-	// (e.g. extproc header + buffered-body phases) must not double-charge.
+// bill adds the settled cost to today's ledger, exactly once per request.
+//
+// The idempotence guard stays here even though the parser has one of its own: a listener
+// can dispatch a terminal frame twice (extproc does, once for headers and once for the
+// buffered body), and this is the ledger — double-counting money is not recoverable from a
+// later correction, because the file has already been written.
+func (p *BudgetTrack) bill(pctx *pipeline.Context) {
 	st := pipeline.GetState[settleState](pctx, stateKey)
 	if st == nil {
 		st = &settleState{}
 		pipeline.SetState(pctx, stateKey, st)
 	}
 	if st.settled {
-		return pipeline.Action{Type: pipeline.Continue}
+		return
+	}
+
+	settled, ok := costing.Load(pctx)
+	if !ok || !settled.Priced {
+		// Nothing was priced, so there is nothing to bill and no ledger fields to
+		// add. NOT marked settled: a listener that calls OnResponse before the
+		// parser has finalized must not lock this request out of being billed by the
+		// terminal frame that follows.
+		return
 	}
 	st.settled = true
 
-	cost, state := headerCost(pctx)
-	source := costevent.SourceGatewayHeader
-	// A header cost is a settled figure the gateway reported, not a rate we looked
-	// up — the strongest provenance there is.
-	provenance := pricing.ProvAuthoritative
-	// A zero on a stream is LiteLLM's placeholder, not an answer, so it falls back
-	// like an absent header. A zero on a non-streamed response IS an answer.
-	streamedPlaceholder := state == headerZero && isEventStream(pctx)
-	declaredFree := state == headerZero && !streamedPlaceholder
-	if state != headerPositive {
-		// Fall back to per-token pricing only when there is no authoritative
-		// header cost: the header is absent, or this is a streamed response
-		// (where LiteLLM always reports 0). A present "0" on a non-streamed
-		// response is a genuine free call (cache hit / error) — charge nothing,
-		// don't invent a cost from the usage block.
-		if !declaredFree {
-			// Price the per-tier counts inference-parser published, through the
-			// process rate table scoped to this request's endpoint.
-			//
-			// The plugin used to run its own SSE parser to gather those counts,
-			// folding the same frames inference-parser had already folded, and to
-			// hold its own four rates. Both are gone: one parser, one rate table,
-			// one place tokens become dollars.
-			usage := pricing.UsageFromInference(pctx.Extensions.Inference)
-			model := ""
-			if pctx.Extensions.Inference != nil {
-				model = pctx.Extensions.Inference.Model
-			}
-			micros, prov, priced := p.costOf(pctx.Host, model, usage)
-			if priced {
-				cost = float64(micros) / 1e6
-				source = costevent.SourceUsageFallback
-				provenance = prov
-			}
-		}
+	// Only a gateway figure is worth comparing against the table. Comparing a modelled
+	// figure with itself would always agree and say nothing.
+	if settled.Source == costevent.SourceGatewayHeader && settled.CostUSD > 0 {
+		p.checkDrift(pctx, settled)
 	}
-	switch {
-	case cost > 0:
-		if source == costevent.SourceGatewayHeader {
-			// Only a header cost is authoritative. Comparing a modelled figure against
-			// itself would always agree and say nothing.
-			p.checkDrift(pctx, cost)
-		}
-		if total, ok := p.accumulate(cost); ok {
-			p.emitCost(pctx, cost, source, total, provenance)
-		}
-	case declaredFree:
-		// The gateway reported a parsed, finite, exactly-zero cost on a NON-streamed
-		// response: a genuine free call — a cache hit, or an error it declined to
-		// charge for. Nothing is added to the ledger, but the event is published so
-		// downstream knows this was PRICED at zero rather than unpriced. Without it
-		// the aggregator finds no figure and invents a cost for a call the gateway
-		// declared free.
-		//
-		// Deliberately NOT reached for an unusable header, nor for a stream whose
-		// usage fallback failed to price. Those are unpriced, and claiming them as
-		// settled zeros would count them toward coverage and drop them from the
-		// unpriced list — the inverse of the bug this branch fixes.
-		p.emitSettledZero(pctx)
+
+	total, added := p.accumulate(settled.CostUSD)
+	if !added {
+		// A settled zero: the gateway charged nothing, so nothing enters the ledger.
+		// The record still needs this plugin's fields, because a client showing a
+		// budget needs the daily total for a free call as much as for a billed one.
+		p.mu.Lock()
+		total = p.ledger.TotalSpend
+		p.mu.Unlock()
 	}
-	return pipeline.Action{Type: pipeline.Continue}
+	p.amend(pctx, total)
 }
 
-// emitSettledZero publishes a zero cost the gateway actually reported, as distinct
-// from the absence of any figure.
-func (p *BudgetTrack) emitSettledZero(pctx *pipeline.Context) {
-	if pctx.Extensions.Custom == nil {
-		pctx.Extensions.Custom = map[string]any{}
+// amend adds this plugin's own fields to the record the cost owner published.
+//
+// The one sanctioned second write to that key: the daily total and the configured maximum
+// are the budget's business and nothing else's, and the alternative — a second event just
+// for two numbers — would make every consumer join two records to render one line.
+func (p *BudgetTrack) amend(pctx *pipeline.Context, dailyTotal float64) {
+	if costing.Amend(pctx, func(ev *costevent.Event) {
+		ev.DailyTotalUSD = dailyTotal
+		ev.DailyMaxUSD = p.cfg.MaxBudget
+	}) {
+		return
 	}
-	p.mu.Lock()
-	total := p.ledger.TotalSpend
-	p.mu.Unlock()
-	pctx.Extensions.Custom[p.Name()+pipeline.PluginEventSuffix] = costevent.Event{
-		CostUSD:       0,
-		Source:        costevent.SourceGatewayHeader,
-		DailyTotalUSD: total,
-		DailyMaxUSD:   p.cfg.MaxBudget,
-		Provenance:    pricing.ProvAuthoritative.String(),
-		Settled:       true,
-	}
+	// No record to amend means no cost owner ran. Nothing to say, and inventing a
+	// record here would report a cost this plugin did not compute.
 }
 
 // accumulate adds one priced call to today's ledger and persists it,
@@ -355,99 +288,6 @@ func (p *BudgetTrack) accumulate(cost float64) (dailyTotal float64, added bool) 
 	p.saveLedger()
 	p.mu.Unlock()
 	return total, true
-}
-
-// emitCost writes the costEvent to pctx.Extensions.Custom; the listener
-// forwards it to SessionEvent.Plugins under the plugin name.
-func (p *BudgetTrack) emitCost(pctx *pipeline.Context, cost float64, source string, dailyTotal float64, prov pricing.Provenance) {
-	if pctx.Extensions.Custom == nil {
-		pctx.Extensions.Custom = map[string]any{}
-	}
-	pctx.Extensions.Custom[p.Name()+pipeline.PluginEventSuffix] = costevent.Event{
-		CostUSD:       cost,
-		Source:        source,
-		DailyTotalUSD: dailyTotal,
-		DailyMaxUSD:   p.cfg.MaxBudget,
-		Provenance:    prov.String(),
-		Settled:       true,
-	}
-}
-
-// costOf prices usage through the injected rate table.
-//
-// The nil guard is on the INTERFACE, which is the trap: an un-injected plugin holds
-// a nil interface and calling a method on it panics, where a nil *pricing.Registry
-// would have been safe. tool-prune hit exactly this and its fail-open masked the
-// panic as silently-disabled pruning.
-func (p *BudgetTrack) costOf(host, model string, u pricing.Usage) (micros int64, prov pricing.Provenance, ok bool) {
-	if p.rates == nil {
-		return 0, pricing.ProvNone, false
-	}
-	rates, prov := p.rates.Resolve(host, model, u.PromptTotal())
-	if prov == pricing.ProvNone {
-		return 0, pricing.ProvNone, false
-	}
-	micros, ok = pricing.Cost(rates, u)
-	if !ok {
-		return 0, pricing.ProvNone, false
-	}
-	return micros, prov, true
-}
-
-// headerCostState says what the gateway's cost header actually told us. A bool
-// could not carry this, and collapsing these cases caused a real defect: every
-// state below except headerPositive returned (0, true), so "the gateway declared
-// this call free" was indistinguishable from "the header was garbage" and from
-// "this is a stream, where LiteLLM always stamps 0 as a placeholder". Publishing a
-// settled zero for all of them counted unpriced traffic as priced.
-type headerCostState int
-
-const (
-	// headerAbsent: no cost header at all. Price from token usage.
-	headerAbsent headerCostState = iota
-	// headerUnusable: a header was present but could not be believed — unparseable,
-	// negative, NaN or Inf. NOT a declaration of anything, so it must not suppress
-	// the usage fallback and must never publish a settled zero.
-	headerUnusable
-	// headerZero: present, parsed, finite and exactly zero. On a NON-streamed
-	// response this is the gateway saying the call was free — a cache hit, or an
-	// error it declined to charge for. On a streamed response it means nothing:
-	// LiteLLM stamps 0 there by design because the total is unknown when headers
-	// are sent.
-	headerZero
-	// headerPositive: a usable figure.
-	headerPositive
-)
-
-// headerCost returns the cost the gateway reported and what kind of answer it was.
-func headerCost(pctx *pipeline.Context) (cost float64, state headerCostState) {
-	costStr := pctx.ResponseHeaders.Get(responseCostHeader)
-	if costStr == "" {
-		// Anthropic /v1/messages (and newer LiteLLM) omit the bare header.
-		costStr = pctx.ResponseHeaders.Get(responseCostOriginalHeader)
-	}
-	if costStr == "" {
-		return 0, headerAbsent
-	}
-	c, err := strconv.ParseFloat(costStr, 64)
-	if err != nil || math.IsNaN(c) || math.IsInf(c, 0) || c < 0 {
-		return 0, headerUnusable
-	}
-	if c == 0 {
-		return 0, headerZero
-	}
-	return c, headerPositive
-}
-
-// isEventStream reports whether the response is a text/event-stream (SSE) — the
-// streamed shape where LiteLLM reports cost 0 in the header, so usage-based
-// pricing is the intended fallback.
-func isEventStream(pctx *pipeline.Context) bool {
-	ct := pctx.ResponseHeaders.Get("Content-Type")
-	if i := strings.IndexByte(ct, ';'); i >= 0 {
-		ct = ct[:i]
-	}
-	return strings.EqualFold(strings.TrimSpace(ct), "text/event-stream")
 }
 
 func (p *BudgetTrack) todayUTC() string {

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin.go
@@ -247,7 +247,13 @@ func (p *BudgetTrack) bill(pctx *pipeline.Context) {
 		// A settled zero: the gateway charged nothing, so nothing enters the ledger.
 		// The record still needs this plugin's fields, because a client showing a
 		// budget needs the daily total for a free call as much as for a billed one.
+		//
+		// resetIfNewDay first, under the lock, exactly as accumulate does. A request
+		// that starts before midnight UTC and settles after it would otherwise stamp
+		// YESTERDAY's total onto today's first event — and a free call is a plausible
+		// first request of the day, since a cache hit costs nothing.
 		p.mu.Lock()
+		p.resetIfNewDay()
 		total = p.ledger.TotalSpend
 		p.mu.Unlock()
 	}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -934,3 +934,37 @@ func TestEndToEnd_UnpricedResponseReachesAggregatorUnpriced(t *testing.T) {
 		t.Errorf("Tokens = %d, want 1000", snap.Totals.Tokens)
 	}
 }
+
+// A request that starts before midnight UTC and settles after it must not stamp yesterday's
+// total onto today's first event.
+//
+// The free-call path is where this bites: it reports the day's total without adding to it, so
+// it reads the ledger directly, and a cache hit is a plausible first request of a new day.
+func TestBill_SettledZeroRollsTheLedgerDate(t *testing.T) {
+	p := configure(t, 5.00)
+	// Yesterday's ledger, as loadLedger would leave it for a process that has been up
+	// across midnight.
+	p.ledger = spendLedger{Date: "2026-09-10", TotalSpend: 4.20, TotalCalls: 7}
+
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0"}}}
+	p.OnResponse(context.Background(), pctx)
+
+	ev := getCostEvent(t, pctx)
+	if ev == nil {
+		t.Fatal("no settled-zero event")
+	}
+	if ev.DailyTotalUSD != 0 {
+		t.Errorf("DailyTotalUSD = %v, want 0 — yesterday's spend leaked into today's event", ev.DailyTotalUSD)
+	}
+	if p.ledger.TotalSpend != 0 || p.ledger.TotalCalls != 0 {
+		t.Errorf("ledger not rolled: %+v", p.ledger)
+	}
+	// Same day, and the total is reported as-is.
+	p2 := configure(t, 5.00)
+	p2.ledger = spendLedger{Date: p2.todayUTC(), TotalSpend: 1.25, TotalCalls: 3}
+	pctx2 := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0"}}}
+	p2.OnResponse(context.Background(), pctx2)
+	if ev2 := getCostEvent(t, pctx2); ev2 == nil || ev2.DailyTotalUSD != 1.25 {
+		t.Errorf("same-day total = %+v, want 1.25", ev2)
+	}
+}

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -310,7 +310,7 @@ func (b *billing) settle(pctx *pipeline.Context) {
 	s := costing.Settle(pctx, b.rates)
 	costing.Store(pctx, s)
 	if s.Priced {
-		costing.Publish(pctx, costing.Record(s, costing.Avoided(pctx, b.rates)))
+		costing.Publish(pctx, costing.NewRecord(s, costing.Avoided(pctx, b.rates)))
 	}
 }
 

--- a/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 	"github.com/rossoctl/cortex/authbridge/authlib/session"
@@ -21,7 +22,7 @@ import (
 )
 
 // configure builds a BudgetTrack with a temp-dir spend file and the given budget.
-func configure(t *testing.T, maxBudget float64) *BudgetTrack {
+func configure(t *testing.T, maxBudget float64) *billing {
 	t.Helper()
 	p := New()
 	cfg := budgetTrackConfig{
@@ -32,7 +33,9 @@ func configure(t *testing.T, maxBudget float64) *BudgetTrack {
 	if err := p.Configure(raw); err != nil {
 		t.Fatalf("Configure() error = %v", err)
 	}
-	return p
+	// No rates: the header path needs none, and a nil resolver is the state a binary
+	// without pricing wiring is in.
+	return &billing{BudgetTrack: p}
 }
 
 // TestOnResponseReadsResponseHeader is the regression guard for the core fix:
@@ -40,7 +43,7 @@ func configure(t *testing.T, maxBudget float64) *BudgetTrack {
 func TestOnResponseReadsResponseHeader(t *testing.T) {
 	p := configure(t, 5.00)
 	pctx := &pipeline.Context{
-		ResponseHeaders: http.Header{responseCostHeader: {"0.0025"}},
+		ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.0025"}},
 	}
 
 	if action := p.OnResponse(context.Background(), pctx); action.Type != pipeline.Continue {
@@ -59,7 +62,7 @@ func TestOnResponseReadsResponseHeader(t *testing.T) {
 func TestOnResponseIgnoresRequestHeader(t *testing.T) {
 	p := configure(t, 5.00)
 	pctx := &pipeline.Context{
-		Headers:         http.Header{responseCostHeader: {"0.0025"}}, // wrong place; must be ignored
+		Headers:         http.Header{costing.ResponseCostHeader: {"0.0025"}}, // wrong place; must be ignored
 		ResponseHeaders: http.Header{},
 	}
 
@@ -74,7 +77,7 @@ func TestOnResponseIgnoresRequestHeader(t *testing.T) {
 func TestOnResponseFallsBackToOriginal(t *testing.T) {
 	p := configure(t, 5.00)
 	pctx := &pipeline.Context{
-		ResponseHeaders: http.Header{responseCostOriginalHeader: {"2.204e-05"}},
+		ResponseHeaders: http.Header{costing.ResponseCostOriginalHeader: {"2.204e-05"}},
 	}
 
 	p.OnResponse(context.Background(), pctx)
@@ -89,8 +92,8 @@ func TestOnResponseBareHeaderWins(t *testing.T) {
 	p := configure(t, 5.00)
 	pctx := &pipeline.Context{
 		ResponseHeaders: http.Header{
-			responseCostHeader:         {"0.001"},
-			responseCostOriginalHeader: {"0.002"},
+			costing.ResponseCostHeader:         {"0.001"},
+			costing.ResponseCostOriginalHeader: {"0.002"},
 		},
 	}
 
@@ -108,9 +111,9 @@ func TestOnResponseIgnoresMissingOrInvalid(t *testing.T) {
 		headers http.Header
 	}{
 		{"missing", http.Header{}},
-		{"zero", http.Header{responseCostHeader: {"0"}}},
-		{"negative", http.Header{responseCostHeader: {"-1"}}},
-		{"unparseable", http.Header{responseCostHeader: {"abc"}}},
+		{"zero", http.Header{costing.ResponseCostHeader: {"0"}}},
+		{"negative", http.Header{costing.ResponseCostHeader: {"-1"}}},
+		{"unparseable", http.Header{costing.ResponseCostHeader: {"abc"}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := configure(t, 5.00)
@@ -137,7 +140,7 @@ func TestOnRequestEnforcesBudget(t *testing.T) {
 
 	// Accumulate past the budget via a response.
 	p.OnResponse(context.Background(), &pipeline.Context{
-		ResponseHeaders: http.Header{responseCostHeader: {"0.002"}},
+		ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.002"}},
 	})
 
 	// Over budget: rejected with 429 / budget.exceeded.
@@ -163,12 +166,14 @@ func TestLedgerPersistsAcrossInstances(t *testing.T) {
 	spendFile := filepath.Join(t.TempDir(), "spend.json")
 	raw, _ := json.Marshal(budgetTrackConfig{SpendFile: spendFile, MaxBudget: 5.00})
 
-	p1 := New()
+	// Wrapped, because the plugin no longer prices: something has to settle the cost
+	// before there is anything to persist.
+	p1 := &billing{BudgetTrack: New()}
 	if err := p1.Configure(raw); err != nil {
 		t.Fatalf("Configure() error = %v", err)
 	}
 	p1.OnResponse(context.Background(), &pipeline.Context{
-		ResponseHeaders: http.Header{responseCostHeader: {"0.01"}},
+		ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.01"}},
 	})
 
 	p2 := New()
@@ -249,7 +254,7 @@ func TestConcurrentOnResponse(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			p.OnResponse(context.Background(), &pipeline.Context{
-				ResponseHeaders: http.Header{responseCostHeader: {"0.01"}},
+				ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.01"}},
 			})
 		}()
 	}
@@ -269,7 +274,47 @@ func TestConcurrentOnResponse(t *testing.T) {
 // configurePriced builds a plugin whose rates reach it by injection, as
 // plugins.BuildWithDeps does in production. Rates left at 0 are UNSET, not free:
 // pricing.Cost refuses to price a tier that carried tokens without a rate.
-func configurePriced(t *testing.T, maxBudget float64, perTier map[pricing.Tier]float64) *BudgetTrack {
+// billing is a BudgetTrack plus the rate table the COST OWNER holds in production.
+//
+// The plugin no longer prices anything, so a test that wants a bill has to do what the
+// pipeline does: let the cost owner settle first. settle runs the same authlib/costing
+// entry points inference-parser calls, which keeps these tests about billing — the
+// end-to-end proof that the parser drives them lives in sse_equivalence_test.go and
+// forwardproxy_integration_test.go, both of which run the real parser.
+type billing struct {
+	*BudgetTrack
+	rates pricing.Resolver
+}
+
+// OnResponse and OnResponseFrame settle first, then bill — the order the pipeline produces,
+// since the parser sits later in the chain and the response pass runs in reverse.
+//
+// Overriding them on the wrapper rather than editing every call site keeps these tests
+// reading as they did, which matters: their recorded costs are the equivalence proof that
+// this refactor did not change anybody's bill.
+func (b *billing) OnResponse(ctx context.Context, pctx *pipeline.Context) pipeline.Action {
+	b.settle(pctx)
+	return b.BudgetTrack.OnResponse(ctx, pctx)
+}
+
+func (b *billing) OnResponseFrame(ctx context.Context, pctx *pipeline.Context, frame []byte, last bool) pipeline.Action {
+	if last {
+		b.settle(pctx)
+	}
+	return b.BudgetTrack.OnResponseFrame(ctx, pctx, frame, last)
+}
+
+// settle stands in for the cost owner: price the response, stash the outcome, publish the
+// record.
+func (b *billing) settle(pctx *pipeline.Context) {
+	s := costing.Settle(pctx, b.rates)
+	costing.Store(pctx, s)
+	if s.Priced {
+		costing.Publish(pctx, costing.Record(s, costing.Avoided(pctx, b.rates)))
+	}
+}
+
+func configurePriced(t *testing.T, maxBudget float64, perTier map[pricing.Tier]float64) *billing {
 	t.Helper()
 	p := New()
 	var r pricing.Rates
@@ -284,7 +329,7 @@ func configurePriced(t *testing.T, maxBudget float64, perTier map[pricing.Tier]f
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.SetPricingResolver(pricing.NewRegistry(tab))
+	rates := pricing.NewRegistry(tab)
 	raw, _ := json.Marshal(budgetTrackConfig{
 		SpendFile: filepath.Join(t.TempDir(), "spend.json"),
 		MaxBudget: maxBudget,
@@ -292,7 +337,7 @@ func configurePriced(t *testing.T, maxBudget float64, perTier map[pricing.Tier]f
 	if err := p.Configure(raw); err != nil {
 		t.Fatalf("Configure() error = %v", err)
 	}
-	return p
+	return &billing{BudgetTrack: p, rates: rates}
 }
 
 // pricedInference seeds the per-tier counts inference-parser would have published,
@@ -359,7 +404,7 @@ func TestStreamingWithoutPricesRecordsZero(t *testing.T) {
 // per-token pricing is ignored.
 func TestHeaderCostWinsOverUsage(t *testing.T) {
 	p := configurePriced(t, 5.00, map[pricing.Tier]float64{pricing.TierInput: 1e-6, pricing.TierOutput: 5e-6})
-	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.02"}}}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.02"}}}
 	// single-frame buffered json also carries usage, which must be ignored
 	body := []byte(`data: {"usage":{"prompt_tokens":100,"completion_tokens":40}}`)
 	p.OnResponseFrame(context.Background(), pctx, body, true)
@@ -372,7 +417,7 @@ func TestHeaderCostWinsOverUsage(t *testing.T) {
 // -original present on the terminal frame is still honored.
 func TestOnResponseFrameOriginalFallback(t *testing.T) {
 	p := configurePriced(t, 5.00, map[pricing.Tier]float64{pricing.TierInput: 1e-6, pricing.TierOutput: 5e-6})
-	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostOriginalHeader: {"6.688e-05"}}}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostOriginalHeader: {"6.688e-05"}}}
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
 	if got := p.ledger.TotalSpend; got < 6.687e-05 || got > 6.689e-05 {
 		t.Errorf("TotalSpend = %v, want 6.688e-05", got)
@@ -445,7 +490,7 @@ func TestNonFiniteCostRejected(t *testing.T) {
 		t.Run(hdr, func(t *testing.T) {
 			p := configure(t, 5.00)
 			p.OnResponse(context.Background(), &pipeline.Context{
-				ResponseHeaders: http.Header{responseCostHeader: {hdr}},
+				ResponseHeaders: http.Header{costing.ResponseCostHeader: {hdr}},
 			})
 			if p.ledger.TotalSpend != 0 || p.ledger.TotalCalls != 0 {
 				t.Errorf("%s: ledger mutated: spend=%v calls=%d", hdr, p.ledger.TotalSpend, p.ledger.TotalCalls)
@@ -494,8 +539,8 @@ func TestOnResponseFrameSettlesOnce(t *testing.T) {
 func TestZeroCostHeaderNonStreamedNotRepriced(t *testing.T) {
 	p := configurePriced(t, 5.00, map[pricing.Tier]float64{pricing.TierInput: 1e-6, pricing.TierOutput: 5e-6})
 	pctx := &pipeline.Context{ResponseHeaders: http.Header{
-		responseCostHeader: {"0"},
-		"Content-Type":     {"application/json"},
+		costing.ResponseCostHeader: {"0"},
+		"Content-Type":             {"application/json"},
 	}}
 	p.OnResponseFrame(context.Background(), pctx, []byte(`{"usage":{"input_tokens":100,"output_tokens":40}}`), true)
 	if p.ledger.TotalSpend != 0 || p.ledger.TotalCalls != 0 {
@@ -508,8 +553,8 @@ func TestZeroCostHeaderNonStreamedNotRepriced(t *testing.T) {
 func TestZeroCostHeaderStreamedPricesFromUsage(t *testing.T) {
 	p := configurePriced(t, 5.00, map[pricing.Tier]float64{pricing.TierInput: 1e-6, pricing.TierOutput: 5e-6})
 	pctx := &pipeline.Context{ResponseHeaders: http.Header{
-		responseCostHeader: {"0"},
-		"Content-Type":     {"text/event-stream; charset=utf-8"},
+		costing.ResponseCostHeader: {"0"},
+		"Content-Type":             {"text/event-stream; charset=utf-8"},
 	}}
 	pricedInference(pctx, 100, 0, 0, 40)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -552,7 +597,7 @@ func TestPluginNameMatchesCostEventKey(t *testing.T) {
 // build.
 func TestEmitCostWireFormatIsAdditive(t *testing.T) {
 	p := configure(t, 10)
-	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.25"}}}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.25"}}}
 	p.OnResponse(context.Background(), pctx)
 
 	ev := getCostEvent(t, pctx)
@@ -605,7 +650,7 @@ func TestEmitCost_ProvenanceOmittedWhenAbsent(t *testing.T) {
 // the ledger's post-add state and DailyMaxUSD from config.
 func TestEmitCost_HeaderPath(t *testing.T) {
 	p := configure(t, 5.00)
-	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.0025"}}}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.0025"}}}
 	p.OnResponse(context.Background(), pctx)
 
 	ev := getCostEvent(t, pctx)
@@ -629,7 +674,7 @@ func TestEmitCost_HeaderPath(t *testing.T) {
 	// DailyTotalUSD accumulating while CostUSD stays per-response.
 	// Without this a bug that emitted per-call cost as the daily
 	// total would pass every other assertion here.
-	pctx2 := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.0025"}}}
+	pctx2 := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.0025"}}}
 	p.OnResponse(context.Background(), pctx2)
 	ev2 := getCostEvent(t, pctx2)
 	if ev2 == nil {
@@ -648,8 +693,8 @@ func TestEmitCost_HeaderPath(t *testing.T) {
 func TestEmitCost_UsageFallback(t *testing.T) {
 	p := configurePriced(t, 5.00, map[pricing.Tier]float64{pricing.TierInput: 1e-6, pricing.TierOutput: 5e-6})
 	pctx := &pipeline.Context{ResponseHeaders: http.Header{
-		responseCostHeader: {"0"},
-		"Content-Type":     {"text/event-stream; charset=utf-8"},
+		costing.ResponseCostHeader: {"0"},
+		"Content-Type":             {"text/event-stream; charset=utf-8"},
 	}}
 	pricedInference(pctx, 100, 0, 0, 40)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)
@@ -674,17 +719,26 @@ func TestEmitCost_UsageFallback(t *testing.T) {
 	}
 }
 
-// TestEmitCost_NoEmitWhenUnpriced: an OnResponse call whose header is missing
-// or invalid must NOT emit a cost event (matches the ledger-untouched
-// invariant asserted by TestOnResponseIgnoresMissingOrInvalid).
+// TestEmitCost_NoEmitWhenUnpriced: a response whose header is missing or invalid must NOT
+// emit a cost event (matching the ledger-untouched invariant asserted by
+// TestOnResponseIgnoresMissingOrInvalid).
+//
+// A header of exactly "0" is deliberately NOT in that set. On a non-streamed response it is
+// the gateway saying the call was free — an answer, not an absence — and publishing it as a
+// settled zero is what stops the usage aggregator from re-pricing a free call from its own
+// rate table. See TestSettledZero_OnlyForADeclaredFreeCall.
+//
+// Before cortex #972 this asymmetry existed by accident: OnResponse handled only a positive
+// header, so the settled zero was published on the frame path and silently dropped on the
+// buffered one. The two now share one decision (costing.Settle), so a listener choosing
+// OnResponse no longer reports a different cost from one choosing OnResponseFrame.
 func TestEmitCost_NoEmitWhenUnpriced(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		headers http.Header
 	}{
 		{"missing", http.Header{}},
-		{"zero", http.Header{responseCostHeader: {"0"}}},
-		{"unparseable", http.Header{responseCostHeader: {"abc"}}},
+		{"unparseable", http.Header{costing.ResponseCostHeader: {"abc"}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := configure(t, 5.00)
@@ -697,6 +751,33 @@ func TestEmitCost_NoEmitWhenUnpriced(t *testing.T) {
 	}
 }
 
+// A declared-free call publishes a settled zero on BOTH response paths, and adds nothing to
+// the ledger. The two halves matter for different reasons: the event stops the aggregator
+// inventing a cost, and the untouched ledger keeps a free call out of the budget.
+func TestEmitCost_DeclaredZeroIsPublishedOnEitherPath(t *testing.T) {
+	for _, name := range []string{"OnResponse", "OnResponseFrame"} {
+		t.Run(name, func(t *testing.T) {
+			p := configure(t, 5.00)
+			pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0"}}}
+			if name == "OnResponse" {
+				p.OnResponse(context.Background(), pctx)
+			} else {
+				p.OnResponseFrame(context.Background(), pctx, nil, true)
+			}
+			ev := getCostEvent(t, pctx)
+			if ev == nil {
+				t.Fatal("no event for a gateway-declared free call; the aggregator will re-price it")
+			}
+			if !ev.Settled || ev.CostUSD != 0 {
+				t.Errorf("event = %+v, want a settled zero", *ev)
+			}
+			if p.ledger.TotalSpend != 0 || p.ledger.TotalCalls != 0 {
+				t.Errorf("ledger moved on a free call: spend=%v calls=%d", p.ledger.TotalSpend, p.ledger.TotalCalls)
+			}
+		})
+	}
+}
+
 // TestOnRequestRecordsDenyInvocation: the 429 path must record a deny
 // Invocation with the spend snapshot, or phase:"denied" never surfaces.
 func TestOnRequestRecordsDenyInvocation(t *testing.T) {
@@ -704,7 +785,7 @@ func TestOnRequestRecordsDenyInvocation(t *testing.T) {
 
 	// Push past the budget so the next OnRequest denies.
 	p.OnResponse(context.Background(), &pipeline.Context{
-		ResponseHeaders: http.Header{responseCostHeader: {"0.002"}},
+		ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.002"}},
 	})
 
 	// Stamp Plugin+Phase like Pipeline.Run does — without it Record leaves
@@ -785,7 +866,7 @@ func TestEndToEnd_CostReachesUsageAggregator(t *testing.T) {
 	store.AddRecorder(agg)
 
 	// The plugin prices a response, exactly as OnResponse would in a pipeline.
-	pctx := &pipeline.Context{ResponseHeaders: http.Header{responseCostHeader: {"0.0421"}}}
+	pctx := &pipeline.Context{ResponseHeaders: http.Header{costing.ResponseCostHeader: {"0.0421"}}}
 	p.OnResponse(context.Background(), pctx)
 
 	// The listener's promotion step, verbatim from forwardproxy/server.go.

--- a/authbridge/authlib/plugins/litellm_budgettrack/settled_zero_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/settled_zero_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
@@ -16,7 +17,7 @@ import (
 // list, the inverse of the bug the branch was added to fix.
 func TestSettledZero_OnlyForADeclaredFreeCall(t *testing.T) {
 	// A model the table does not price, so the usage fallback cannot rescue a case.
-	unpriced := func(t *testing.T) *BudgetTrack {
+	unpriced := func(t *testing.T) *billing {
 		t.Helper()
 		p := New()
 		var r pricing.Rates
@@ -27,11 +28,12 @@ func TestSettledZero_OnlyForADeclaredFreeCall(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.SetPricingResolver(pricing.NewRegistry(tab))
 		if err := p.Configure([]byte(`{"spend_file":"` + t.TempDir() + `/s.json","max_budget":100}`)); err != nil {
 			t.Fatal(err)
 		}
-		return p
+		// The rates go to the COST OWNER now, not to this plugin — see the billing
+		// wrapper in plugin_test.go.
+		return &billing{BudgetTrack: p, rates: pricing.NewRegistry(tab)}
 	}
 
 	for _, tc := range []struct {
@@ -71,7 +73,7 @@ func TestSettledZero_OnlyForADeclaredFreeCall(t *testing.T) {
 			p := unpriced(t)
 			h := http.Header{}
 			if tc.header != "" {
-				h.Set(responseCostHeader, tc.header)
+				h.Set(costing.ResponseCostHeader, tc.header)
 			}
 			if tc.streamed {
 				h.Set("Content-Type", "text/event-stream")
@@ -113,8 +115,8 @@ func TestSettledZero_StreamedZeroStillPricesFromUsage(t *testing.T) {
 		pricing.TierInput: 1e-6, pricing.TierOutput: 5e-6,
 	})
 	pctx := &pipeline.Context{ResponseHeaders: http.Header{
-		responseCostHeader: {"0"},
-		"Content-Type":     {"text/event-stream"},
+		costing.ResponseCostHeader: {"0"},
+		"Content-Type":             {"text/event-stream"},
 	}}
 	pricedInference(pctx, 1000, 0, 0, 100)
 	p.OnResponseFrame(context.Background(), pctx, nil, true)

--- a/authbridge/authlib/plugins/litellm_budgettrack/sse_equivalence_test.go
+++ b/authbridge/authlib/plugins/litellm_budgettrack/sse_equivalence_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins/inferenceparser"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
@@ -95,7 +96,7 @@ func sseCases() []sseCase {
 
 // runSSE drives one case through the plugin's frame path and returns the settled
 // cost event, if any.
-func runSSE(t *testing.T, p *BudgetTrack, c sseCase) (costevent.Event, bool) {
+func runSSE(t *testing.T, p *billing, c sseCase) (costevent.Event, bool) {
 	t.Helper()
 	pctx := &pipeline.Context{
 		Path:            "/v1/messages?beta=true",
@@ -105,7 +106,10 @@ func runSSE(t *testing.T, p *BudgetTrack, c sseCase) (costevent.Event, bool) {
 	pctx.ResponseHeaders.Set("Content-Type", "text/event-stream")
 	// No cost header: streamed responses always report 0, which is what makes the
 	// usage path load-bearing rather than a fallback nobody hits.
-	primeInference(t, pctx, c.frames)
+	// The parser carries the rate table now, and settles the cost on the terminal
+	// frame. Running it with the resolver is what makes this an end-to-end proof of
+	// the production path rather than a test of a stub.
+	primeInference(t, pctx, c.frames, p.rates)
 
 	for i, f := range c.frames {
 		last := i == len(c.frames)-1
@@ -152,9 +156,9 @@ func TestSSEEquivalence_HeaderCostStillWins(t *testing.T) {
 	p := newPricedBudgetTrack(t)
 	pctx := &pipeline.Context{Path: "/v1/messages", Host: "gw.internal", ResponseHeaders: http.Header{}}
 	pctx.ResponseHeaders.Set("Content-Type", "application/json")
-	pctx.ResponseHeaders.Set(responseCostHeader, "0.25")
+	pctx.ResponseHeaders.Set(costing.ResponseCostHeader, "0.25")
 	frames := []string{`{"usage":{"input_tokens":1000,"output_tokens":500}}`}
-	primeInference(t, pctx, frames)
+	primeInference(t, pctx, frames, p.rates)
 
 	p.OnResponseFrame(context.Background(), pctx, []byte(frames[0]), true)
 
@@ -190,14 +194,15 @@ func spendFile(t *testing.T) string {
 // after, they are the plugin's only source. Keeping the shim identical across the
 // change is what makes the recorded costs a real invariant rather than two
 // unrelated measurements.
-func primeInference(t *testing.T, pctx *pipeline.Context, frames []string) {
+func primeInference(t *testing.T, pctx *pipeline.Context, frames []string, rates pricing.Resolver) {
 	t.Helper()
 	ip := inferenceparser.NewInferenceParser()
+	ip.SetPricingResolver(rates)
 	// The parser needs a request-side extension to fold into, and Stream must be
 	// true or it treats a single last=true frame as a buffered JSON body.
 	pctx.Extensions.Inference = &pipeline.InferenceExtension{
 		Model:  "claude-opus-5",
-		Stream: isEventStream(pctx),
+		Stream: costing.IsEventStream(pctx),
 	}
 	for i, f := range frames {
 		ip.OnResponseFrame(context.Background(), pctx, []byte(f), i == len(frames)-1)
@@ -210,7 +215,7 @@ func primeInference(t *testing.T, pctx *pipeline.Context, frames []string) {
 // does in production. This shim is the only thing in this file that changed with
 // the migration — the recorded costs above were not touched, which is what makes
 // them an equivalence proof rather than a fresh expectation.
-func newPricedBudgetTrack(t *testing.T) *BudgetTrack {
+func newPricedBudgetTrack(t *testing.T) *billing {
 	t.Helper()
 	p := New()
 	raw, err := json.Marshal(map[string]any{
@@ -235,9 +240,8 @@ func newPricedBudgetTrack(t *testing.T) *BudgetTrack {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.SetPricingResolver(pricing.NewRegistry(tab))
 	if err := p.Configure(raw); err != nil {
 		t.Fatalf("Configure: %v", err)
 	}
-	return p
+	return &billing{BudgetTrack: p, rates: pricing.NewRegistry(tab)}
 }

--- a/authbridge/authlib/plugins/toolprune/event.go
+++ b/authbridge/authlib/plugins/toolprune/event.go
@@ -9,12 +9,14 @@ import (
 // pruneEvent is the per-request record published under "tool-prune/event", so a
 // consumer can show what this one request saved instead of only an aggregate.
 //
-// It deliberately carries the applicable rates rather than a finished dollar
-// figure. The dollar amount depends on which prompt-cache tier the saving came
-// out of, and that is only known from the response — so the request-side event
-// supplies the inputs and the consumer, which can pair request to response by
-// RequestID, does the last step. Carrying the rates also means a consumer needs
-// no knowledge of the built-in default table.
+// It carries FACTS ONLY — what was removed and how big the body was. No rates, no dollars.
+//
+// It used to carry rates so a consumer could do the arithmetic, because the dollar amount
+// depends on which prompt-cache tier the saving came out of and that is only known from the
+// response. The conclusion was right and the remedy was backwards: the money step belongs
+// where both halves are in hand, which is the cost owner on the response side. It publishes
+// the priced saving in costevent.Event.Avoided, attributed to this plugin, so no consumer
+// needs rates and none of them can disagree about the figure.
 //
 // No body content: the session store is unauthenticated, so this holds counts,
 // tool names the operator themselves configured, and rates.
@@ -32,13 +34,6 @@ type pruneEvent struct {
 	// present this as "would have saved", never as money already not spent.
 	Projected bool   `json:"projected,omitempty"`
 	Model     string `json:"model,omitempty"`
-
-	// Rates are USD per token for this request's model, already resolved
-	// through config → flat fallback → built-in defaults.
-	RateInput      float64 `json:"rateInput,omitempty"`
-	RateCacheWrite float64 `json:"rateCacheWrite,omitempty"`
-	RateCacheRead  float64 `json:"rateCacheRead,omitempty"`
-	RateSource     string  `json:"rateSource,omitempty"` // configured | default | none
 }
 
 func (p *ToolPrune) publish(pctx *pipeline.Context, ev pruneEvent) {

--- a/authbridge/authlib/plugins/toolprune/metrics.go
+++ b/authbridge/authlib/plugins/toolprune/metrics.go
@@ -49,6 +49,21 @@ type metrics struct {
 	// token total by any single rate would be wrong by that factor.
 	usdSaved float64
 
+	// usdProjected is what observe mode WOULD have saved. Kept apart from usdSaved
+	// because in observe mode SetBody is a no-op: those bytes went upstream and were
+	// paid for, so adding them to a realized total reports money that was spent as
+	// money that was not. The row is named separately for the same reason.
+	usdProjected float64
+	// savedProjected is the token half of the same distinction. One bucket, not three:
+	// the tier split exists so a real total can be multiplied by the right rate, and a
+	// hypothetical needs no such precision.
+	savedProjected float64
+	// savedUntiered holds tokens whose tier could not be established — a record written
+	// by a build with a tier vocabulary this one does not know. Counted, but kept out of
+	// the three tier buckets rather than defaulted into input, which would misattribute
+	// by up to 12.5x and read as a real input saving.
+	savedUntiered float64
+
 	// Requests whose model had no configured rate. Counted and named rather
 	// than charged at another model's rate, so an incomplete pricing table
 	// shows up as a gap instead of silently under-reporting the total.
@@ -103,19 +118,35 @@ func (m *metrics) recoveredPanic() {
 	m.mu.Unlock()
 }
 
-func (m *metrics) observeSaving(tokens float64, t pricing.Tier, usd float64, prov pricing.Provenance, model string) {
+// observeSaving records one request's saving.
+//
+// tier is nil when it could not be established; projected marks a saving that was measured
+// but never applied. Both are separate arguments rather than inferred here, because the
+// caller reads them off the cost record and this layer must not guess: a fabricated tier and
+// a hypothetical counted as real are the two ways this readout can lie about money.
+func (m *metrics) observeSaving(tokens float64, tier *pricing.Tier, usd float64, prov pricing.Provenance, model string, projected bool) {
 	m.mu.Lock()
-	switch t {
-	case pricing.TierCacheWrite:
+	switch {
+	case projected:
+		// Not attributed to a tier: it was not saved, so there is no billed tier it
+		// came out of.
+		m.savedProjected += tokens
+	case tier == nil:
+		m.savedUntiered += tokens
+	case *tier == pricing.TierCacheWrite:
 		m.savedCacheWrite += tokens
-	case pricing.TierCacheRead:
+	case *tier == pricing.TierCacheRead:
 		m.savedCacheRead += tokens
 	default:
 		m.savedInput += tokens
 	}
 	m.requestsCosted++
 	if prov != pricing.ProvNone {
-		m.usdSaved += usd
+		if projected {
+			m.usdProjected += usd
+		} else {
+			m.usdSaved += usd
+		}
 		if prov == pricing.ProvBundled {
 			m.usedBundledRates = true
 		}
@@ -207,6 +238,20 @@ func (m *metrics) snapshot() []pipeline.Metric {
 			out = append(out, pipeline.Metric{Name: t.name, Value: t.val, Unit: "tokens", Note: note})
 		}
 	}
+	if m.savedProjected > 0 {
+		out = append(out, pipeline.Metric{
+			Name: "tokens would save", Value: m.savedProjected, Unit: "tokens",
+			Note: "observe mode — measured but NOT applied",
+		})
+	}
+	if m.usdSaved == 0 && m.usdProjected > 0 {
+		// A deployment running purely in observe mode has no realized row above to
+		// hang this off, and silence would read as "nothing to save here".
+		out = append(out, pipeline.Metric{
+			Name: "$ would save", Value: m.usdProjected, Unit: "usd",
+			Note: "observe mode — measured but NOT applied; this money was spent",
+		})
+	}
 	if m.requestsCosted == 0 && acted > 0 {
 		out = append(out, pipeline.Metric{
 			Name: "tokens saved", Value: 0, Unit: "tokens",
@@ -242,6 +287,18 @@ func (m *metrics) snapshot() []pipeline.Metric {
 		}
 		grossNote += "gross — excludes cache re-warm after a remove-list change"
 		out = append(out, pipeline.Metric{Name: "$ saved", Value: m.usdSaved, Unit: "usd", Note: grossNote})
+		if m.usdProjected > 0 {
+			out = append(out, pipeline.Metric{
+				Name: "$ would save", Value: m.usdProjected, Unit: "usd",
+				Note: "observe mode — measured but NOT applied; this money was spent",
+			})
+		}
+		if m.savedUntiered > 0 {
+			out = append(out, pipeline.Metric{
+				Name: "tokens saved (tier unknown)", Value: m.savedUntiered, Unit: "tokens",
+				Note: "a cost record named a prompt tier this build does not know",
+			})
+		}
 		if priced := m.requestsCosted - m.unpriced; priced > 0 {
 			out = append(out, pipeline.Metric{
 				Name:  "$ saved / request",

--- a/authbridge/authlib/plugins/toolprune/plugin.go
+++ b/authbridge/authlib/plugins/toolprune/plugin.go
@@ -36,6 +36,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/plugins"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
@@ -78,9 +79,11 @@ type ToolPrune struct {
 	raw    json.RawMessage
 	remove map[string]struct{}
 
-	// rates is the process rate table, injected by plugins.BuildWithDeps before
-	// Configure runs. Read only through resolveRates, which guards it.
-	rates pricing.Resolver
+	// No rate table here any more. This plugin reduces tokens; pricing the reduction is
+	// the cost owner's job, and OnFinish reads the figure back off the published record.
+	// Dropping the resolver also removes the nil-interface trap that once silently
+	// stopped pruning altogether: an un-injected pricing.Resolver panics on call, and
+	// this plugin's fail-open recovery swallowed the panic.
 
 	m         metrics
 	driftOnce sync.Once
@@ -93,28 +96,6 @@ func New() *ToolPrune { return &ToolPrune{} }
 
 func init() {
 	plugins.RegisterPlugin("tool-prune", func() pipeline.Plugin { return New() })
-}
-
-// SetPricingResolver implements pricing.ResolverConsumer.
-func (p *ToolPrune) SetPricingResolver(r pricing.Resolver) { p.rates = r }
-
-// resolveRates is the only read of the rate table.
-//
-// The nil guard is load-bearing and easy to get wrong: the field is an INTERFACE,
-// so a plugin that was never injected holds a nil interface, and calling a method
-// on that panics. A nil *pricing.Registry would have been safe — its methods
-// tolerate a nil receiver — but the interface type is what lets a test substitute
-// a fixed table, so the guard lives here instead.
-//
-// This is not a theoretical hazard: without it, an un-injected plugin panicked on
-// the request path. The plugin's fail-open recovered and forwarded the original
-// body, so pruning silently stopped working rather than crashing — which is the
-// worse failure, because nothing surfaced it.
-func (p *ToolPrune) resolveRates(host, model string, promptTotal int) (pricing.Rates, pricing.Provenance) {
-	if p.rates == nil {
-		return pricing.Rates{}, pricing.ProvNone
-	}
-	return p.rates.Resolve(host, model, promptTotal)
 }
 
 func (p *ToolPrune) Name() string { return "tool-prune" }
@@ -461,17 +442,6 @@ func (p *ToolPrune) OnRequest(_ context.Context, pctx *pipeline.Context) (action
 	// headed for — the same model can bill differently on a discounted gateway
 	// than on the vendor endpoint, and only the target host distinguishes them.
 	//
-	// Resolved at prompt size 0, so these are BASE rates: a long-context threshold
-	// depends on the prompt token count, which the provider only reports on the
-	// response. OnFinish resolves again with the real count, so the metrics and the
-	// `$ saved` total are threshold-correct; only the rates published on this event
-	// are base-tier. A consumer doing its own arithmetic from them under-prices a
-	// request past the threshold, which is why that arithmetic is moving out of the
-	// consumer entirely.
-	rates, prov := p.resolveRates(pctx.Host, inferenceModel(pctx), 0)
-	rateInput, _ := rates.For(pricing.TierInput)
-	rateWrite, _ := rates.For(pricing.TierCacheWrite)
-	rateRead, _ := rates.For(pricing.TierCacheRead)
 	// SetBody BEFORE publishing, so the event can report what was actually sent.
 	// Under ErrorPolicyObserve it is a no-op on bytes and leaves bodyMutated
 	// false — this same code path measures without enforcing.
@@ -489,10 +459,6 @@ func (p *ToolPrune) OnRequest(_ context.Context, pctx *pipeline.Context) (action
 		BodyBytesAfter: bodySent,
 		Projected:      !applied,
 		Model:          inferenceModel(pctx),
-		RateInput:      rateInput,
-		RateCacheWrite: rateWrite,
-		RateCacheRead:  rateRead,
-		RateSource:     prov.String(),
 	})
 	// Carry the saving to OnFinish, where the response reveals which token tier
 	// it came out of. SetState keeps it private to this plugin, unlike
@@ -535,33 +501,62 @@ func (p *ToolPrune) OnFinish(_ context.Context, pctx *pipeline.Context) {
 	if st == nil || st.bytesRemoved <= 0 {
 		return
 	}
-	inf := pctx.Extensions.Inference
-	if inf == nil || len(pctx.Body) == 0 {
-		return
-	}
-	promptTotal := inf.InputTokens + inf.CacheReadTokens + inf.CacheWriteTokens
-	if promptTotal <= 0 {
-		// Fall back to the aggregate when a provider reports only a total.
-		promptTotal = inf.PromptTokens
-	}
-	if promptTotal <= 0 {
-		return
-	}
-	tokens := float64(st.bytesRemoved) * float64(promptTotal) / float64(len(pctx.Body))
-	if tokens <= 0 {
-		return
-	}
-	t := tierOf(inf)
-	// Resolved with the real prompt total, so a long-context threshold applies.
-	rates, prov := p.resolveRates(pctx.Host, inf.Model, promptTotal)
-	rate, ok := rates.For(t)
+	// The saving is priced by the cost owner, not here.
+	//
+	// This function used to do it: estimate tokens from the byte delta, pick the tier,
+	// resolve rates, multiply. That was the third copy of the same arithmetic — abctl had
+	// one and litellm-budget-track had another — and this plugin's job is reducing
+	// tokens, not accounting for money. It now reads the figure attributed to it and
+	// aggregates, so the pane and the ledger cannot disagree about what was saved.
+	//
+	// Nothing to report is the normal case for a request with no inference in it.
+	sv, ok := savingFor(pctx, p.Name())
 	if !ok {
-		// No usable rate for the tier this request actually used. Count it
-		// unpriced rather than charging zero into the total — pricing a carried
-		// tier at zero would hide the gap inside the priced denominator.
-		prov = pricing.ProvNone
+		return
 	}
-	p.m.observeSaving(tokens, t, tokens*rate, prov, inf.Model)
+	tier, ok := pricing.TierFromString(sv.Tier)
+	if !ok {
+		// An unrecognized tier means the record and this build disagree about the
+		// vocabulary. Counting it in a tier bucket would misattribute up to 12.5x, so
+		// the tokens are recorded without one.
+		tier = pricing.TierInput
+	}
+	prov := pricing.ProvNone
+	if sv.Provenance != "" {
+		if pv, ok := pricing.ProvenanceFromString(sv.Provenance); ok {
+			prov = pv
+		}
+	}
+	p.m.observeSaving(float64(sv.TokensAvoided), tier, sv.USD, prov, modelOf(pctx))
+}
+
+// savingFor pulls this plugin's entry out of the published cost record.
+//
+// Reads the record rather than recomputing, and reads it by COMPONENT so a pipeline with
+// several body-shrinking plugins attributes each one's saving to itself.
+func savingFor(pctx *pipeline.Context, component string) (costevent.Saving, bool) {
+	if pctx == nil || len(pctx.Extensions.Custom) == 0 {
+		return costevent.Saving{}, false
+	}
+	ev, ok := pctx.Extensions.Custom[costevent.Key+pipeline.PluginEventSuffix].(costevent.Event)
+	if !ok {
+		return costevent.Saving{}, false
+	}
+	for _, s := range ev.Avoided {
+		if s.Component == component {
+			return s, true
+		}
+	}
+	return costevent.Saving{}, false
+}
+
+// modelOf names the model for the unpriced-model tally, which is what tells an operator
+// WHICH pricing entry to add.
+func modelOf(pctx *pipeline.Context) string {
+	if pctx.Extensions.Inference == nil {
+		return ""
+	}
+	return pctx.Extensions.Inference.Model
 }
 
 // tierOf picks the tier the pruned manifest belonged to, delegating the rule to

--- a/authbridge/authlib/plugins/toolprune/plugin.go
+++ b/authbridge/authlib/plugins/toolprune/plugin.go
@@ -514,12 +514,12 @@ func (p *ToolPrune) OnFinish(_ context.Context, pctx *pipeline.Context) {
 	if !ok {
 		return
 	}
-	tier, ok := pricing.TierFromString(sv.Tier)
-	if !ok {
-		// An unrecognized tier means the record and this build disagree about the
-		// vocabulary. Counting it in a tier bucket would misattribute up to 12.5x, so
-		// the tokens are recorded without one.
-		tier = pricing.TierInput
+	// An unrecognized tier means the record and this build disagree about the vocabulary.
+	// Passed as nil rather than defaulted: naming it input would misattribute the tokens
+	// by up to 12.5x and render as a real input saving.
+	var tier *pricing.Tier
+	if t, ok := pricing.TierFromString(sv.Tier); ok {
+		tier = &t
 	}
 	prov := pricing.ProvNone
 	if sv.Provenance != "" {
@@ -527,7 +527,9 @@ func (p *ToolPrune) OnFinish(_ context.Context, pctx *pipeline.Context) {
 			prov = pv
 		}
 	}
-	p.m.observeSaving(float64(sv.TokensAvoided), tier, sv.USD, prov, modelOf(pctx))
+	// Projected travels with the figure: in observe mode the bytes went upstream and were
+	// billed, so this is money that WAS spent and must not join a realized total.
+	p.m.observeSaving(float64(sv.TokensAvoided), tier, sv.USD, prov, modelOf(pctx), sv.Projected)
 }
 
 // savingFor pulls this plugin's entry out of the published cost record.

--- a/authbridge/authlib/plugins/toolprune/plugin_test.go
+++ b/authbridge/authlib/plugins/toolprune/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
@@ -1060,5 +1061,72 @@ func TestEvent_ObserveModeSavingIsProjected(t *testing.T) {
 	}
 	if !got[0].Projected {
 		t.Error("observe-mode saving is not marked Projected; it would read as money not spent")
+	}
+}
+
+// Observe mode measures without applying: those bytes went upstream and were billed. So the
+// dollars belong in a "would save" row, never in the realized "$ saved" total — the readout
+// is the one place an operator reads this as money.
+func TestMetrics_ObserveModeDollarsAreNotRealized(t *testing.T) {
+	p := withRates(t, configured(t, "NotebookEdit"), anyEndpoint("*", tierRates(1e-05, 1.25e-05, 1e-06)))
+	pctx := inferenceCtx("/v1/messages", anthropicBody, "Read", "NotebookEdit", "Bash")
+	run(t, p.ToolPrune, pctx, pipeline.ErrorPolicyObserve)
+	pctx.Extensions.Inference.Model = "claude-opus-5"
+	pctx.Extensions.Inference.CacheWriteTokens = 24701
+	p.settle(pctx)
+	p.OnFinish(context.Background(), pctx)
+
+	ms := p.Metrics()
+	for _, m := range ms {
+		if m.Name == "$ saved" {
+			t.Errorf("$ saved = %v in observe mode; that money was spent", m.Value)
+		}
+		if m.Name == "tokens saved: cache write" {
+			t.Errorf("projected tokens landed in a realized tier row: %+v", m)
+		}
+	}
+	would := findMetric(t, ms, "$ would save")
+	if would.Value <= 0 {
+		t.Errorf("$ would save = %v, want the hypothetical figure", would.Value)
+	}
+	if !strings.Contains(would.Note, "NOT applied") {
+		t.Errorf("note does not say the saving was not applied: %q", would.Note)
+	}
+	if tw := findMetric(t, ms, "tokens would save"); tw.Value <= 0 {
+		t.Errorf("tokens would save = %v, want the projected tokens", tw.Value)
+	}
+}
+
+// A tier this build does not recognize is counted, but not as input: defaulting would
+// misattribute by up to 12.5x and read as a real input saving.
+func TestMetrics_UnknownTierIsNotInput(t *testing.T) {
+	p := withRates(t, configured(t, "NotebookEdit"), anyEndpoint("*", tierRates(1e-05, 1.25e-05, 1e-06)))
+	pctx := pruneOnce(t, p)
+	pctx.Extensions.Inference.Model = "claude-opus-5"
+	pctx.Extensions.Inference.CacheWriteTokens = 24701
+	p.settle(pctx)
+
+	// Rewrite the published record with a tier name from a future build.
+	ev, ok := pctx.Extensions.Custom[costevent.Key+pipeline.PluginEventSuffix].(costevent.Event)
+	if !ok {
+		t.Fatal("no cost record to rewrite")
+	}
+	if len(ev.Avoided) != 1 {
+		t.Fatalf("expected one saving, got %+v", ev.Avoided)
+	}
+	ev.Avoided[0].Tier = "cache_read_1h"
+	costing.Publish(pctx, ev)
+
+	p.OnFinish(context.Background(), pctx)
+
+	ms := p.Metrics()
+	for _, m := range ms {
+		if m.Name == "tokens saved: input" {
+			t.Errorf("an unknown tier was counted as input: %+v", m)
+		}
+	}
+	unknown := findMetric(t, ms, "tokens saved (tier unknown)")
+	if unknown.Value <= 0 {
+		t.Errorf("tier-unknown row = %v, want the tokens counted", unknown.Value)
 	}
 }

--- a/authbridge/authlib/plugins/toolprune/plugin_test.go
+++ b/authbridge/authlib/plugins/toolprune/plugin_test.go
@@ -690,7 +690,7 @@ func withRates(t *testing.T, p *ToolPrune, entries ...pricing.Entry) *pricedPrun
 func (p *pricedPrune) settle(pctx *pipeline.Context) {
 	s := costing.Settle(pctx, p.rates)
 	costing.Store(pctx, s)
-	costing.Publish(pctx, costing.Record(s, costing.Avoided(pctx, p.rates)))
+	costing.Publish(pctx, costing.NewRecord(s, costing.Avoided(pctx, p.rates)))
 }
 
 // tierRates builds prompt-tier rates from per-token values. Zero means "no rate

--- a/authbridge/authlib/plugins/toolprune/plugin_test.go
+++ b/authbridge/authlib/plugins/toolprune/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costing"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
@@ -296,18 +297,21 @@ func TestPrune_EnforceCountsPruned(t *testing.T) {
 }
 
 // finish drives OnFinish with a given per-tier usage split.
-func finish(t *testing.T, p *ToolPrune, pctx *pipeline.Context, input, cacheRead, cacheWrite int) {
+func finish(t *testing.T, p *pricedPrune, pctx *pipeline.Context, input, cacheRead, cacheWrite int) {
 	t.Helper()
 	pctx.Extensions.Inference.InputTokens = input
 	pctx.Extensions.Inference.CacheReadTokens = cacheRead
 	pctx.Extensions.Inference.CacheWriteTokens = cacheWrite
+	// The cost owner settles once the response is known, then OnFinish aggregates the
+	// figure it published.
+	p.settle(pctx)
 	p.OnFinish(context.Background(), pctx)
 }
 
-func pruneOnce(t *testing.T, p *ToolPrune) *pipeline.Context {
+func pruneOnce(t *testing.T, p *pricedPrune) *pipeline.Context {
 	t.Helper()
 	pctx := inferenceCtx("/v1/messages", anthropicBody, "Read", "NotebookEdit", "Bash")
-	run(t, p, pctx)
+	run(t, p.ToolPrune, pctx)
 	if !pctx.BodyMutated() {
 		t.Fatal("expected a prune")
 	}
@@ -318,7 +322,7 @@ func pruneOnce(t *testing.T, p *ToolPrune) *pipeline.Context {
 // no ratio to convert bytes with, so report zero with the reason rather than a
 // number or a NaN.
 func TestMetrics_NoUsageYetReportsZero(t *testing.T) {
-	p := configured(t, "NotebookEdit")
+	p := withRates(t, configured(t, "NotebookEdit"))
 	pruneOnce(t, p)
 	m := findMetric(t, p.Metrics(), "tokens saved")
 	if m.Value != 0 || m.Note != "no response usage seen yet" {
@@ -343,7 +347,7 @@ func TestMetrics_AttributesSavingToTheRightTier(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := configured(t, "NotebookEdit")
+			p := withRates(t, configured(t, "NotebookEdit"))
 			pctx := pruneOnce(t, p)
 			finish(t, p, pctx, tc.input, tc.cacheRead, tc.cacheWrite)
 
@@ -404,7 +408,8 @@ func TestPricing_BundledRatesPriceKnownModels(t *testing.T) {
 // everything. A model in neither the table nor the config is counted, not
 // charged at some other model's rate.
 func TestPricing_UnknownModelStillUnpriced(t *testing.T) {
-	p := configured(t, "NotebookEdit")
+	// No entries: no rate anywhere, which is exactly this test's subject.
+	p := withRates(t, configured(t, "NotebookEdit"))
 	pruneWithModel(t, p, "gcp/gemini-3-pro-preview")
 
 	gap := findMetric(t, p.Metrics(), "requests unpriced")
@@ -423,7 +428,7 @@ func TestPricing_UnknownModelStillUnpriced(t *testing.T) {
 // published ratios, differ by more than an order of magnitude. A flat rate would
 // be wrong by that factor.
 func TestMetrics_TierRatesDifferBy12x(t *testing.T) {
-	cfg := func(t *testing.T) *ToolPrune {
+	cfg := func(t *testing.T) *pricedPrune {
 		// 1.25x input for a write, 0.1x for a read — Anthropic's published ratios.
 		return withRates(t, configured(t, "NotebookEdit"),
 			anyEndpoint("*", tierRates(1e-05, 1.25e-05, 1e-06)))
@@ -661,14 +666,31 @@ func TestPrune_PathMismatchRecordsThePath(t *testing.T) {
 // withRates injects a rate table into p, standing in for what
 // plugins.BuildWithDeps does in production. Rates reach the plugin by injection
 // now, not through its own config, so every pricing test builds a table.
-func withRates(t *testing.T, p *ToolPrune, entries ...pricing.Entry) *ToolPrune {
+// pricedPrune is the plugin plus the rate table the COST OWNER holds in production.
+//
+// The plugin has no resolver any more: it publishes what it removed and reads the priced
+// figure back off the record. So a test that wants a dollar figure has to do what the
+// pipeline does — let the cost owner settle first.
+type pricedPrune struct {
+	*ToolPrune
+	rates pricing.Resolver
+}
+
+func withRates(t *testing.T, p *ToolPrune, entries ...pricing.Entry) *pricedPrune {
 	t.Helper()
 	tab, err := pricing.NewTable(entries)
 	if err != nil {
 		t.Fatalf("pricing.NewTable: %v", err)
 	}
-	p.SetPricingResolver(pricing.NewRegistry(tab))
-	return p
+	return &pricedPrune{ToolPrune: p, rates: pricing.NewRegistry(tab)}
+}
+
+// settle stands in for inference-parser: price the response and publish the record,
+// including the saving attributed to this plugin.
+func (p *pricedPrune) settle(pctx *pipeline.Context) {
+	s := costing.Settle(pctx, p.rates)
+	costing.Store(pctx, s)
+	costing.Publish(pctx, costing.Record(s, costing.Avoided(pctx, p.rates)))
 }
 
 // tierRates builds prompt-tier rates from per-token values. Zero means "no rate
@@ -704,12 +726,15 @@ func configuredJSON(t *testing.T, raw string) *ToolPrune {
 
 // pruneWithModel runs one prune and finishes it as the named model, with a
 // cache-write split (the cache-miss shape).
-func pruneWithModel(t *testing.T, p *ToolPrune, model string) {
+func pruneWithModel(t *testing.T, p *pricedPrune, model string) {
 	t.Helper()
 	pctx := inferenceCtx("/v1/messages", anthropicBody, "Read", "NotebookEdit", "Bash")
-	run(t, p, pctx)
+	run(t, p.ToolPrune, pctx)
 	pctx.Extensions.Inference.Model = model
 	pctx.Extensions.Inference.CacheWriteTokens = 24701
+	// The cost owner runs between the request and OnFinish, exactly as the pipeline
+	// orders it: the response is what reveals which tier the saving came out of.
+	p.settle(pctx)
 	p.OnFinish(context.Background(), pctx)
 }
 
@@ -980,5 +1005,60 @@ func TestMetrics_RecoveredPanicIsVisible(t *testing.T) {
 	pruneWithModel(t, withRates(t, p, pricing.Bundled()...), "claude-opus-5")
 	if m := findMetric(t, p.Metrics(), "panics recovered"); m.Value != 1 {
 		t.Errorf("panics recovered = %v after traffic, want 1", m.Value)
+	}
+}
+
+// costing reads this plugin's event STRUCTURALLY, by JSON tag, so it can price a saving
+// without importing the plugin. That keeps the dependency pointing the right way — a plugin
+// that shrinks a body should know nothing about pricing — at the cost of a coupling the
+// compiler cannot see.
+//
+// This is that coupling, asserted: rename bytesRemoved, bodyBytesAfter or projected and the
+// saving silently becomes zero, in a figure operators read as money.
+func TestEvent_FieldNamesCostingDependsOn(t *testing.T) {
+	p := withRates(t, configured(t, "NotebookEdit"), anyEndpoint("*", tierRates(1e-05, 1.25e-05, 1e-06)))
+	pctx := pruneOnce(t, p)
+	pctx.Extensions.Inference.Model = "claude-opus-5"
+	pctx.Extensions.Inference.CacheWriteTokens = 24701
+
+	got := costing.Avoided(pctx, p.rates)
+	if len(got) != 1 {
+		t.Fatalf("costing found %d savings, want 1 — the event's field names have drifted: %+v", len(got), got)
+	}
+	s := got[0]
+	if s.Component != "tool-prune" {
+		t.Errorf("component = %q, want tool-prune", s.Component)
+	}
+	if s.TokensAvoided <= 0 {
+		t.Errorf("tokensAvoided = %d; bytesRemoved or bodyBytesAfter did not decode", s.TokensAvoided)
+	}
+	if s.USD <= 0 {
+		t.Errorf("usd = %v, want a priced saving", s.USD)
+	}
+	if !s.Estimated {
+		t.Error("saving is not marked Estimated; it comes from a byte ratio, not a tokenizer")
+	}
+	if s.Projected {
+		t.Error("saving is marked Projected, but this prune was applied")
+	}
+}
+
+// Observe mode measures without applying, and the saving must say so: those bytes went
+// upstream and were paid for.
+func TestEvent_ObserveModeSavingIsProjected(t *testing.T) {
+	// observe is a PIPELINE policy, not plugin config: the plugin measures and skips
+	// SetBody, so the original bytes go upstream and get billed.
+	p := withRates(t, configured(t, "NotebookEdit"), anyEndpoint("*", tierRates(1e-05, 1.25e-05, 1e-06)))
+	pctx := inferenceCtx("/v1/messages", anthropicBody, "Read", "NotebookEdit", "Bash")
+	run(t, p.ToolPrune, pctx, pipeline.ErrorPolicyObserve)
+	pctx.Extensions.Inference.Model = "claude-opus-5"
+	pctx.Extensions.Inference.CacheWriteTokens = 24701
+
+	got := costing.Avoided(pctx, p.rates)
+	if len(got) != 1 {
+		t.Fatalf("no saving reported in observe mode: %+v", got)
+	}
+	if !got[0].Projected {
+		t.Error("observe-mode saving is not marked Projected; it would read as money not spent")
 	}
 }

--- a/authbridge/authlib/pricing/estimate.go
+++ b/authbridge/authlib/pricing/estimate.go
@@ -1,0 +1,59 @@
+package pricing
+
+import "math"
+
+// EstimateTokensFromBytes converts a byte-level body reduction into an estimated prompt
+// token reduction, calibrated on the request it came from.
+//
+// ESTIMATE, and named so. The calibration is this request's own measured ratio —
+// promptTokens over the body size actually sent — which is sound when the removed span
+// had the same token density as what remained, and wrong when it did not. A tool manifest
+// is denser in punctuation than prose, so a prune measured against a prompt of mostly
+// prose overstates its own saving. The output gets quoted in dollars, so that has to be
+// said out loud rather than left for a reader to infer.
+//
+// bodyBytes must be the size of the body ACTUALLY SENT upstream, which is not the pruned
+// size when a plugin measured a saving without applying it: dividing by the smaller
+// counterfactual size would inflate tokens-per-byte and overstate the saving.
+//
+// Returns 0 when any input is non-positive, which covers "nothing was removed", "no
+// response yet" and "no body" without the caller distinguishing them — there is no
+// estimate to make in any of those cases.
+func EstimateTokensFromBytes(bytesRemoved, promptTokens, bodyBytes int) int {
+	if bytesRemoved <= 0 || promptTokens <= 0 || bodyBytes <= 0 {
+		return 0
+	}
+	tokens := float64(bytesRemoved) * float64(promptTokens) / float64(bodyBytes)
+	if tokens < 0.5 {
+		// Rounds to zero. Report it as zero rather than as a token, so a saving too
+		// small to price does not read as one that was priced at nothing.
+		return 0
+	}
+	return int(math.Round(tokens))
+}
+
+// AvoidedUsage places an estimated prompt-token saving into the single tier the request's
+// prompt actually landed in.
+//
+// One tier, not spread across them: the removed bytes were part of one prompt, and that
+// prompt was billed as cache-write, cache-read or fresh input. Which one changes the
+// answer by up to 12.5x, so the choice is the whole substance of the figure and belongs
+// beside PromptTier rather than in a caller.
+//
+// A deliberate simplification: a prompt can straddle tiers — some cached, some fresh —
+// and PromptTier picks the dominant one. Attributing the saving to the dominant tier is
+// the best available answer without knowing WHERE in the prompt the removal happened.
+func AvoidedUsage(u Usage, tokens int) (Usage, Tier) {
+	tier := PromptTier(u)
+	out := Usage{}
+	switch tier {
+	case TierCacheWrite:
+		out.CacheWrite = tokens
+	case TierCacheRead:
+		out.CacheRead = tokens
+	default:
+		tier = TierInput
+		out.Input = tokens
+	}
+	return out, tier
+}

--- a/authbridge/authlib/pricing/estimate_test.go
+++ b/authbridge/authlib/pricing/estimate_test.go
@@ -72,3 +72,21 @@ func TestAvoidedUsage_NeverAttributesOutput(t *testing.T) {
 		t.Error("tier is output; a prompt saving can never come out of the output tier")
 	}
 }
+
+// The spelling must match the config keys, because a tier name in a cost record is meant to
+// be pasted into `pricing:` without translation.
+func TestTierString_MatchesConfigSpelling(t *testing.T) {
+	for tier, want := range map[Tier]string{
+		TierInput:      "input",
+		TierCacheWrite: "cache_write",
+		TierCacheRead:  "cache_read",
+		TierOutput:     "output",
+	} {
+		if got := tier.String(); got != want {
+			t.Errorf("Tier(%d).String() = %q, want %q", int(tier), got, want)
+		}
+	}
+	if got := Tier(99).String(); got != "unknown" {
+		t.Errorf("out-of-range tier = %q, want %q", got, "unknown")
+	}
+}

--- a/authbridge/authlib/pricing/estimate_test.go
+++ b/authbridge/authlib/pricing/estimate_test.go
@@ -1,0 +1,74 @@
+package pricing
+
+import "testing"
+
+func TestEstimateTokensFromBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name                                string
+		bytesRemoved, promptTokens, bodyByt int
+		want                                int
+	}{
+		// 10% of the body removed from a 100k-token prompt.
+		{"proportional", 1000, 100_000, 10_000, 10_000},
+		{"rounds to nearest", 3, 10, 7, 4}, // 3*10/7 = 4.29
+		// Below half a token is reported as none: a saving too small to price must
+		// not read as one priced at nothing.
+		{"sub-token", 1, 1, 1000, 0},
+		{"nothing removed", 0, 100, 100, 0},
+		{"no response yet", 100, 0, 100, 0},
+		{"no body", 100, 100, 0, 0},
+		{"negative bytes", -100, 100, 100, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EstimateTokensFromBytes(tc.bytesRemoved, tc.promptTokens, tc.bodyByt); got != tc.want {
+				t.Errorf("= %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// The tier is the substance of the figure: the same token count differs by 12.5x between
+// cache-read and cache-write, so a saving attributed to the wrong tier is not a rounding
+// error.
+func TestAvoidedUsage_PlacesTheSavingInThePromptsOwnTier(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		prompt Usage
+		want   Tier
+		field  func(Usage) int
+	}{
+		{"fresh input", Usage{Input: 1000}, TierInput, func(u Usage) int { return u.Input }},
+		{"cache write", Usage{CacheWrite: 1000}, TierCacheWrite, func(u Usage) int { return u.CacheWrite }},
+		{"cache read", Usage{CacheRead: 1000}, TierCacheRead, func(u Usage) int { return u.CacheRead }},
+		// No prompt tokens at all: nothing to attribute to, and input is the only
+		// defensible default.
+		{"empty", Usage{}, TierInput, func(u Usage) int { return u.Input }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, tier := AvoidedUsage(tc.prompt, 40)
+			if tier != tc.want {
+				t.Errorf("tier = %v, want %v", tier, tc.want)
+			}
+			if n := tc.field(got); n != 40 {
+				t.Errorf("tokens landed in the wrong tier: %+v", got)
+			}
+			// And ONLY that tier: a saving counted twice would double the figure.
+			if total := got.Input + got.CacheWrite + got.CacheRead + got.Output; total != 40 {
+				t.Errorf("tokens total %d across tiers, want 40 in exactly one: %+v", total, got)
+			}
+		})
+	}
+}
+
+// Output tokens are never a saving: pruning the request cannot shorten the reply, and
+// attributing output cost to it would be false. (The same reasoning as
+// tui/prune_saving.go's publishedRates.)
+func TestAvoidedUsage_NeverAttributesOutput(t *testing.T) {
+	got, tier := AvoidedUsage(Usage{Input: 100, Output: 5000}, 40)
+	if got.Output != 0 {
+		t.Errorf("attributed %d output tokens to a prompt saving", got.Output)
+	}
+	if tier == TierOutput {
+		t.Error("tier is output; a prompt saving can never come out of the output tier")
+	}
+}

--- a/authbridge/authlib/pricing/provenance.go
+++ b/authbridge/authlib/pricing/provenance.go
@@ -62,3 +62,17 @@ func (p Provenance) String() string {
 type Resolver interface {
 	Resolve(endpoint, model string, promptTotal int) (Rates, Provenance)
 }
+
+// ProvenanceFromString is the inverse of String, for a level that has been through JSON.
+//
+// False for anything unrecognized rather than defaulting: provenance decides precedence and
+// drives WarnIfUnpinned, so a silent fallback to a valid-looking level would either suppress
+// a warning an operator needs or outrank a rate they configured.
+func ProvenanceFromString(s string) (Provenance, bool) {
+	for _, p := range []Provenance{ProvNone, ProvBundled, ProvDiscovered, ProvConfigured, ProvAuthoritative} {
+		if p.String() == s {
+			return p, true
+		}
+	}
+	return ProvNone, false
+}

--- a/authbridge/authlib/pricing/rates.go
+++ b/authbridge/authlib/pricing/rates.go
@@ -188,3 +188,39 @@ func PromptTier(u Usage) Tier {
 		return TierInput
 	}
 }
+
+// String names a tier using the spelling operators write in `pricing:` config, so a tier
+// reported in a cost record or an error can be pasted straight into a YAML key without
+// translation.
+func (t Tier) String() string {
+	switch t {
+	case TierInput:
+		return "input"
+	case TierCacheWrite:
+		return "cache_write"
+	case TierCacheRead:
+		return "cache_read"
+	case TierOutput:
+		return "output"
+	}
+	return "unknown"
+}
+
+// TierFromString is the inverse of Tier.String, for a tier that has been through JSON.
+//
+// Reports false for anything unrecognized rather than defaulting to input: a saving
+// attributed to the wrong tier is off by up to 12.5x, and silently picking the cheapest
+// interpretation would understate it.
+func TierFromString(s string) (Tier, bool) {
+	switch s {
+	case "input":
+		return TierInput, true
+	case "cache_write":
+		return TierCacheWrite, true
+	case "cache_read":
+		return TierCacheRead, true
+	case "output":
+		return TierOutput, true
+	}
+	return TierInput, false
+}

--- a/authbridge/authlib/usage/pricing_test.go
+++ b/authbridge/authlib/usage/pricing_test.go
@@ -333,3 +333,58 @@ func TestPricing_ProvenanceReachesTheSnapshot(t *testing.T) {
 		t.Errorf("snapshot JSON carries no pricedBy: %s", b)
 	}
 }
+
+// Avoided cost must never reach spend. This is the invariant that keeps a counterfactual
+// out of a real total, and it is asserted here because usage.go:212 is the only place in the
+// codebase that sums money — one line, guarded once.
+//
+// Two records, identical except that one carries a large avoided figure. Every money field
+// the aggregator reports must be identical across the two.
+func TestAggregator_TotalsAreInvariantToAvoidedCost(t *testing.T) {
+	snapshotWith := func(t *testing.T, avoided []costevent.Saving) Snapshot {
+		t.Helper()
+		a := New(WithPricing(nil))
+		raw, err := json.Marshal(costevent.Event{
+			CostUSD:    0.25,
+			Source:     costevent.SourceGatewayHeader,
+			Provenance: "authoritative",
+			Settled:    true,
+			// A deliberately absurd figure: if it leaks into a total, no rounding
+			// tolerance could hide it.
+			Avoided: avoided,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ev := &pipeline.SessionEvent{
+			Phase:     pipeline.SessionResponse,
+			Host:      "gw.internal",
+			Inference: &pipeline.InferenceExtension{Model: "claude-opus-5", InputTokens: 100, OutputTokens: 10},
+			Plugins:   map[string]json.RawMessage{costevent.Key: raw},
+		}
+		a.Record("session-1", ev)
+		return a.Snapshot(10*BucketWidth, BucketWidth, "", GroupNone)
+	}
+
+	without := snapshotWith(t, nil)
+	with := snapshotWith(t, []costevent.Saving{
+		{Component: "tool-prune", TokensAvoided: 500_000, USD: 999.99, Tier: "cache_write", Estimated: true},
+		{Component: "some-future-plugin", TokensAvoided: 1_000, USD: 42, Tier: "input", Projected: true},
+	})
+
+	if with.Totals.CostMicros != without.Totals.CostMicros {
+		t.Errorf("CostMicros = %d with avoided cost, %d without — a counterfactual entered spend",
+			with.Totals.CostMicros, without.Totals.CostMicros)
+	}
+	if with.Totals.PricedRequests != without.Totals.PricedRequests {
+		t.Errorf("PricedRequests = %d vs %d", with.Totals.PricedRequests, without.Totals.PricedRequests)
+	}
+	if with.Totals.Requests != without.Totals.Requests {
+		t.Errorf("Requests = %d vs %d", with.Totals.Requests, without.Totals.Requests)
+	}
+	// And the figure that IS real still lands: an invariant that holds because nothing
+	// was recorded at all would prove nothing.
+	if with.Totals.CostMicros != 250_000 {
+		t.Errorf("CostMicros = %d, want the record's own 250000", with.Totals.CostMicros)
+	}
+}

--- a/authbridge/cmd/abctl/tui/cost_event.go
+++ b/authbridge/cmd/abctl/tui/cost_event.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
 
 // costEvent is the litellm-budget-track per-response event.
@@ -40,35 +39,22 @@ func decodeCostEvent(e *pipeline.SessionEvent) (costEvent, bool) {
 	return costevent.Decode(e)
 }
 
-// promptCost models what the prompt of one request cost, from the response's
-// per-tier token counts and the rates tool-prune published on the request.
+// promptCost is what the PROMPT of one request cost, read off the cost record.
 //
-// Tier-weighted rather than a flat prompt x single-rate: providers bill a cache
-// read at ~0.1x the uncached input rate and a cache write at ~1.25x, so a
-// cache-heavy turn (the common case for a long-running agent) is overstated by
-// close to an order of magnitude by flat pricing.
+// Not computed here any more. The record carries a prompt-only figure precisely so a
+// request row can show one: the gateway reports a single total for the call and cannot
+// answer "what did the prompt cost", while a flat prompt-times-one-rate figure overstates
+// a cache-heavy turn — the common case for a long-running agent — by close to an order of
+// magnitude, because a cache read bills at ~0.1x input and a write at ~1.25x.
 //
-// The arithmetic is pricing.Cost's, not this file's. This function only supplies
-// inputs; it holds no rates and multiplies nothing.
-//
-// Output is deliberately zeroed. tool-prune publishes no output rate, and Cost
-// refuses to price a tier that carried tokens with no rate — correctly, since a
-// partial total is worse than none. What this figure means is what the PROMPT
-// cost, which is the half tool-prune can speak to.
-//
-// A model with no rates yields ok=false rather than a $0.00 that would read as a
-// free prompt.
-func promptCost(ps pruneSaving, resp *pipeline.InferenceExtension) (usd float64, ok bool) {
-	if resp == nil || ps.RateSource == "none" {
+// False when the proxy could not model it, which is an older proxy or a model with no rate,
+// rather than a $0.00 that would read as a free prompt.
+func promptCost(resp *pipeline.SessionEvent) (usd float64, ok bool) {
+	ev, ok := costevent.Record(resp)
+	if !ok || ev.PromptUSD <= 0 {
 		return 0, false
 	}
-	u := pricing.UsageFromInference(resp)
-	u.Output = 0
-	micros, priced := pricing.Cost(ps.publishedRates(), u)
-	if !priced || micros <= 0 {
-		return 0, false
-	}
-	return float64(micros) / 1e6, true
+	return ev.PromptUSD, true
 }
 
 // promptTokens is the request's own billed token count: what the provider

--- a/authbridge/cmd/abctl/tui/cost_event.go
+++ b/authbridge/cmd/abctl/tui/cost_event.go
@@ -93,10 +93,19 @@ func savingSign(projected bool) string {
 // responsible for, with what was kept off it in parentheses. A bare total when
 // there was no saving.
 //
-// The total is exact-with-commas and the saving compact, matching how each is
-// already rendered today: the total is a measured count worth reading precisely,
-// the saving a derived estimate where trailing digits would be false precision.
-func formatTokensWithSaving(total int, saved float64, projected bool) string {
+// The total is exact-with-commas and an ESTIMATED saving compact: the total is a measured
+// count worth reading precisely, an estimate a figure where trailing digits would be false
+// precision. That is the estimate marker — precision itself — and it is why a counted saving
+// renders exact instead.
+//
+// No third glyph for estimated. "~" already means projected, and every saving published today
+// is estimated (costing derives them from a byte ratio), so a marker on 100% of rows would
+// distinguish nothing while adding noise to every one. The moment a component reports a
+// saving counted by a tokenizer, it renders differently here without a legend to learn.
+//
+// The record itself carries the flag verbatim, so an operator pressing enter sees
+// "estimated": true regardless of how the cell reads.
+func formatTokensWithSaving(total int, saved float64, projected, estimated bool) string {
 	if total <= 0 {
 		return ""
 	}
@@ -104,7 +113,11 @@ func formatTokensWithSaving(total int, saved float64, projected bool) string {
 	if saved <= 0 {
 		return cell
 	}
-	return cell + "(" + savingSign(projected) + formatCompact(saved) + ")"
+	figure := formatCompact(saved)
+	if !estimated {
+		figure = formatCount(int(saved))
+	}
+	return cell + "(" + savingSign(projected) + figure + ")"
 }
 
 // formatUSDWithSaving is formatTokensWithSaving for money: "$0.2546(−$0.0037)".

--- a/authbridge/cmd/abctl/tui/cost_event_test.go
+++ b/authbridge/cmd/abctl/tui/cost_event_test.go
@@ -370,3 +370,28 @@ func TestMethodColumnDistinguishesDatedModelIDs(t *testing.T) {
 		t.Errorf("eventMethod = %d cols, want <= %d", n, methodColWidth)
 	}
 }
+
+// Precision IS the estimate marker: an estimated saving renders compact because trailing
+// digits would be false precision, and a counted one renders exact. No extra glyph — "~"
+// already means projected, and every saving published today is estimated, so a marker on
+// every row would distinguish nothing.
+func TestFormatTokensWithSaving_PrecisionMarksTheEstimate(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		projected, estimated bool
+		want                 string
+	}{
+		{"estimated and applied", false, true, "681,300(−9.9k)"},
+		{"estimated and projected", true, true, "681,300(~9.9k)"},
+		// A saving counted by a tokenizer, which nothing publishes yet: exact digits,
+		// because they would be real.
+		{"counted and applied", false, false, "681,300(−9,899)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatTokensWithSaving(681_300, 9_899, tc.projected, tc.estimated)
+			if got != tc.want {
+				t.Errorf("= %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/authbridge/cmd/abctl/tui/cost_event_test.go
+++ b/authbridge/cmd/abctl/tui/cost_event_test.go
@@ -5,13 +5,21 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
-// costWire is the exact JSON litellm-budget-track publishes under
-// "litellm-budget-track".
+// costWire is the exact JSON the proxy publishes as a cost record.
+//
+// It carries what this UI now READS rather than computes: the exchange total, the
+// prompt-only figure a request row shows, and the saving attributed to tool-prune. The
+// figures are the ones abctl used to derive itself — prompt 1,300 x 3.8e-6 + 680,000 x
+// 3.8e-7 = 0.26334, saving 9,899 tokens at the cache-read rate = 0.0038 — so the rendered
+// cells below are unchanged by the move. That is the point: same output, one owner.
 const costWire = `{"cost_usd":0.2824,"source":"gateway-header",
-  "daily_total_usd":1.4207,"daily_max_usd":5}`
+  "daily_total_usd":1.4207,"daily_max_usd":5,"prompt_usd":0.26334,
+  "avoided":[{"component":"tool-prune","tokensAvoided":9899,"usd":0.0038,
+  "tier":"cache_read","estimated":true}]}`
 
 // bigPromptWire is a tool-prune event sized for the cache-heavy agent turn this
 // split exists for: a ~2.4MB body (≈3.5 bytes/token against a 681k-token prompt)
@@ -161,24 +169,32 @@ func TestCostCellPhases(t *testing.T) {
 // rate overstates a cache-heavy turn by close to an order of magnitude, which is
 // the common shape for a long-running agent. The weighted figure must be well
 // below the flat one.
-func TestPromptCostIsTierWeighted(t *testing.T) {
-	ps := pruneSaving{RateInput: 3.8e-6, RateCacheRead: 3.8e-7, RateCacheWrite: 4.75e-6, RateSource: "default"}
+// The tier weighting now happens in the proxy (authlib/costing computes the prompt-only
+// figure; authlib/pricing weights the tiers), and is tested there against the real rate
+// table. What abctl must still get right is reading the published figure and declining to
+// invent one — a $0.00 in this column reads as a free prompt.
+func TestPromptCost_ReadsThePublishedFigure(t *testing.T) {
 	inf := &pipeline.InferenceExtension{InputTokens: 1_000, CacheReadTokens: 99_000}
-	got, ok := promptCost(ps, inf)
+	// A tier-weighted figure, well below the 0.38 a flat input rate would produce for
+	// the same 100k prompt: that gap is why the proxy weights it rather than the UI.
+	e := recordEvent(t, costevent.Event{CostUSD: 0.05, Settled: true, PromptUSD: 0.0414})
+	e.Inference = inf
+	got, ok := promptCost(e)
 	if !ok {
 		t.Fatal("no cost figure")
 	}
-	flat := float64(promptTokens(inf)) * ps.RateInput
-	if got >= flat {
-		t.Errorf("weighted %v should be below flat %v", got, flat)
+	if got != 0.0414 {
+		t.Errorf("promptCost = %v, want the published 0.0414", got)
 	}
-	want := 1_000*3.8e-6 + 99_000*3.8e-7
-	if got < want-1e-12 || got > want+1e-12 {
-		t.Errorf("promptCost = %v, want %v", got, want)
+	if flat := float64(promptTokens(inf)) * 3.8e-6; got >= flat {
+		t.Errorf("published figure %v is not below the flat %v; the weighting was lost", got, flat)
 	}
-	// nil usage yields no figure rather than a zero that reads as free.
-	if _, ok := promptCost(ps, nil); ok {
-		t.Error("nil usage produced a cost figure")
+	// No record, and a record with no prompt figure, both decline rather than showing 0.
+	if _, ok := promptCost(respEvent("", inf)); ok {
+		t.Error("a response with no record produced a cost figure")
+	}
+	if _, ok := promptCost(recordEvent(t, costevent.Event{CostUSD: 0.05, Settled: true})); ok {
+		t.Error("a record with no prompt figure produced one")
 	}
 }
 

--- a/authbridge/cmd/abctl/tui/detail_pane.go
+++ b/authbridge/cmd/abctl/tui/detail_pane.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
@@ -135,6 +136,21 @@ func filterForDetail(data []byte, phase pipeline.SessionPhase) []byte {
 	}
 	if a2a, ok := m["a2a"].(map[string]any); ok {
 		m["a2a"] = filterFields(a2a, a2aKeep)
+	}
+	// ONE cost record, not two.
+	//
+	// The proxy publishes the record under the current key AND the legacy plugin-name
+	// key, so an abctl older than the rename keeps showing cost at all. This abctl reads
+	// the current one, so rendering both would show an operator the same object twice
+	// under two names and give them no way to tell which is authoritative.
+	//
+	// Dropped from the VIEW only. yankEventToFile marshals the event itself, so the
+	// yanked file still holds exactly what went over the wire — the same split this
+	// function already makes for identity, one line down.
+	if pl, ok := m["plugins"].(map[string]any); ok {
+		if _, current := pl[costevent.Key]; current {
+			delete(pl, costevent.PluginName)
+		}
 	}
 	// Identity is summarized at the session level (events pane banner).
 	// Drop it from per-event detail rows to reduce repetition — the full

--- a/authbridge/cmd/abctl/tui/detail_pane_test.go
+++ b/authbridge/cmd/abctl/tui/detail_pane_test.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
@@ -99,5 +101,49 @@ func TestTunnelHeader_NoInvocations(t *testing.T) {
 	}
 	if strings.Count(got, "\n") != 0 {
 		t.Errorf("tunnelHeader with no invocations should be one line\ngot:\n%s", got)
+	}
+}
+
+// The proxy writes the cost record under both the current and the legacy key, so an abctl
+// older than the rename keeps showing cost. This abctl reads the current one, so the detail
+// view must show ONE record — two identical objects under two names give an operator no way
+// to tell which is authoritative.
+func TestFilterForDetail_ShowsOneCostRecord(t *testing.T) {
+	record := `{"cost_usd":0.25,"settled":true}`
+	wire := []byte(`{"phase":"response","plugins":{` +
+		`"` + costevent.Key + `":` + record + `,` +
+		`"` + costevent.PluginName + `":` + record + `,` +
+		`"tool-prune":{"bytesRemoved":900}}}`)
+
+	var got map[string]any
+	if err := json.Unmarshal(filterForDetail(wire, pipeline.SessionResponse), &got); err != nil {
+		t.Fatal(err)
+	}
+	pl, ok := got["plugins"].(map[string]any)
+	if !ok {
+		t.Fatalf("no plugins block survived: %v", got)
+	}
+	if _, ok := pl[costevent.Key]; !ok {
+		t.Errorf("the current cost key was dropped: %v", pl)
+	}
+	if _, ok := pl[costevent.PluginName]; ok {
+		t.Errorf("the legacy duplicate is still rendered: %v", pl)
+	}
+	// Unrelated plugin events are untouched — this filters a duplicate, not a category.
+	if _, ok := pl["tool-prune"]; !ok {
+		t.Errorf("an unrelated plugin event was dropped: %v", pl)
+	}
+}
+
+// A proxy older than the rename writes ONLY the legacy key, and its cost must still render.
+func TestFilterForDetail_KeepsALoneLegacyRecord(t *testing.T) {
+	wire := []byte(`{"phase":"response","plugins":{"` + costevent.PluginName + `":{"cost_usd":0.25}}}`)
+	var got map[string]any
+	if err := json.Unmarshal(filterForDetail(wire, pipeline.SessionResponse), &got); err != nil {
+		t.Fatal(err)
+	}
+	pl, _ := got["plugins"].(map[string]any)
+	if _, ok := pl[costevent.PluginName]; !ok {
+		t.Errorf("a lone legacy record was dropped, so an older proxy shows no cost: %v", pl)
 	}
 }

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -899,9 +899,8 @@ func (m *model) tokensCell(rows []eventRow, partner map[int]int, i int, ev *pipe
 		}
 		var saved float64
 		var projected bool
-		if ps, ok := decodePruneSaving(ev); ok {
-			saved, _, _ = savedTokensAndCost(ps, resp.Inference)
-			projected = ps.Projected
+		if s, ok := pruneSavingFor(resp); ok {
+			saved, projected = float64(s.TokensAvoided), s.Projected
 		}
 		return formatTokensWithSaving(promptTokens(resp.Inference), saved, projected)
 	default:
@@ -948,16 +947,16 @@ func (m *model) costCell(rows []eventRow, partner map[int]int, i int, ev *pipeli
 		if resp == nil {
 			return ""
 		}
-		ps, ok := decodePruneSaving(ev)
+		total, ok := promptCost(resp)
 		if !ok {
 			return ""
 		}
-		total, ok := promptCost(ps, resp.Inference)
-		if !ok {
-			return ""
+		var savedUSD float64
+		var projected bool
+		if s, ok := pruneSavingFor(resp); ok {
+			savedUSD, projected = s.USD, s.Projected
 		}
-		_, savedUSD, _ := savedTokensAndCost(ps, resp.Inference)
-		return formatUSDWithSaving(total, savedUSD, ps.Projected)
+		return formatUSDWithSaving(total, savedUSD, projected)
 	default:
 		return ""
 	}

--- a/authbridge/cmd/abctl/tui/events_pane.go
+++ b/authbridge/cmd/abctl/tui/events_pane.go
@@ -898,11 +898,11 @@ func (m *model) tokensCell(rows []eventRow, partner map[int]int, i int, ev *pipe
 			return ""
 		}
 		var saved float64
-		var projected bool
+		var projected, estimated bool
 		if s, ok := pruneSavingFor(resp); ok {
-			saved, projected = float64(s.TokensAvoided), s.Projected
+			saved, projected, estimated = float64(s.TokensAvoided), s.Projected, s.Estimated
 		}
-		return formatTokensWithSaving(promptTokens(resp.Inference), saved, projected)
+		return formatTokensWithSaving(promptTokens(resp.Inference), saved, projected, estimated)
 	default:
 		return ""
 	}

--- a/authbridge/cmd/abctl/tui/local_preview_test.go
+++ b/authbridge/cmd/abctl/tui/local_preview_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 	"github.com/rossoctl/cortex/authbridge/authlib/session"
 	"github.com/rossoctl/cortex/authbridge/authlib/sessionapi"
@@ -56,9 +57,14 @@ func seedAgentTurns(store *session.Store, sid string, n int) {
 				OutputTokens: output, TotalTokens: 1_300 + cacheRead + output,
 			},
 			Plugins: map[string]json.RawMessage{
-				"litellm-budget-track": json.RawMessage(fmt.Sprintf(
-					`{"cost_usd":%.4f,"source":"gateway-header","daily_total_usd":%.4f,"daily_max_usd":5}`,
-					cost, cost*float64(i+1))),
+				// The cost record, as the proxy publishes it on the RESPONSE: the
+				// prompt-only figure and the saving now travel here rather than
+				// being derived in the UI from rates on the request event.
+				costevent.Key: json.RawMessage(fmt.Sprintf(
+					`{"cost_usd":%.4f,"source":"gateway-header","daily_total_usd":%.4f,"daily_max_usd":5,`+
+						`"prompt_usd":%.5f,"avoided":[{"component":"tool-prune","tokensAvoided":9899,`+
+						`"usd":0.0038,"tier":"cache_read","estimated":true}]}`,
+					cost, cost*float64(i+1), 1_300*3.8e-6+float64(cacheRead)*3.8e-7)),
 			},
 			Invocations: &pipeline.Invocations{Outbound: []pipeline.Invocation{
 				{Plugin: "inference-parser", Action: pipeline.ActionObserve, Reason: "parsed"},

--- a/authbridge/cmd/abctl/tui/prune_saving.go
+++ b/authbridge/cmd/abctl/tui/prune_saving.go
@@ -1,123 +1,46 @@
 package tui
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
-	"github.com/rossoctl/cortex/authbridge/authlib/pricing"
 )
 
-// pruneSaving is the tool-prune per-request event as published on the request
-// event under "tool-prune". Mirrors the plugin's shape; a decode test guards the
-// tags.
-type pruneSaving struct {
-	BytesRemoved   int     `json:"bytesRemoved"`
-	BodyBytesAfter int     `json:"bodyBytesAfter"`
-	RateInput      float64 `json:"rateInput"`
-	RateCacheWrite float64 `json:"rateCacheWrite"`
-	RateCacheRead  float64 `json:"rateCacheRead"`
-	RateSource     string  `json:"rateSource"`
-	// Projected marks observe mode: the saving was measured but the bytes were
-	// not actually removed, so it must not render as money already not spent.
-	Projected bool `json:"projected"`
-}
-
-// decodePruneSaving pulls the tool-prune event off a request event, if present.
-func decodePruneSaving(e *pipeline.SessionEvent) (pruneSaving, bool) {
-	if e == nil || len(e.Plugins) == 0 {
-		return pruneSaving{}, false
-	}
-	raw, ok := e.Plugins["tool-prune"]
-	if !ok {
-		return pruneSaving{}, false
-	}
-	var ps pruneSaving
-	if err := json.Unmarshal(raw, &ps); err != nil || ps.BytesRemoved <= 0 || ps.BodyBytesAfter <= 0 {
-		return pruneSaving{}, false
-	}
-	return ps, true
-}
-
-// publishedRates rebuilds a pricing.Rates from the rates tool-prune put on its
-// event, so the arithmetic below can go through pricing.Cost rather than being a
-// second implementation of it.
+// This file used to turn tool-prune's byte saving into tokens and dollars.
 //
-// No output rate: tool-prune deliberately publishes none, because pruning only
-// ever shrinks the prompt and attributing output cost to it would be false.
-func (ps pruneSaving) publishedRates() pricing.Rates {
-	var r pricing.Rates
-	for tier, v := range map[pricing.Tier]float64{
-		pricing.TierInput:      ps.RateInput,
-		pricing.TierCacheWrite: ps.RateCacheWrite,
-		pricing.TierCacheRead:  ps.RateCacheRead,
-	} {
-		if v > 0 {
-			r.Base[tier], r.Set[tier] = v, true
+// It no longer does any of that arithmetic. The proxy prices the saving where both halves
+// are in hand — the byte delta from the request, the tier and the token ratio from the
+// response — and publishes the result in the cost record. Doing it here meant abctl held a
+// rate table's worth of assumptions, applied them to base-tier rates that were wrong past a
+// long-context threshold, and could disagree with the server after a hot reload swapped the
+// table between the event and the render.
+//
+// What is left is reading a figure and formatting it.
+
+// savingFor returns the saving the proxy attributed to a component, off the response event
+// that carries the cost record.
+//
+// The response event, not the request one: the saving is only priceable once the response
+// reveals which prompt tier it came out of, so that is where the priced figure lands. A
+// request row reaches it through the same pairing it already does to show token totals.
+func savingFor(resp *pipeline.SessionEvent, component string) (costevent.Saving, bool) {
+	ev, ok := costevent.Record(resp)
+	if !ok {
+		return costevent.Saving{}, false
+	}
+	for _, s := range ev.Avoided {
+		if s.Component == component {
+			return s, true
 		}
 	}
-	return r
+	return costevent.Saving{}, false
 }
 
-// provenance names where this row's rates came from, for display. Empty when the
-// producer published none, which is an older proxy rather than an error.
-func (ps pruneSaving) provenance() string {
-	if ps.RateSource == "" || ps.RateSource == "none" {
-		return ""
-	}
-	return ps.RateSource
-}
-
-// savedTokensAndCost converts a request's byte saving into tokens and dollars,
-// using the response's own usage.
-//
-// The two halves live on different events by necessity: the byte saving is known
-// when the request is rewritten, and the tier it came out of — and the ratio to
-// convert bytes to tokens — only from the response. So this is the last step of an
-// arithmetic the plugin starts.
-//
-// The dollars themselves are computed by pricing.Cost, not here. This function
-// supplies inputs and picks the tier via pricing.PromptTier; it holds no rate
-// table and no multiplication of its own. Before the consolidation this file
-// multiplied rates by tokens itself, which made it one of five places that turned
-// tokens into dollars and the only one nothing else tested.
-func savedTokensAndCost(ps pruneSaving, resp *pipeline.InferenceExtension) (tokens, usd float64, ok bool) {
-	if resp == nil {
-		return 0, 0, false
-	}
-	u := pricing.UsageFromInference(resp)
-	prompt := u.PromptTotal()
-	if prompt <= 0 {
-		return 0, 0, false
-	}
-	// The plugin calibrates on the request it just sent: prompt tokens over the
-	// post-prune body size, both measured on the same request so the two sides
-	// agree.
-	tokens = float64(ps.BytesRemoved) * float64(prompt) / float64(ps.BodyBytesAfter)
-	if tokens <= 0 {
-		return 0, 0, false
-	}
-
-	// The whole saving is attributed to the one tier it came out of, so the Usage
-	// handed to Cost carries a count in that tier alone.
-	saved := pricing.Usage{}
-	switch pricing.PromptTier(u) {
-	case pricing.TierCacheWrite:
-		saved.CacheWrite = int(math.Round(tokens))
-	case pricing.TierCacheRead:
-		saved.CacheRead = int(math.Round(tokens))
-	default:
-		saved.Input = int(math.Round(tokens))
-	}
-	micros, priced := pricing.Cost(ps.publishedRates(), saved)
-	if !priced {
-		// The tier this request used has no rate. Report the token saving, which is
-		// still known, and decline the dollars rather than showing a zero that
-		// would read as "this saved nothing".
-		return tokens, 0, true
-	}
-	return tokens, float64(micros) / 1e6, true
+// pruneSavingFor is the tool-prune saving specifically, which is the only one rendered today.
+func pruneSavingFor(resp *pipeline.SessionEvent) (costevent.Saving, bool) {
+	return savingFor(resp, "tool-prune")
 }
 
 // formatCompact renders a token count tersely enough for a table cell: 10577
@@ -129,12 +52,10 @@ func formatCompact(v float64) string {
 	case v >= 1_000:
 		return fmt.Sprintf("%.1fk", v/1_000)
 	default:
-		return fmt.Sprintf("%.0f", v)
+		return fmt.Sprintf("%.0f", math.Round(v))
 	}
 }
 
-// formatUSD keeps small amounts legible: a per-request saving is often fractions
-// of a cent, where %.2f would round every row to "0.00".
 func formatUSD(v float64) string {
 	switch {
 	case v >= 1:

--- a/authbridge/cmd/abctl/tui/prune_saving_test.go
+++ b/authbridge/cmd/abctl/tui/prune_saving_test.go
@@ -2,250 +2,145 @@ package tui
 
 import (
 	"encoding/json"
-	"strings"
 	"testing"
 
+	"github.com/rossoctl/cortex/authbridge/authlib/costevent"
 	"github.com/rossoctl/cortex/authbridge/authlib/pipeline"
 )
 
-// wire is the exact JSON the plugin publishes under "tool-prune".
-const wire = `{"toolsRemoved":["NotebookEdit","WebSearch"],"bytesRemoved":28568,
-  "bodyBytesAfter":90635,"model":"claude-opus-5","rateInput":3.8e-06,
-  "rateCacheWrite":4.75e-06,"rateCacheRead":3.8e-07,"rateSource":"default"}`
+// These tests used to cover abctl's own byte-to-token-to-dollar arithmetic. That arithmetic
+// moved to the proxy (authlib/costing, authlib/pricing), where it is tested against the real
+// parser, and abctl's remaining job is reading a figure off the record. So these now cover
+// the reading — including the cases where there is nothing to read, which must render as
+// "not reported" rather than as zero.
 
+// recordEvent builds a response event carrying a cost record, as the proxy publishes it.
+func recordEvent(t *testing.T, ev costevent.Event) *pipeline.SessionEvent {
+	t.Helper()
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &pipeline.SessionEvent{
+		Phase:   pipeline.SessionResponse,
+		Plugins: map[string]json.RawMessage{costevent.Key: raw},
+	}
+}
+
+func TestSavingFor_ReadsTheAttributedComponent(t *testing.T) {
+	e := recordEvent(t, costevent.Event{
+		CostUSD: 0.04,
+		Settled: true,
+		Avoided: []costevent.Saving{
+			{Component: "some-other-plugin", TokensAvoided: 1, USD: 0.99},
+			{Component: "tool-prune", TokensAvoided: 10_577, USD: 0.0041, Tier: "cache_write", Estimated: true},
+		},
+	})
+
+	got, ok := pruneSavingFor(e)
+	if !ok {
+		t.Fatal("tool-prune's saving not found")
+	}
+	// By component, not by position: a pipeline can have several body-shrinking plugins,
+	// and attributing one's saving to another is worse than reporting none.
+	if got.TokensAvoided != 10_577 || got.USD != 0.0041 {
+		t.Errorf("saving = %+v, want tool-prune's own figures", got)
+	}
+	if got.Tier != "cache_write" {
+		t.Errorf("tier = %q; it is what makes the figure checkable, since tiers differ by 12.5x", got.Tier)
+	}
+	if _, ok := savingFor(e, "not-in-this-record"); ok {
+		t.Error("found a saving for a component that did not report one")
+	}
+}
+
+// Absent is not zero. A saving that cannot be read must leave the cell empty, because a
+// rendered 0 reads as "this saved nothing" — a claim nobody made.
+func TestSavingFor_AbsentIsNotZero(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		e    *pipeline.SessionEvent
+	}{
+		{"nil event", nil},
+		{"no plugins", &pipeline.SessionEvent{Phase: pipeline.SessionResponse}},
+		{"a record with no savings", recordEvent(t, costevent.Event{CostUSD: 0.04, Settled: true})},
+		{"only the prune facts, no record", &pipeline.SessionEvent{
+			Plugins: map[string]json.RawMessage{"tool-prune": json.RawMessage(`{"bytesRemoved":900}`)},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := pruneSavingFor(tc.e); ok {
+				t.Error("reported a saving where none was published")
+			}
+		})
+	}
+}
+
+// A record present but unpriced still yields its saving. That is the whole point of
+// costevent.Record answering presence separately from pricedness: a request the table cannot
+// price is exactly the one whose token saving is most worth showing.
+func TestSavingFor_SurvivesAnUnpricedRecord(t *testing.T) {
+	e := recordEvent(t, costevent.Event{
+		Avoided: []costevent.Saving{{Component: "tool-prune", TokensAvoided: 500, Tier: "input", Estimated: true}},
+	})
+	got, ok := pruneSavingFor(e)
+	if !ok {
+		t.Fatal("saving lost on an unpriced record")
+	}
+	if got.TokensAvoided != 500 {
+		t.Errorf("tokens = %d, want 500", got.TokensAvoided)
+	}
+	if got.USD != 0 {
+		t.Errorf("USD = %v, want 0 — no rate covered it", got.USD)
+	}
+	// And the cost column must stay empty rather than show $0.00.
+	if _, ok := promptCost(e); ok {
+		t.Error("promptCost reported a figure for an unpriced record")
+	}
+}
+
+// The legacy key still decodes, because a proxy older than the rename writes only that one.
+func TestSavingFor_ReadsTheLegacyKey(t *testing.T) {
+	raw, err := json.Marshal(costevent.Event{
+		PromptUSD: 0.0395,
+		Avoided:   []costevent.Saving{{Component: "tool-prune", TokensAvoided: 10, USD: 0.001}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := &pipeline.SessionEvent{
+		Phase:   pipeline.SessionResponse,
+		Plugins: map[string]json.RawMessage{costevent.PluginName: raw},
+	}
+	if _, ok := pruneSavingFor(e); !ok {
+		t.Error("saving not read from the legacy key")
+	}
+	if usd, ok := promptCost(e); !ok || usd != 0.0395 {
+		t.Errorf("promptCost from the legacy key = %v (ok=%v), want 0.0395", usd, ok)
+	}
+}
+
+func TestFormatCompact(t *testing.T) {
+	for in, want := range map[float64]string{
+		0:         "0",
+		999:       "999",
+		10_577:    "10.6k",
+		2_500_000: "2.5M",
+	} {
+		if got := formatCompact(in); got != want {
+			t.Errorf("formatCompact(%v) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// reqEvent builds a request event carrying tool-prune's facts.
+//
+// Still useful even though the pane no longer reads them for money: the facts are what the
+// plugin publishes, and a request row is where they live.
 func reqEvent(t *testing.T, raw string) *pipeline.SessionEvent {
 	t.Helper()
 	return &pipeline.SessionEvent{
 		Phase:   pipeline.SessionRequest,
 		Plugins: map[string]json.RawMessage{"tool-prune": json.RawMessage(raw)},
-	}
-}
-
-// TestDecodePruneSaving guards the tags against drift with the plugin's struct.
-// A silent decode failure would show a plain token total and look like the plugin
-// having saved nothing.
-func TestDecodePruneSaving(t *testing.T) {
-	ps, ok := decodePruneSaving(reqEvent(t, wire))
-	if !ok {
-		t.Fatal("failed to decode the published event")
-	}
-	if ps.BytesRemoved != 28568 || ps.BodyBytesAfter != 90635 {
-		t.Errorf("byte fields = %d/%d", ps.BytesRemoved, ps.BodyBytesAfter)
-	}
-	if ps.RateCacheWrite != 4.75e-06 || ps.RateCacheRead != 3.8e-07 {
-		t.Errorf("rates did not decode: %+v", ps)
-	}
-	if ps.RateSource != "default" {
-		t.Errorf("RateSource = %q", ps.RateSource)
-	}
-	// Absent, malformed, and zero-valued all decline rather than render zeros.
-	for _, bad := range []*pipeline.SessionEvent{
-		nil,
-		{Phase: pipeline.SessionRequest},
-		reqEvent(t, `{"bytesRemoved":0,"bodyBytesAfter":100}`),
-		reqEvent(t, `{"bytesRemoved":5,"bodyBytesAfter":0}`),
-		reqEvent(t, `not json`),
-	} {
-		if _, ok := decodePruneSaving(bad); ok {
-			t.Errorf("should not decode: %+v", bad)
-		}
-	}
-}
-
-// TestSavedTokensAndCost_TierDecidesTheValue is the point of doing this per
-// request. The same saved bytes are worth over 12x more on a cache miss than on
-// a cache hit, because providers charge ~1.25x input for a write and ~0.1x for a
-// read. An aggregate that averages the two describes neither turn.
-func TestSavedTokensAndCost_TierDecidesTheValue(t *testing.T) {
-	ps, _ := decodePruneSaving(reqEvent(t, wire))
-
-	miss := &pipeline.InferenceExtension{InputTokens: 8881, CacheWriteTokens: 24701}
-	hit := &pipeline.InferenceExtension{InputTokens: 26, CacheReadTokens: 24701, CacheWriteTokens: 8907}
-
-	tMiss, usdMiss, ok := savedTokensAndCost(ps, miss)
-	if !ok || tMiss <= 0 || usdMiss <= 0 {
-		t.Fatalf("miss: tokens=%v usd=%v ok=%v", tMiss, usdMiss, ok)
-	}
-	_, usdHit, ok := savedTokensAndCost(ps, hit)
-	if !ok || usdHit <= 0 {
-		t.Fatalf("hit: usd=%v ok=%v", usdHit, ok)
-	}
-	if r := usdMiss / usdHit; r < 11 || r > 14 {
-		t.Errorf("miss/hit cost ratio = %.2f, want ~12.5 — the tier must pick the rate", r)
-	}
-
-	// A provider that reports only an aggregate still works.
-	agg := &pipeline.InferenceExtension{PromptTokens: 33582}
-	if _, _, ok := savedTokensAndCost(ps, agg); !ok {
-		t.Error("should fall back to PromptTokens when the split is absent")
-	}
-	// No usage at all declines rather than dividing by zero.
-	if _, _, ok := savedTokensAndCost(ps, &pipeline.InferenceExtension{}); ok {
-		t.Error("no usage should not produce a figure")
-	}
-	if _, _, ok := savedTokensAndCost(ps, nil); ok {
-		t.Error("nil usage should not produce a figure")
-	}
-}
-
-// TestFormatTokensWithSaving: a request row carries its prompt total with the
-// saving in parentheses. The total is exact-with-commas (a measured count) and
-// the saving compact (a derived estimate), so the two are not read as equally
-// precise.
-func TestFormatTokensWithSaving(t *testing.T) {
-	got := formatTokensWithSaving(681300, 10577.5, false)
-	for _, want := range []string{"681,300", "(−10.6k)"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("cell %q missing %q", got, want)
-		}
-	}
-	// Nothing saved: a bare total, no empty parentheses.
-	if got := formatTokensWithSaving(681300, 0, false); got != "681,300" {
-		t.Errorf("no-saving cell = %q, want %q", got, "681,300")
-	}
-	// No total: blank, so rows without a paired response stay empty rather than
-	// rendering a lone "0".
-	if got := formatTokensWithSaving(0, 10577.5, false); got != "" {
-		t.Errorf("no-total cell = %q, want empty", got)
-	}
-}
-
-// TestFormatUSDWithSaving: both halves at fixed 4dp. formatUSD's variable
-// precision would render the total at 3dp and the saving at 4dp, misaligning the
-// decimal point in a single column and implying different accuracy.
-func TestFormatUSDWithSaving(t *testing.T) {
-	got := formatUSDWithSaving(0.2546, 0.0037, false)
-	if got != "$0.2546(−$0.0037)" {
-		t.Errorf("cell = %q, want %q", got, "$0.2546(−$0.0037)")
-	}
-	if got := formatUSDWithSaving(0.2546, 0, false); got != "$0.2546" {
-		t.Errorf("no-saving cell = %q, want %q", got, "$0.2546")
-	}
-	if got := formatUSDWithSaving(0, 0.0037, false); got != "" {
-		t.Errorf("no-total cell = %q, want empty", got)
-	}
-}
-
-// TestSavingSignProjected: an observe-mode figure must be visually distinct from
-// a realized one, or an operator adds up money that was still spent.
-func TestSavingSignProjected(t *testing.T) {
-	real := formatTokensWithSaving(681300, 10577.5, false)
-	proj := formatTokensWithSaving(681300, 10577.5, true)
-	if real == proj {
-		t.Fatalf("projected renders identically to realized: %q", real)
-	}
-	if !strings.Contains(proj, "(~") {
-		t.Errorf("projected cell %q should mark the saving with ~", proj)
-	}
-	if strings.Contains(proj, "−") {
-		t.Errorf("projected = %q, must not claim bytes were removed", proj)
-	}
-	realUSD := formatUSDWithSaving(0.2546, 0.0037, false)
-	projUSD := formatUSDWithSaving(0.2546, 0.0037, true)
-	if realUSD == projUSD {
-		t.Fatalf("projected cost renders identically to realized: %q", realUSD)
-	}
-	if strings.Contains(projUSD, "−") {
-		t.Errorf("projected cost = %q, must not claim money was not spent", projUSD)
-	}
-}
-
-// TestUnpricedModelShowsNoCost: RateSource "none" means no rate was resolvable,
-// so the COST cell must stay blank rather than invent a $0.00 that reads as a
-// free prompt. The tokens cell is unaffected — the count is still real.
-func TestUnpricedModelShowsNoCost(t *testing.T) {
-	resp := &pipeline.InferenceExtension{InputTokens: 100, CacheReadTokens: 500}
-	if _, ok := promptCost(pruneSaving{RateSource: "none", RateInput: 1e-6}, resp); ok {
-		t.Error("an unpriced model produced a cost figure")
-	}
-	// A resolved rate does price.
-	if _, ok := promptCost(pruneSaving{RateSource: "default", RateInput: 1e-6, RateCacheRead: 1e-7}, resp); !ok {
-		t.Error("a priced model produced no cost figure")
-	}
-}
-
-func TestFormatCompactAndUSD(t *testing.T) {
-	for in, want := range map[float64]string{0: "0", 950: "950", 10577.5: "10.6k", 2_400_000: "2.4M"} {
-		if got := formatCompact(in); got != want {
-			t.Errorf("formatCompact(%v) = %q, want %q", in, got, want)
-		}
-	}
-	// Sub-cent savings must not all round to 0.00.
-	for in, want := range map[float64]string{1.5: "1.50", 0.05: "0.050", 0.0004: "0.0004"} {
-		if got := formatUSD(in); got != want {
-			t.Errorf("formatUSD(%v) = %q, want %q", in, got, want)
-		}
-	}
-}
-
-// TestComputeEventPairs_DuplicateResponseStaysUnpaired: a second response sharing
-// a RequestID — a retry, or a streamed reply recorded twice — finds the request
-// already paired. Falling through to the adjacency heuristic would have it walk
-// back and claim an unrelated earlier request, reintroducing exactly the
-// mis-attribution the id was added to end.
-func TestComputeEventPairs_DuplicateResponseStaysUnpaired(t *testing.T) {
-	ev := func(phase pipeline.SessionPhase, id string, code int) *pipeline.SessionEvent {
-		return &pipeline.SessionEvent{
-			Direction: pipeline.Outbound, Phase: phase,
-			Host: "h", RequestID: id, StatusCode: code,
-		}
-	}
-	rows := []eventRow{
-		{event: ev(pipeline.SessionRequest, "aaa", 0)},    // 0
-		{event: ev(pipeline.SessionRequest, "bbb", 0)},    // 1
-		{event: ev(pipeline.SessionResponse, "bbb", 200)}, // 2 pairs with 1
-		{event: ev(pipeline.SessionResponse, "bbb", 500)}, // 3 duplicate for bbb
-	}
-	_, partner := computeEventPairs(rows)
-
-	if partner[1] != 2 {
-		t.Errorf("bbb should pair 1↔2, got %v", partner)
-	}
-	if j, ok := partner[3]; ok {
-		t.Errorf("duplicate response paired with row %d; it must stay unpaired", j)
-	}
-	if j, ok := partner[0]; ok {
-		t.Errorf("request aaa was claimed by the duplicate (row %d) — the bug this guards", j)
-	}
-}
-
-// TestRequestCells_RequireAnIDMatch: pricing against a heuristically matched
-// response could take its cache tier from a different request, and the tiers are
-// ~12.5x apart — a wrong figure presented as a measurement. Both request-side
-// cells must enforce it, since both read the paired response.
-func TestRequestCells_RequireAnIDMatch(t *testing.T) {
-	req := reqEvent(t, wire)
-	req.RequestID = "aaa"
-	resp := &pipeline.SessionEvent{
-		Phase: pipeline.SessionResponse, RequestID: "zzz", // different exchange
-		Inference: &pipeline.InferenceExtension{CacheWriteTokens: 24701, TotalTokens: 33582},
-	}
-	rows := []eventRow{{event: req}, {event: resp}}
-	partner := map[int]int{0: 1, 1: 0}
-	m := &model{}
-	if got := m.tokensCell(rows, partner, 0, req); got != "" {
-		t.Errorf("tokens priced against a mismatched response: %q", got)
-	}
-	if got := m.costCell(rows, partner, 0, req); got != "" {
-		t.Errorf("cost priced against a mismatched response: %q", got)
-	}
-	// Matching ids do price.
-	resp.RequestID = "aaa"
-	if got := m.tokensCell(rows, partner, 0, req); got == "" {
-		t.Error("an id-matched pair should show tokens")
-	}
-	if got := m.costCell(rows, partner, 0, req); got == "" {
-		t.Error("an id-matched pair should show a cost")
-	}
-}
-
-// TestPruneSavingProjectedDecodes guards the wire tag.
-func TestPruneSavingProjectedDecodes(t *testing.T) {
-	ps, ok := decodePruneSaving(reqEvent(t, `{"bytesRemoved":100,"bodyBytesAfter":1000,"projected":true}`))
-	if !ok {
-		t.Fatal("decode failed")
-	}
-	if !ps.Projected {
-		t.Error("projected did not decode")
 	}
 }

--- a/authbridge/docs/litellm-budgettrack-plugin.md
+++ b/authbridge/docs/litellm-budgettrack-plugin.md
@@ -42,6 +42,13 @@ The plugin hooks:
 
 ### Cost source (what the terminal frame charges)
 
+**Since cortex #972 this plugin does not settle the cost itself.** `inference-parser` does,
+via `authlib/costing`, because it is the component that knows when token usage is final; this
+plugin bills the published figure, adds the day's total, enforces the cap, and reports drift.
+The two sources below are still the rule — they just live in one place now, shared with every
+other consumer of a cost, instead of being implemented here and again in the usage
+aggregator.
+
 The cost is settled **once**, on the terminal frame, from one of two sources:
 
 - **Response header** — `x-litellm-response-cost`, falling back to the pre-discount

--- a/authbridge/docs/plugin-catalog.md
+++ b/authbridge/docs/plugin-catalog.md
@@ -110,9 +110,25 @@ model to point it at, see
 ## `inference-parser`
 
 Parses outbound OpenAI-compatible LLM inference requests/responses into
-`pctx.Extensions.Inference` for downstream policy plugins.
+`pctx.Extensions.Inference` for downstream policy plugins, **and prices the finished
+response** — it is the one place tokens become dollars.
 
-No configuration — no config struct, does not implement `Configurable`.
+Costing lives here because this is the only component that knows when usage is *final*: it
+owns the three response-finalization paths and the assembled-usage handling (Claude Code's
+`?beta=true` path reports cache counts on `message_delta`, not `message_start`). It also
+means cost can never be missing while token counts are present — previously the figure came
+from `litellm-budget-track`, so a pipeline without that plugin showed tokens and no money,
+with the same field silently meaning "modelled" rather than "authoritative" depending on
+configuration.
+
+The arithmetic and the gateway header semantics are in `authlib/costing`, not in the parser:
+a provider-shaped body parser has no business knowing one gateway's header names. The result
+is published as a cost record keyed `cost` on the session event (see
+[Cost records](#cost-records)).
+
+No configuration — no config struct, does not implement `Configurable`. Rates arrive by
+injection from the top-level [`pricing:`](#pricing) section; with none configured the parser
+still parses and reports the traffic as unpriced.
 
 ## `jwt-validation`
 
@@ -159,8 +175,8 @@ denial by a plugin ordered before it emits no spans.
 
 ## `litellm-budget-track`
 
-Tracks the `x-litellm-response-cost` response header and enforces a
-daily spend budget. Full details in
+Keeps the daily spend ledger and enforces a spend budget, from the cost record
+`inference-parser` publishes. Full details in
 [litellm-budgettrack-plugin.md](./litellm-budgettrack-plugin.md).
 
 **Provider-specific:** `x-litellm-response-cost` is emitted only by
@@ -171,7 +187,7 @@ cost is ever accumulated and the budget never trips.
 
 - `spend_file` (string) — path to the JSON spend ledger file; required. The ledger is a small JSON file the plugin creates and rewrites, holding the current UTC date plus the cumulative spend and call count for that day (it resets automatically at midnight UTC) — see [Ledger Format](./litellm-budgettrack-plugin.md#ledger-format).
 - `max_budget` (float64) — daily budget in USD; required, must be > 0.
-- **No rate options.** Rates live in the top-level [`pricing:`](#pricing) section, resolved by `authlib/pricing`, so cost is consistent wherever it is reported. This plugin prices the per-tier token counts `inference-parser` publishes.
+- **No rate options, and no pricing at all.** This plugin bills a figure it does not compute: `inference-parser` settles the cost and publishes the record, and this plugin adds the day's total, enforces the cap, and warns when the rate table disagrees with what the gateway charged. Rates live in the top-level [`pricing:`](#pricing) section.
 - **Requires `inference-parser` LATER in the chain** (`RequiresLater`). The response passes walk the chain in reverse, so the parser must sit at a higher index to fold each frame before this plugin settles the cost. A chain without it — or with it earlier — fails to build.
 
 ## `mcp-parser`
@@ -326,7 +342,9 @@ body-reading plugin (it rewrites the request body). Declares
 
 - `remove` (`[]string`) — tool names to delete from the manifest. The complete verdict: no learning, no state, no storage. Names absent from a given request are ignored. **An empty list is the off switch** — the plugin is inert until a name is added, which is how it ships in the local install.
 - `paths` (`[]string`) — request paths to act on, matched exactly or by suffix. Defaults to `/v1/chat/completions`, `/v1/completions`, `/v1/messages`.
-- **No rate options.** The 12 rate knobs and the built-in family table are gone; rates come from the top-level [`pricing:`](#pricing) section. A figure derived from the bundled table is labelled `bundled`, and a model with no rate anywhere is counted in a `requests unpriced` row rather than charged at another model's rate. There is still no output rate: pruning only shrinks the prompt.
+- **No rates and no pricing.** This plugin reduces tokens; pricing the reduction belongs to whoever owns cost. It publishes what it removed — tool names, byte delta, and whether the prune was applied or only measured — and reads the priced figure back off the cost record to fill its `$ saved` metric. A figure derived from the bundled table is still labelled `bundled`, and a model with no rate anywhere is still counted in a `requests unpriced` row rather than charged at another model's rate. There is still no output rate: pruning only shrinks the prompt.
+
+  The saving has to be priced on the response side, not here: the dollar amount depends on which prompt-cache tier the removed tokens came out of — 1x, 1.25x or 0.1x of the same rate — and only the response reveals that. It is inherently a request-fact times a response-fact.
 
 Generate the list from local transcripts with `abctl tools scan`, which
 proposes only tools it recognises as Claude Code built-ins and never proposes
@@ -338,6 +356,34 @@ called" would then mean every tool it knows. See
 [`tool-prune-plugin.md`](./tool-prune-plugin.md) for the measure-then-enforce
 rollout, the metrics readout, and what the saving does and does not change.
 
+
+## Cost records
+
+Every priced request publishes one record on its response session event, under the key
+`cost`. One producer, one record, one number.
+
+The key names the **concern, not the producer**. It used to be the producing plugin's name
+(`litellm-budget-track`), which made moving costing to the component that actually knows the
+token counts a breaking wire change — for live consumers and for every event already in a
+session store. The framework set that precedent itself: `pipeline/context.go` publishes
+`body-mutation` from the core, "because a switch of plugin names in a future refactor
+shouldn't break operators' dashboards". The legacy key is still written and still read, and
+comes out a release after the rename ships.
+
+| field | meaning |
+|---|---|
+| `cost_usd` | what the request cost. `source` says whether the gateway reported it (`gateway-header`) or it was modelled from token counts (`usage-fallback`); `provenance` says how much to trust the rates behind a modelled figure |
+| `settled` | a figure exists — **including a deliberate zero**, which is the gateway saying the call was free. Without it, "free" and "nobody priced this" were indistinguishable, and a cache hit got re-priced from the rate table |
+| `prompt_usd` | the modelled cost of the prompt alone, tier-weighted. A breakdown, **not** a component of a sum: it is the table's figure even when `cost_usd` is the gateway's |
+| `avoided[]` | cost that was **not** incurred, attributed per component, with `tokensAvoided`, `usd`, the `tier` it came out of, and two honesty flags: `estimated` (derived from a byte ratio, not a tokenizer) and `projected` (measured but never applied — that money *was* spent) |
+| `daily_total_usd`, `daily_max_usd` | added by `litellm-budget-track` when it is in the pipeline; the budget's business, not the cost owner's |
+
+**Nothing in `avoided` is spend.** No consumer may add it to a cost, a budget or a usage
+total; a test in `authlib/usage` asserts the aggregator's totals are unchanged by its
+presence. It is a container rather than a few flat fields because more counterfactuals are
+coming — compaction, redaction, "what a cheaper model would have cost" — and as siblings of
+`cost_usd` the record would become half-real and half-hypothetical, which is how someone
+eventually sums two fields that must never be summed.
 
 ## `pricing:`
 

--- a/authbridge/docs/plugin-catalog.md
+++ b/authbridge/docs/plugin-catalog.md
@@ -115,11 +115,16 @@ response** — it is the one place tokens become dollars.
 
 Costing lives here because this is the only component that knows when usage is *final*: it
 owns the three response-finalization paths and the assembled-usage handling (Claude Code's
-`?beta=true` path reports cache counts on `message_delta`, not `message_start`). It also
-means cost can never be missing while token counts are present — previously the figure came
-from `litellm-budget-track`, so a pipeline without that plugin showed tokens and no money,
-with the same field silently meaning "modelled" rather than "authoritative" depending on
+`?beta=true` path reports cache counts on `message_delta`, not `message_start`). It also means a
+priced request can no longer be missing its record: previously the figure came from
+`litellm-budget-track`, so a pipeline without that plugin showed tokens and no money, with
+the same field silently meaning "modelled" rather than "authoritative" depending on
 configuration.
+
+A record is not the same as a price. Where no rate resolves for the model, the record is
+still published — carrying the token counts, any avoided cost, and no dollar figure — and the
+gap is named in `/v1/usage`'s `unpricedBy` so an operator knows which `pricing:` entry to
+add. An absent figure is reported as absent, never as `$0.00`.
 
 The arithmetic and the gateway header semantics are in `authlib/costing`, not in the parser:
 a provider-shaped body parser has no business knowing one gateway's header names. The result


### PR DESCRIPTION
## Summary

Implements #972. Cost was computed in **four** places, and *which* place answered depended on
which plugins an operator enabled — which is how a live `abctl` view showed rows with token
counts and no money, while the same requests carried dollars in `/v1/usage`.

Three layers, one job each:

| layer | job | where |
|---|---|---|
| parsers | wire → facts: tokens, model, the gateway's reported cost | `inference-parser` |
| costing | facts + rates → one settled figure, once | `authlib/costing` (new) |
| consumers | act on it | budget enforces, usage records, abctl displays |

### Why `inference-parser` owns costing

Not taste — three things the code settled:

- **It is the only component that knows when usage is FINAL.** It owns the three
  response-finalization paths and the assembled-usage handling for Claude Code's
  `?beta=true` shape (cache counts arrive on `message_delta`, not `message_start`). Costing
  anywhere else duplicates that assembly or races it.
- **Cost can no longer be missing while tokens are present.** No parser means no tokens, so
  nothing to price and nothing to explain. Previously the figure came from
  `litellm-budget-track`, so a pipeline without it silently turned every cost into a modelled
  one — the same field changing meaning by configuration.
- **Consumers already declare the dependency.** `plugins/registry.go:342-360` documents
  `RequiresLater` as a **hard AND with ordering**: the pipeline refuses to build without the
  parser, and the response pass runs in reverse, so the parser settles before any consumer
  looks.

The gateway header semantics and the arithmetic live in `authlib/costing`, not in the parser —
a provider-shaped body parser has no business knowing one gateway's header names.

Key changes:

- **`litellm-budget-track` keeps the ledger, the cap and the drift warning, and stops
  computing money.** It is no longer a pricing consumer at all. Drift now reads *both* figures
  off the settled outcome instead of recomputing the modelled half: a check that re-derives
  its own input is comparing its own arithmetic.
- **`tool-prune` stops carrying rates and loses its resolver.** Its own comment had the
  diagnosis right — the dollar amount depends on which prompt-cache tier the saving came out
  of, and only the response reveals that — and the wrong remedy. The money step belongs where
  both halves are in hand. Dropping the resolver also removes the nil-interface trap that once
  silently stopped pruning: a nil `pricing.Resolver` panics on call and the plugin's fail-open
  swallowed it.
- **`abctl` stops doing arithmetic.** It held a rate table's worth of assumptions, applied them
  to base-tier rates that were wrong past a long-context threshold, and could disagree with the
  server after a hot reload swapped the table between the event and the render.
- **`pricing.EstimateTokensFromBytes` / `AvoidedUsage`** carry the bytes→tokens calibration and
  the tier choice, named `Estimate` because that is what it is — the ratio is per-request, so it
  is wrong when the removed span had a different token density from what remained, and that
  caveat now sits on the function whose output gets quoted in dollars.

### Wire shape

- **`costevent.Key = "cost"` names the concern, not the producer** — which is what let the
  producer move at all. The framework set that precedent itself: `pipeline/context.go`
  publishes `body-mutation` from the core "because a switch of plugin names in a future
  refactor shouldn't break operators' dashboards". Both keys are written and read; the legacy
  write comes out a release later, because `abctl` is a separate binary that can lag the proxy.
- **`Record()` / `Priced()` split presence from pricedness.** `Decode` conflated them, so a
  record with no usable figure was indistinguishable from no record — and a saving on a request
  the table cannot price is exactly the one worth showing.
- **`prompt_usd`** carries the prompt-only modelled figure a request row needs; a breakdown,
  never a component of a sum.
- **`avoided[]`** holds counterfactual cost per component, with `estimated` and `projected`
  flags. Nothing in it is spend.

## One behaviour change beyond the move

A gateway-declared zero now publishes a settled zero on the buffered `OnResponse` path too.
Previously only the frame path did, so a listener's choice of hook changed the reported cost.
Both paths are now asserted.

## Testing

- **The SSE equivalence tests keep their recorded costs** and now drive the *real* parser with
  a real rate table — which is what makes them a proof that nobody's bill changed.
- **`abctl`'s cell tests keep their exact expected strings** (`681,300(−9.9k)`,
  `$0.2633(−$0.0038)`) and now read those figures off the record: same rendered output, one
  owner.
- **`authlib/usage` asserts totals are invariant to `avoided`** — two identical records, one
  carrying $999.99 of avoided cost, must produce identical `CostMicros` and `PricedRequests`.
  That guards the single line in the codebase that sums money.
- **`authlib/costing`** covers the precedence rule directly: header wins, `-original` is the
  charged cost, a stream's zero falls back, a declared zero suppresses the fallback, an
  unusable header falls back, a nil resolver is unpriced not a panic.
- **`tool-prune` asserts the field names `costing` reads structurally** — rename
  `bytesRemoved` and the saving silently becomes zero in a figure operators read as money.
- `plugins/deps_test.go` now asserts the inverse of what it did: the parser IS a pricing
  consumer and the budget plugin is not.

`go vet` clean across every module. `golangci-lint --new-from-rev=upstream/main`: 0 issues.
pre-commit passes. The one `cmd/abctl` failure
(`TestRunExec_BeforeFirstStartRunsAndSaysWhatIsLost`) reproduces on a clean worktree of
`upstream/main` — it leaks the developer's real `SSL_CERT_FILE` bundle into the child.

## Related issue(s)

Refs #972

---

Assisted-By: Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cost records now include prompt-only costs and estimated savings from avoided processing.
  - Cost calculations consistently prioritize finalized gateway figures, with pricing fallback when needed.
  - Savings are displayed in the TUI with token, dollar, tier, and projected-status details.
  - Declared zero-cost requests are recognized and reported correctly.

- **Bug Fixes**
  - Avoided savings no longer inflate spending, budget totals, or usage counts.
  - Cost records remain readable from both current and legacy event formats.

- **Documentation**
  - Updated cost, pricing, savings, and plugin behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->