### PR TITLE
build: :technologist: Add make targets for abctl and authbridge-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ cortex-ca/
 # `go build ./...` inside authbridge/scripts/profile-tags drops its 3 MB binary beside
 # the source, where it is easy to stage by accident — it was, once.
 /authbridge/scripts/profile-tags/profile-tags
+
+# Output dir for `make abctl` / `make authbridge-proxy`.
+/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # Root Makefile for cortex monorepo
 # Orchestrates linting and formatting across all sub-projects
 
-.PHONY: lint fmt pre-commit build-proxy-init pricing-table help
+.PHONY: lint fmt pre-commit build-proxy-init pricing-table abctl authbridge-proxy help
+
+BIN_DIR := $(CURDIR)/bin
 
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -39,3 +41,23 @@ endif
 	cd authbridge/authlib && $(if $(filter 1,$(NO_PROXY_FOR_GEN)),HTTPS_PROXY= HTTP_PROXY= ALL_PROXY=,) \
 		go run ./pricing/internal/gen -commit $(COMMIT) -dir ./pricing
 	cd authbridge/authlib && go test ./pricing/ -run TestBundled
+
+##@ Binary Targets
+
+# authbridge-proxy's plugin set is resolved from a named profile via
+# authbridge/scripts/profile-tags — the same helper CI uses — so the tag
+# list stays in sync without hand-maintenance. abctl links no plugins.
+
+abctl: ## Build abctl to ./bin/abctl
+	@mkdir -p $(BIN_DIR)
+	cd authbridge/cmd/abctl && go build -o $(BIN_DIR)/abctl .
+
+authbridge-proxy: ## Build authbridge-proxy to ./bin/authbridge-proxy (PROFILE=full|lite|local, default full)
+	@mkdir -p $(BIN_DIR)
+	@# Resolve the profile's tag list at build time so the plugin set stays
+	@# in sync with authbridge/scripts/profile-tags without hand-maintenance.
+	@# An unknown profile exits non-zero — the $$(...) captures that and
+	@# the target fails.
+	TAGS=$$(go -C authbridge/scripts/profile-tags run . $(or $(PROFILE),full)) && \
+		cd authbridge/cmd/authbridge-proxy && \
+		go build -tags "$$TAGS" -o $(BIN_DIR)/authbridge-proxy .

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,17 @@ endif
 
 abctl: ## Build abctl to ./bin/abctl
 	@mkdir -p $(BIN_DIR)
-	cd authbridge/cmd/abctl && go build -o $(BIN_DIR)/abctl .
+	cd authbridge/cmd/abctl && GOWORK=off go build -o $(BIN_DIR)/abctl .
 
 authbridge-proxy: ## Build authbridge-proxy to ./bin/authbridge-proxy (PROFILE=full|lite|local, default full)
 	@mkdir -p $(BIN_DIR)
-	@# Resolve the profile's tag list at build time so the plugin set stays
-	@# in sync with authbridge/scripts/profile-tags without hand-maintenance.
-	@# An unknown profile exits non-zero — the $$(...) captures that and
-	@# the target fails.
+	@# Restrict PROFILE to the plugin sets this binary ships.
+	@if [ -n "$(PROFILE)" ] && [ -z "$(filter full lite local,$(PROFILE))" ]; then \
+		echo "PROFILE=$(PROFILE) is not one of: full lite local" >&2; \
+		exit 1; \
+	fi
+	@# GOWORK=off matches CI and the Dockerfile — workspace mode can select a
+	@# higher third-party version than this binary's own go.mod requires.
 	TAGS=$$(go -C authbridge/scripts/profile-tags run . $(or $(PROFILE),full)) && \
 		cd authbridge/cmd/authbridge-proxy && \
-		go build -tags "$$TAGS" -o $(BIN_DIR)/authbridge-proxy .
+		GOWORK=off go build -tags "$$TAGS" -o $(BIN_DIR)/authbridge-proxy .

--- a/authbridge/README.md
+++ b/authbridge/README.md
@@ -29,8 +29,11 @@ abctl --version
 - **macOS** binaries are portable but unsigned; after extracting, clear the Gatekeeper
   quarantine once: `xattr -dr com.apple.quarantine ./abctl` (or `codesign --sign - ./abctl`).
 
-Building from source instead is just `cd authbridge/cmd/abctl && go build .` (likewise
-`cmd/authbridge-proxy`).
+Building from source: `make abctl` or `make authbridge-proxy` from the repo
+root. `authbridge-proxy` defaults to the `full` plugin profile; pass
+`PROFILE=lite` or `local` for smaller sets. See
+[Build-tag plugin selection](#build-tag-plugin-selection) for the underlying
+`go build` invocations.
 
 ## Deployment Modes
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/rossoctl/rossoctl/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (case-insensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix matching is case-insensitive (e.g. fix, Fix, and FIX are all valid)
    and validated via the `allowed_prefixes` input of the GitHub Action used. [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`) - recommended.

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Adds `make abctl` and `make authbridge-proxy` at the repo root so a developer can build the binaries without knowing which plugin tags to pass. Both land in `./bin/`. `authbridge-proxy` takes a `PROFILE=` knob (`full` default, or `lite` / `local`) and resolves the tag list via `authbridge/scripts/profile-tags`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>

## Related issue(s)

Closes #914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added convenient build targets for the `abctl` and `authbridge-proxy` binaries.
  - `authbridge-proxy` builds with the default full plugin profile, with options for lite and local profiles.
  - Builds now place generated binaries in a dedicated `bin` directory.

- **Documentation**
  - Updated source-build instructions to use the new Make targets from the repository root.
  - Added guidance for selecting plugin profiles when building `authbridge-proxy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->