### PR TITLE
Feat: abctl footer shows a feedback link

### DIFF
--- a/authbridge/cmd/abctl/tui/footer.go
+++ b/authbridge/cmd/abctl/tui/footer.go
@@ -8,9 +8,16 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// feedbackURL is where a user sends feedback or reports a problem. The footer
+// carries it on every screen (see #975): the moment a user is looking at their
+// session data is the moment they have an opinion, and the tool should not make
+// them hunt for the repository. Kept quiet (muted style) and to one line.
+const feedbackURL = "https://github.com/rossoctl/cortex/issues"
+
 // footerView renders the bottom two lines: status (connection + rate + drops
-// + optional transient flash) and a context-sensitive keybinding hint. No
-// lipgloss borders; parent view handles the frame.
+// + optional transient flash, then a muted feedback link) and a
+// context-sensitive keybinding hint. No lipgloss borders; parent view handles
+// the frame.
 func (m *model) footerView() string {
 	var status strings.Builder
 
@@ -74,6 +81,11 @@ func (m *model) footerView() string {
 	if m.flash != "" && (m.flashSticky || time.Now().Before(m.flashUntil)) {
 		status.WriteString(styleTitle.Render("   " + m.flash))
 	}
+
+	// Feedback link, quiet and last on the status line so it never crowds the
+	// connection state or a flash. Always present — this is the one screen
+	// element #975 wants a user to be able to find without looking for it.
+	status.WriteString(styleMuted.Render("   feedback: " + feedbackURL))
 
 	hint := fitHintLine(m.helpView(), m.width)
 

--- a/authbridge/cmd/abctl/tui/footer_test.go
+++ b/authbridge/cmd/abctl/tui/footer_test.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The footer must always carry a way to send feedback. A user who is looking at
+// their session data is the user most likely to have an opinion about it; #975
+// asks that the tool point them somewhere quiet and non-intrusive rather than
+// leaving them to hunt for the repository.
+func TestFooterShowsFeedbackLink(t *testing.T) {
+	if feedbackURL == "" {
+		t.Fatal("feedbackURL const is empty; the footer has nothing to point users at")
+	}
+
+	// A wide terminal so nothing is trimmed for width.
+	m := &model{width: 200, pane: paneSessions}
+	got := m.footerView()
+
+	if !strings.Contains(got, feedbackURL) {
+		t.Errorf("footerView() does not contain the feedback URL %q\n---\n%s", feedbackURL, got)
+	}
+}
+
+// The feedback line must survive a narrow terminal. It is the whole point of the
+// change, so it may not be the first thing dropped when width is tight — a user
+// on an 80-column terminal still needs it.
+func TestFooterFeedbackLinkSurvivesNarrowWidth(t *testing.T) {
+	m := &model{width: 80, pane: paneEvents}
+	got := m.footerView()
+
+	if !strings.Contains(got, feedbackURL) {
+		t.Errorf("footerView() dropped the feedback URL at width 80\n---\n%s", got)
+	}
+}


### PR DESCRIPTION
## What & why

Closes #975. `abctl observe` showed a user their session data but pointed them nowhere when they wanted to report a problem or say what was confusing. The moment a user is looking at the numbers is the moment they have an opinion — so the footer now carries a quiet, muted feedback link on the status line of every screen, in the style of the existing footer hints.

## The change

- A package-level `const feedbackURL = "https://github.com/rossoctl/cortex/issues"`.
- Rendered muted and last on the footer status line, so it never crowds the connection state, rate, drops, or a yank flash.
- The sticky-flash path (a long yank path taking the whole line for one keypress) is left as-is by design; the link returns on the next render.

## Tests

`footer_test.go` (written first, TDD):

- `TestFooterShowsFeedbackLink` — the link is present on a normal screen.
- `TestFooterFeedbackLinkSurvivesNarrowWidth` — it is not the first thing dropped on an 80-column terminal.

> **Note on verification:** this module targets Go 1.26.5 and the sandbox this was authored in could not download that toolchain, so `go test ./tui/...` was **not run locally**. The test was written before the implementation (it does not compile without the new const), and the change is small and self-contained. **CI is the source of truth here** — please confirm the `tui` tests pass before merge. Opened as a draft for that reason.

## Follow-up context

One of three feedback items from the Cortex v0.9.0 epic ([#962](https://github.com/rossoctl/cortex/issues/962)) exit-criterion-5 follow-ups. Siblings: #977 (docs feedback template + end-of-page call) and #976 (install.sh success/next-steps message, held until install.sh lands). The URL here should match whatever the docs template (#977) settles on.

## Checklist

- [x] DCO sign-off; `Assisted-By` trailer, no `Co-Authored-By`
- [x] Capitalized PR title prefix (`Feat:`)
- [x] Test written before implementation
- [ ] `tui` tests confirmed green in CI (blocks leaving draft — could not run locally, see note)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * The TUI feedback link now opens the issue template picker.
  * The link is shown when sufficient space is available and omitted at narrow widths to keep the status footer from wrapping.
* **Bug Fixes**
  * Improved footer layout behavior across different terminal widths and status states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->