### PR TITLE
Docs: add a laptop feedback issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/laptop-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/laptop-feedback.yml
@@ -1,0 +1,75 @@
+name: Laptop feedback
+description: Tell us about running Cortex on your own computer — what worked, what was confusing, or what broke.
+title: "Feedback: "
+labels: ["feedback", "laptop"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for trying Cortex on your laptop. This form is for feedback on the
+        local tool — the install, `abctl observe`, and the numbers it shows.
+
+        For a security issue, do not use this form. See
+        [SECURITY.md](https://github.com/rossoctl/cortex/blob/main/SECURITY.md).
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of feedback is this?
+      options:
+        - Something was confusing
+        - Something did not work
+        - The numbers did not tell me what I expected
+        - A suggestion
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened, and what did you expect?
+      description: >
+        Describe what you did and what you saw. If the numbers did not tell you
+        what you expected, say which number and what you were trying to learn.
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system and architecture
+      description: The output of `uname -sm`.
+      placeholder: "Darwin arm64"
+    validations:
+      required: true
+  - type: input
+    id: agent
+    attributes:
+      label: Agent and model
+      description: The coding agent you ran, and the model it used.
+      placeholder: "Claude Code, claude-sonnet-4"
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Cortex version
+      description: The output of `abctl --version`.
+      placeholder: "v0.9.0"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Service status and logs
+      description: >
+        The output of `abctl service status`, and the last part of the service
+        log if it is relevant. Remove any secret before you paste.
+      render: text
+    validations:
+      required: false
+  - type: checkboxes
+    id: other-tools
+    attributes:
+      label: Did anything else on your machine change?
+      options:
+        - label: "`git`, `gh`, `ssh` or `curl` stopped working after I installed Cortex"
+          required: false


### PR DESCRIPTION
## What & why

Part of #977. A user running Cortex on their laptop had no structured way to report a problem or say what was confusing. This adds a GitHub issue form, **Laptop feedback**, so that feedback arrives with the context that makes it actionable.

The repository had no `.github/ISSUE_TEMPLATE/` directory yet, so this creates it with one form. GitHub keeps the blank-issue option available alongside it.

## The form

Fields chosen to match the "what to attach to a bug report" list already in the laptop troubleshooting docs:

- Kind of feedback (confusing / did not work / numbers / suggestion).
- What happened and what you expected.
- OS and architecture (`uname -sm`) — required.
- Agent and model.
- Cortex version (`abctl --version`).
- Service status and log (`abctl service status`), with a note to remove secrets.
- Whether another tool (`git`, `gh`, `ssh`, `curl`) broke.

## Where it connects

- The abctl footer feedback link (#975, PR #978) points at `rossoctl/cortex/issues`, which surfaces this form.
- The docs give an end-of-page "give feedback" prompt that links here — a companion PR in `rossoctl/rossoctl` (part of the same #977).

## Note on verification

The repo's YAML lint and the `check-yaml` pre-commit hook validate issue forms in CI. The sandbox this was authored in has no local YAML validator, so structure was reviewed by hand against GitHub's issue-form schema. **Please let CI confirm the form parses** before merge; opened as a draft for that reason.

## Checklist

- [x] DCO sign-off; `Assisted-By` trailer
- [x] Capitalized PR title prefix (`Docs:`)
- [ ] YAML lint / issue-form parse confirmed in CI (blocks leaving draft)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
